### PR TITLE
✨ Add type query in public get user

### DIFF
--- a/src/routes/users/getPublicInfo.js
+++ b/src/routes/users/getPublicInfo.js
@@ -19,10 +19,15 @@ const router = Router();
 router.get('/id/:id/min', async (req, res, next) => {
   try {
     const username = req.params.id;
+    const { type } = req.query;
+    let types = [];
+    if (type) {
+      types = type.split(',');
+    }
     const payload = await getUserWithCivicLikerProperties(username);
     if (payload) {
       res.set('Cache-Control', 'public, max-age=30');
-      res.json(filterUserDataMin(payload));
+      res.json(filterUserDataMin(payload, types));
     } else {
       res.sendStatus(404);
     }

--- a/src/util/ValidationHelper.js
+++ b/src/util/ValidationHelper.js
@@ -64,17 +64,18 @@ export function filterUserData(u) {
   };
 }
 
-export function filterUserDataMin({
-  user,
-  displayName,
-  avatar,
-  wallet,
-  cosmosWallet,
-  isSubscribedCivicLiker,
-  isCivicLikerTrial,
-  civicLikerSince,
-}) {
-  return {
+export function filterUserDataMin(userObject, types = []) {
+  const {
+    user,
+    displayName,
+    avatar,
+    wallet,
+    cosmosWallet,
+    isSubscribedCivicLiker,
+    isCivicLikerTrial,
+    civicLikerSince,
+  } = userObject;
+  const output = {
     user,
     displayName,
     avatar,
@@ -84,6 +85,10 @@ export function filterUserDataMin({
     isSubscribedCivicLiker,
     civicLikerSince,
   };
+  if (types.includes('payment')) {
+    output.paymentRedirectWhiteList = userObject.paymentRedirectWhiteList;
+  }
+  return output;
 }
 
 export function filterUserDataScoped(u, scope = []) {


### PR DESCRIPTION
Want to allow public to query user profile with a `type` selector
It allows `/min` api to keep `/min` while other usecases, such as payment widget, can get extra fields that is needed for their user cases