### PR TITLE
✨ Add archive bookmark API

### DIFF
--- a/src/routes/users/bookmarks.js
+++ b/src/routes/users/bookmarks.js
@@ -79,15 +79,19 @@ router.get('/bookmarks/:id?', jwtAuth('read:bookmarks'),
         .doc(user)
         .collection('bookmarks');
       if (archived === '0') {
-        query = query.where('isArchived', '==', false);
+        // TODO: old bookmark does not include this field,
+        // making them not included in this query result
+        // Should use isArchived query after data is clean
+        // query = query.where('isArchived', '==', false);
       } else if (archived === '1') {
         query = query.where('isArchived', '==', true);
       }
       query = await query.orderBy('ts', 'desc').get();
-      const list = [];
+      let list = [];
       query.docs.forEach((d) => {
         list.push(filterBookmarks({ id: d.id, ...d.data() }));
       });
+      if (archived === '0') list = list.filter(b => !b.isArchived);
       res.json({ list });
     } catch (err) {
       next(err);

--- a/src/util/ValidationHelper.js
+++ b/src/util/ValidationHelper.js
@@ -362,11 +362,13 @@ export function filterBookmarks({
   id,
   url,
   ts,
+  isArchived,
 }) {
   return {
     id,
     url,
     ts,
+    isArchived,
   };
 }
 


### PR DESCRIPTION
Add default isArchived flag for bookmark entries to prepare for data migration.
Add querystring `archived` in GET API, which has default value 0. `archived=1` will return only archived bookmarks, while `archived=` (empty value) will return both archived and unarchived bookmark.