### PR TITLE
🐛 Explicitly define cache control for 4xx response in lcd proxy

### DIFF
--- a/src/routes/cosmos/iscn-dev/lcd.js
+++ b/src/routes/cosmos/iscn-dev/lcd.js
@@ -137,8 +137,14 @@ router.use(proxy(ISCN_LCD_ENDPOINT, {
   },
   userResHeaderDecorator: (headers, userReq, userRes, proxyReq, proxyRes) => {
     /* eslint-disable no-param-reassign */
-    if (userReq.method === 'GET' && proxyRes.statusCode >= 200 && proxyRes.statusCode <= 299) {
-      headers['cache-control'] = 'public, max-age=1';
+    if (userReq.method === 'GET') {
+      if (proxyRes.statusCode >= 200 && proxyRes.statusCode <= 299) {
+        headers['cache-control'] = 'public, max-age=1';
+      } else {
+        headers['cache-control'] = 'no-store, no-cache, must-revalidate, proxy-revalidate';
+        headers.pragma = 'no-cache';
+        headers.expires = '0';
+      }
     }
     return headers;
     /* eslint-enable no-param-reassign */

--- a/src/routes/cosmos/lcd.js
+++ b/src/routes/cosmos/lcd.js
@@ -262,8 +262,14 @@ router.use(proxy(COSMOS_LCD_ENDPOINT, {
   },
   userResHeaderDecorator: (headers, userReq, userRes, proxyReq, proxyRes) => {
     /* eslint-disable no-param-reassign */
-    if (userReq.method === 'GET' && proxyRes.statusCode >= 200 && proxyRes.statusCode <= 299) {
-      headers['cache-control'] = 'public, max-age=1';
+    if (userReq.method === 'GET') {
+      if (proxyRes.statusCode >= 200 && proxyRes.statusCode <= 299) {
+        headers['cache-control'] = 'public, max-age=1';
+      } else {
+        headers['cache-control'] = 'no-store, no-cache, must-revalidate, proxy-revalidate';
+        headers.pragma = 'no-cache';
+        headers.expires = '0';
+      }
     }
     return headers;
     /* eslint-enable no-param-reassign */


### PR DESCRIPTION
cloudflare might cache 404 response without any cache control header according to current page rule