### PR TITLE
⚡️ Improve arweave upload performance and add deduplicate

### DIFF
--- a/src/routes/arweave/index.js
+++ b/src/routes/arweave/index.js
@@ -21,13 +21,15 @@ router.post(
   async (req, res, next) => {
     try {
       const { files } = req;
+      const { deduplicate = '1' } = req.query;
+      const checkDuplicate = deduplicate && deduplicate !== '0';
       const arFiles = convertMulterFiles(files);
       const [
         ipfsHash,
         prices,
       ] = await Promise.all([
         getIPFSHash(arFiles),
-        estimateARPrices(arFiles),
+        estimateARPrices(arFiles, checkDuplicate),
       ]);
       const pricesWithLIKE = await convertARPricesToLIKE(prices);
       const {
@@ -64,13 +66,15 @@ router.post('/upload',
   async (req, res, next) => {
     try {
       const { files } = req;
+      const { deduplicate = '1' } = req.query;
+      const checkDuplicate = deduplicate && deduplicate !== '0';
       const arFiles = convertMulterFiles(files);
       const [
         ipfsHash,
         prices,
       ] = await Promise.all([
         getIPFSHash(arFiles),
-        estimateARPrices(arFiles),
+        estimateARPrices(arFiles, checkDuplicate),
       ]);
       const {
         key,
@@ -122,7 +126,7 @@ router.post('/upload',
       }
       const arweaveIdList = existingPriceList ? existingPriceList.map(l => l.arweaveId) : undefined;
       const [{ arweaveId, list }] = await Promise.all([
-        uploadFilesToArweave(arFiles, arweaveIdList),
+        uploadFilesToArweave(arFiles, arweaveIdList, checkDuplicate),
         uploadFilesToIPFS(arFiles),
       ]);
       publisher.publish(PUBSUB_TOPIC_MISC, req, {

--- a/src/routes/iscn/index.js
+++ b/src/routes/iscn/index.js
@@ -3,7 +3,7 @@ import bodyParser from 'body-parser';
 import multer from 'multer';
 import BigNumber from 'bignumber.js';
 import publisher from '../../util/gcloudPub';
-import { PUBSUB_TOPIC_MISC } from '../../constant';
+import { IS_TESTNET, PUBSUB_TOPIC_MISC } from '../../constant';
 import { jwtAuth } from '../../middleware/jwt';
 import {
   getISCNSigningClient,
@@ -26,7 +26,7 @@ const router = Router();
 async function handleRegisterISCN(req, res, next) {
   try {
     const { user } = req.user;
-    if (!user || !user.azp) {
+    if (!user || (!IS_TESTNET && !user.azp)) {
       // TODO: remove oauth check when open to personal call
       res.status(403).send('OAUTH_NEEDED');
     }
@@ -201,7 +201,7 @@ router.post('/upload',
   async (req, res, next) => {
     try {
       const { user } = req.user;
-      if (!user || !user.azp) {
+      if (!user || (!IS_TESTNET && !user.azp)) {
         // TODO: remove oauth check when open to personal call
         res.status(403).send('OAUTH_NEEDED');
       }

--- a/src/routes/iscn/index.js
+++ b/src/routes/iscn/index.js
@@ -206,13 +206,15 @@ router.post('/upload',
         res.status(403).send('OAUTH_NEEDED');
       }
       const { files } = req;
+      const { deduplicate = '1' } = req.query;
+      const checkDuplicate = deduplicate && deduplicate !== '0';
       const arFiles = convertMulterFiles(files);
       const [
         ipfsHash,
         prices,
       ] = await Promise.all([
         getIPFSHash(arFiles),
-        estimateARPrices(arFiles),
+        estimateARPrices(arFiles, checkDuplicate),
       ]);
       const {
         key,
@@ -262,7 +264,7 @@ router.post('/upload',
           address,
           transferTxSigningFunction,
         ),
-        uploadFilesToArweave(arFiles, arweaveIdList),
+        uploadFilesToArweave(arFiles, arweaveIdList, checkDuplicate),
         uploadFilesToIPFS(arFiles),
       ]);
       const { transactionHash, gasUsed, gasWanted } = txRes;

--- a/src/util/arweave.js
+++ b/src/util/arweave.js
@@ -11,7 +11,7 @@ import {
 import { COINGECKO_AR_LIKE_PRICE_API, IS_TESTNET } from '../constant';
 
 
-const arweaveIdCache = new LRU({ max: 128, maxAge: 10 * 60 * 1000 }); // 10 min
+const arweaveIdCache = new LRU({ max: 4096, maxAge: 86400000 }); // 1day
 
 const IPFS_KEY = 'IPFS-Add';
 

--- a/src/util/arweave.js
+++ b/src/util/arweave.js
@@ -126,8 +126,9 @@ export async function estimateARPrices(files, checkDuplicate = true) {
   }
   const prices = await Promise.all(files.map(f => estimateARPrice(f, checkDuplicate)));
   const filesWithPrice = files.map((f, i) => ({ ...f, arweaveId: prices[i].arweaveId }));
+  const checkManifestDuplicate = checkDuplicate && !filesWithPrice.find(p => !p.arweaveId);
   const manifest = await generateManifestFile(filesWithPrice, { stub: true });
-  const manifestPrice = await estimateARPrice(manifest, checkDuplicate);
+  const manifestPrice = await estimateARPrice(manifest, checkManifestDuplicate);
 
   prices.unshift(manifestPrice);
   const totalAR = prices.reduce((acc, cur) => acc.plus(cur.AR), new BigNumber(0));
@@ -300,7 +301,8 @@ export async function uploadFilesToArweave(files, arweaveIdList, checkDuplicate 
     filesWithId.push({ ...f, arweaveId });
     /* eslint-enable no-await-in-loop */
   }
-  const { manifest, ipfsHash } = await uploadManifestFile(filesWithId, checkDuplicate);
+  /* HACK: do not check manifest duplicate, assume new since we uploaded new file to arweave */
+  const { manifest, ipfsHash } = await uploadManifestFile(filesWithId, false);
   list.unshift({
     key: manifest.key,
     arweaveId: manifest.arweaveId,

--- a/src/util/arweave.js
+++ b/src/util/arweave.js
@@ -181,7 +181,7 @@ export async function submitToArweave(data, ipfsHash) {
   const anchorId = (await arweave.api.get('/tx_anchor')).data;
   const { mimetype, buffer } = data;
   const transaction = await arweave.createTransaction({ data: buffer, last_tx: anchorId }, jwk);
-  transaction.addTag('User-Agent', 'app.like.co');
+  transaction.addTag('User-Agent', 'api.like.co');
   transaction.addTag(IPFS_KEY, ipfsHash);
   transaction.addTag(IPFS_CONSTRAINT_KEY, IPFS_CONSTRAINT);
   transaction.addTag('Content-Type', mimetype);


### PR DESCRIPTION
- Add deduplicate flag, setting off would skip agql call, default on
- Reduce duplicate call to agql when uploading multiple files
- Skip manifest duplicate check if any file in list is new