### PR TITLE
⚡️ Use media network cdn for arweave api

### DIFF
--- a/src/util/arweave.js
+++ b/src/util/arweave.js
@@ -20,8 +20,15 @@ const IPFS_CONSTRAINT = 'v0.1';
 
 const jwk = require('../../config/arweave-key.json');
 
-const arweave = Arweave.init({
+const arweaveGraphQL = Arweave.init({
   host: 'arweave.net',
+  port: 443,
+  protocol: 'https',
+  timeout: 60000,
+});
+
+const arweave = Arweave.init({
+  host: 'gateway.arweave.network',
   port: 443,
   protocol: 'https',
   timeout: 60000,
@@ -31,7 +38,7 @@ export async function getArweaveIdFromHashes(ipfsHash) {
   const cachedInfo = arweaveIdCache.get(ipfsHash);
   if (cachedInfo) return cachedInfo;
   try {
-    const res = await arweave.api.post('/graphql', {
+    const res = await arweaveGraphQL.api.post('/graphql', {
       query: `
     {
       transactions(

--- a/src/util/arweave.js
+++ b/src/util/arweave.js
@@ -310,7 +310,6 @@ export async function uploadFilesToArweave(files, arweaveIdList, checkDuplicate 
     if (!arweaveId) {
       [arweaveId] = await Promise.all([
         submitToArweave(f, ipfsHash, {
-          checkDuplicate,
           anchorId,
         }),
         uploadFileToIPFS(f),

--- a/src/util/arweave.js
+++ b/src/util/arweave.js
@@ -29,8 +29,8 @@ const arweaveGraphQL = Arweave.init({
 
 const arweave = Arweave.init({
   host: 'gateway.arweave.network',
-  port: 443,
-  protocol: 'https',
+  port: 80, // http to avoid strange tls error
+  protocol: 'http',
   timeout: 60000,
 });
 


### PR DESCRIPTION
- Reduce anchor api call by sharing anchor for all tx
- Use media network cdn for non-gql calls