### PR TITLE
♻️ Split signing rpc into separated config

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -14,6 +14,7 @@ config.FIREBASE_STORAGE_BUCKET = process.env.FIREBASE_STORAGE_BUCKET;
 
 config.COSMOS_LCD_ENDPOINT = 'https://node.testnet.like.co';
 config.COSMOS_RPC_ENDPOINT = 'https://node.testnet.like.co/rpc/';
+config.COSMOS_SIGNING_RPC_ENDPOINT = 'https://node.testnet.like.co/rpc/';
 config.COSMOS_CHAIN_ID = 'likecoin-public-testnet-5';
 config.ISCN_DEV_LCD_ENDPOINT = 'localhost:1317';
 config.ISCN_DEV_CHAIN_ID = 'iscn-dev-chain';

--- a/src/util/cosmos/iscn.js
+++ b/src/util/cosmos/iscn.js
@@ -3,9 +3,7 @@ import { DirectSecp256k1Wallet } from '@cosmjs/proto-signing';
 import { ISCNQueryClient, ISCNSigningClient } from '@likecoin/iscn-js';
 import { getAccountInfo } from '.';
 import { COSMOS_PRIVATE_KEY } from '../../../config/secret';
-import {
-  COSMOS_RPC_ENDPOINT,
-} from '../../../config/config';
+import { COSMOS_RPC_ENDPOINT, COSMOS_SIGNING_RPC_ENDPOINT } from '../../../config/config';
 
 let queryClient = null;
 let signingClient = null;
@@ -27,7 +25,7 @@ export async function getISCNSigningClient() {
     const signer = await DirectSecp256k1Wallet.fromKey(privateKeyBytes);
     const [wallet] = await signer.getAccounts();
     const client = new ISCNSigningClient();
-    await client.connectWithSigner(COSMOS_RPC_ENDPOINT, signer);
+    await client.connectWithSigner(COSMOS_SIGNING_RPC_ENDPOINT, signer);
     signingWallet = wallet;
     signingClient = client;
   }

--- a/src/util/cosmos/tx.js
+++ b/src/util/cosmos/tx.js
@@ -13,6 +13,7 @@ import { PUBSUB_TOPIC_MISC } from '../../constant';
 const {
   COSMOS_DENOM,
   COSMOS_RPC_ENDPOINT,
+  COSMOS_SIGNING_RPC_ENDPOINT,
   COSMOS_GAS_PRICE,
 } = require('../../../config/config');
 
@@ -21,6 +22,12 @@ export const DEFAULT_TRANSFER_GAS = 80000;
 export const DEFAULT_CHANGE_ISCN_OWNERSHIP_GAS = 59714;
 
 let stargateClient = null;
+let broadcastClient = null;
+
+async function getBroadcastClient() {
+  if (!broadcastClient) broadcastClient = await StargateClient.connect(COSMOS_SIGNING_RPC_ENDPOINT);
+  return broadcastClient;
+}
 
 async function getClient() {
   if (!stargateClient) stargateClient = await StargateClient.connect(COSMOS_RPC_ENDPOINT);
@@ -78,7 +85,7 @@ async function computeTransactionHash(signedTx) {
 }
 
 async function internalSendTransaction(signedTx) {
-  const client = await getClient();
+  const client = await getBroadcastClient();
   const txBytes = TxRaw.encode(signedTx).finish();
   try {
     const res = await client.broadcastTx(txBytes);


### PR DESCRIPTION
we want query to be loadbalance/cached, but signing to be a same node for increasing sequence