### PR TITLE
♻️ Rename iscnId, iscnPrefix and iscnPrefixDocName

### DIFF
--- a/src/middleware/likernft.js
+++ b/src/middleware/likernft.js
@@ -12,9 +12,10 @@ export const fetchISCNPrefixAndClassId = async (req, res, next) => {
     let iscnPrefix;
     if (!iscnId) {
       iscnPrefix = await getISCNPrefixByClassId(classId);
+    } else {
+      iscnPrefix = getISCNPrefix(iscnId);
     }
     if (!classId) {
-      iscnPrefix = getISCNPrefix(iscnId);
       classId = await getCurrentClassIdByISCNId(iscnPrefix);
     }
     res.locals.iscnPrefix = iscnPrefix;

--- a/src/middleware/likernft.js
+++ b/src/middleware/likernft.js
@@ -1,26 +1,29 @@
 import { ValidationError } from '../util/ValidationError';
+import { getISCNPrefix } from '../util/cosmos/iscn';
 import {
-  getISCNIdByClassId, getCurrentClassIdByISCNId, getISCNPrefixDocName,
+  getISCNPrefixByClassId, getCurrentClassIdByISCNId, getISCNPrefixDocName,
 } from '../util/api/likernft';
 
-export const fetchISCNIdAndClassId = async (req, res, next) => {
+export const fetchISCNPrefixAndClassId = async (req, res, next) => {
   try {
-    let { iscn_id: iscnId, class_id: classId } = req.query;
+    const { iscn_id: iscnId } = req.query;
+    let { class_id: classId } = req.query;
     if (!iscnId && !classId) throw new ValidationError('MISSING_ISCN_OR_CLASS_ID');
-
+    let iscnPrefix;
     if (!iscnId) {
-      iscnId = await getISCNIdByClassId(classId);
+      iscnPrefix = await getISCNPrefixByClassId(classId);
     }
     if (!classId) {
-      classId = await getCurrentClassIdByISCNId(iscnId);
+      iscnPrefix = getISCNPrefix(iscnId);
+      classId = await getCurrentClassIdByISCNId(iscnPrefix);
     }
-    res.locals.iscnId = iscnId;
+    res.locals.iscnPrefix = iscnPrefix;
     res.locals.classId = classId;
-    res.locals.iscnPrefix = getISCNPrefixDocName(iscnId);
+    res.locals.iscnPrefixDocName = getISCNPrefixDocName(iscnPrefix);
     next();
   } catch (err) {
     next(err);
   }
 };
 
-export default fetchISCNIdAndClassId;
+export default fetchISCNPrefixAndClassId;

--- a/src/routes/likernft/history.js
+++ b/src/routes/likernft/history.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import axios from 'axios';
 import { ValidationError } from '../../util/ValidationError';
 import { getISCNDocByClassId } from '../../util/api/likernft';
-import { fetchISCNIdAndClassId } from '../../middleware/likernft';
+import { fetchISCNPrefixAndClassId } from '../../middleware/likernft';
 import { COSMOS_LCD_INDEXER_ENDPOINT } from '../../../config/config';
 import { ONE_DAY_IN_S } from '../../constant';
 
@@ -10,7 +10,7 @@ const router = Router();
 
 router.get(
   '/history',
-  fetchISCNIdAndClassId,
+  fetchISCNPrefixAndClassId,
   async (req, res, next) => {
     try {
       const { nft_id: nftId } = req.query;
@@ -36,7 +36,7 @@ router.get(
 
 router.get(
   '/events',
-  fetchISCNIdAndClassId,
+  fetchISCNPrefixAndClassId,
   async (_, res, next) => {
     try {
       const { classId } = res.locals;

--- a/src/routes/likernft/transfer.js
+++ b/src/routes/likernft/transfer.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 
 import { ValidationError } from '../../util/ValidationError';
-import { getISCNIdByClassId } from '../../util/api/likernft';
+import { getISCNPrefixByClassId } from '../../util/api/likernft';
 import { getNFTTransferInfo, processNFTTransfer } from '../../util/api/likernft/transfer';
 import publisher from '../../util/gcloudPub';
 import { PUBSUB_TOPIC_MISC } from '../../constant';
@@ -22,11 +22,11 @@ router.post(
         classId,
         txTimestamp,
       } = info;
-      const iscnId = await getISCNIdByClassId(classId);
+      const iscnPrefix = await getISCNPrefixByClassId(classId);
       await processNFTTransfer({
         fromAddress,
         toAddress,
-        iscnId,
+        iscnPrefix,
         classId,
         nftId,
         txHash,
@@ -35,7 +35,7 @@ router.post(
       res.json({
         txTimestamp,
         txHash,
-        iscnId,
+        iscnId: iscnPrefix,
         classId,
         nftId,
         fromAddress,
@@ -45,7 +45,7 @@ router.post(
       publisher.publish(PUBSUB_TOPIC_MISC, req, {
         logType: 'LikerNFTTransfer',
         classId,
-        iscnId,
+        iscnId: iscnPrefix,
         nftId,
         txHash,
         timestamp: txTimestamp,

--- a/src/util/api/likernft/index.js
+++ b/src/util/api/likernft/index.js
@@ -10,8 +10,8 @@ export function getISCNPrefixDocName(iscnId) {
 }
 
 export async function getCurrentClassIdByISCNId(iscnId) {
-  const iscnPrefix = getISCNPrefixDocName(iscnId);
-  const iscnDoc = await likeNFTCollection.doc(iscnPrefix).get();
+  const iscnPrefixDocName = getISCNPrefixDocName(iscnId);
+  const iscnDoc = await likeNFTCollection.doc(iscnPrefixDocName).get();
   const iscnData = iscnDoc.data();
   if (!iscnData) {
     throw new ValidationError('ISCN_NFT_NOT_FOUND');
@@ -27,7 +27,7 @@ export async function getISCNDocByClassId(classId) {
   return iscnQuery.docs[0];
 }
 
-export async function getISCNIdByClassId(classId) {
+export async function getISCNPrefixByClassId(classId) {
   const doc = await getISCNDocByClassId(classId);
   return decodeURIComponent(doc.id);
 }

--- a/src/util/api/likernft/mint.js
+++ b/src/util/api/likernft/mint.js
@@ -28,12 +28,12 @@ export async function parseNFTInformationFromSendTxHash(txHash, target = LIKER_N
   };
 }
 
-export async function writeMintedNFTInfo(iscnId, classData, nfts) {
-  const iscnPrefix = getISCNPrefixDocName(iscnId);
+export async function writeMintedNFTInfo(iscnPrefix, classData, nfts) {
+  const iscnPrefixDocName = getISCNPrefixDocName(iscnPrefix);
   const {
     owner: sellerWallet,
     data: iscnData,
-  } = await getNFTISCNData(iscnId);
+  } = await getNFTISCNData(iscnPrefix);
   const url = iscnData.contentMetadata && iscnData.contentMetadata.url;
   const timestamp = Date.now();
   const {
@@ -45,8 +45,9 @@ export async function writeMintedNFTInfo(iscnId, classData, nfts) {
   } = classData;
   const currentBatch = 0;
   const { price, count } = getNFTBatchInfo(currentBatch);
+  const iscnRef = likeNFTCollection.doc(iscnPrefixDocName);
   await Promise.all([
-    likeNFTCollection.doc(iscnPrefix).create({
+    iscnRef.create({
       classId,
       classes: [classId],
       totalCount,
@@ -61,7 +62,7 @@ export async function writeMintedNFTInfo(iscnId, classData, nfts) {
       processingCount: 0,
       timestamp,
     }),
-    likeNFTCollection.doc(iscnPrefix).collection('class').doc(classId).create({
+    iscnRef.collection('class').doc(classId).create({
       id: classId,
       uri,
       lastSoldPrice: 0,
@@ -70,7 +71,7 @@ export async function writeMintedNFTInfo(iscnId, classData, nfts) {
       timestamp,
       metadata: {
         image: AVATAR_DEFAULT_PATH, // TODO: replace with default NFT image
-        externalUrl: url || `${APP_LIKE_CO_ISCN_VIEW_URL}${encodeURIComponent(iscnId)}`,
+        externalUrl: url || `${APP_LIKE_CO_ISCN_VIEW_URL}${encodeURIComponent(iscnPrefix)}`,
         description,
         name,
         backgroundColor: LIKECOIN_DARK_GREEN_THEME_COLOR,
@@ -84,7 +85,7 @@ export async function writeMintedNFTInfo(iscnId, classData, nfts) {
       uri: nftUri,
     } = nfts[i];
     batch.create(
-      likeNFTCollection.doc(iscnPrefix)
+      iscnRef
         .collection('class').doc(classId)
         .collection('nft')
         .doc(nftId),

--- a/src/util/api/likernft/transfer.js
+++ b/src/util/api/likernft/transfer.js
@@ -28,14 +28,14 @@ export async function getNFTTransferInfo(txHash, nftId) {
 export async function processNFTTransfer({
   fromAddress,
   toAddress,
-  iscnId,
+  iscnPrefix,
   classId,
   nftId,
   txHash,
   txTimestamp,
 }) {
-  const iscnPrefix = getISCNPrefixDocName(iscnId);
-  const iscnRef = likeNFTCollection.doc(iscnPrefix);
+  const iscnPrefixDocName = getISCNPrefixDocName(iscnPrefix);
+  const iscnRef = likeNFTCollection.doc(iscnPrefixDocName);
   const classRef = iscnRef.collection('class').doc(classId);
   const nftRef = classRef.collection('nft').doc(nftId);
   await db.runTransaction(async (t) => {


### PR DESCRIPTION
Remove concept of `iscn_id` in likernft apis (except when accepting qs from minting)
Rename iscnPrefix and iscnPrefixDocName accordingly
Always use iscnPrefix to fetch iscn data so we get latest version of information