### PR TITLE
⚡️ Use og content type for nft image

### DIFF
--- a/src/routes/likernft/metadata.js
+++ b/src/routes/likernft/metadata.js
@@ -93,13 +93,17 @@ router.get(
       if (iscnData.exists) {
         ({ image, title = 'Writing NFT' } = iscnData.data());
       }
-      const { image: basicImage, isDefault: isImageMissing } = await getBasicImage(image, title);
+      const {
+        image: basicImage,
+        contentType,
+        isDefault: isImageMissing,
+      } = await getBasicImage(image, title);
       const resizedImage = getResizedImage();
       // Disable image mask for now
       // const combinedImage = await getCombinedImage();
       const cacheTime = isImageMissing ? 60 : 3600;
       res.set('Cache-Control', `public, max-age=${cacheTime}, s-maxage=${cacheTime}, stale-if-error=${ONE_DAY_IN_S}`);
-      res.type('png');
+      res.type(contentType);
       basicImage
         .pipe(resizedImage)
         // .pipe(combinedImage)

--- a/src/util/api/likernft/metadata.js
+++ b/src/util/api/likernft/metadata.js
@@ -39,22 +39,25 @@ export async function getImageMask() {
 
 export async function getBasicImage(image, title) {
   let imageBuffer;
+  let contentType;
   let isDefault = true;
   if (image) {
     const imageData = (await axios.get(image, { responseType: 'stream' }).catch(() => {}));
     if (imageData && imageData.data) {
       imageBuffer = imageData.data;
+      contentType = imageData.headers['content-type'] || 'image/png';
       isDefault = false;
     }
   }
   if (isDefault) {
     const escapedTitle = title.replace(/&/g, '&amp;');
     const textDataBuffer = await addTextOnImage(escapedTitle, 'black');
+    contentType = 'image/png';
     imageBuffer = await sharp(textDataBuffer)
       .png()
       .flatten({ background: { r: 250, g: 250, b: 250 } });
   }
-  return { image: imageBuffer, isDefault };
+  return { image: imageBuffer, contentType, isDefault };
 }
 
 export async function getCombinedImage() {
@@ -70,8 +73,7 @@ export function getResizedImage() {
       fit: sharp.fit.cover,
       width: IMAGE_WIDTH,
       height: IMAGE_HEIGHT,
-    })
-    .png();
+    });
 }
 
 export function getDynamicBackgroundColor(soldCount) {
@@ -91,7 +93,7 @@ export function getLikerNFTDynamicData(classId, classData, iscnData) {
   const { contentMetadata: { url, description } = {} } = iscnData;
   const backgroundColor = getDynamicBackgroundColor(soldCount);
   const payload = {
-    image: `https://${API_EXTERNAL_HOSTNAME}/likernft/metadata/image/class_${classId}.png`,
+    image: `https://${API_EXTERNAL_HOSTNAME}/likernft/metadata/image/class_${classId}`,
     backgroundColor,
   };
   if (description) payload.description = description;


### PR DESCRIPTION
reduce size and time by keeping jpeg jpeg
one issue is that we default to `.png` url when we mint NFT, which might serve jpg now