### PR TITLE
💩 Fix amount could be string or number in stakeholder map

### DIFF
--- a/src/util/api/likernft/purchase.js
+++ b/src/util/api/likernft/purchase.js
@@ -232,7 +232,11 @@ export async function handleNFTPurchaseTransaction({
         value: {
           fromAddress: LIKER_NFT_TARGET_ADDRESS,
           toAddress: wallet,
-          amount: [{ denom: NFT_COSMOS_DENOM, amount: amount.toFixed(0) }],
+          // TODO: fix iscn-js to use string for amount input and output
+          amount: [{
+            denom: NFT_COSMOS_DENOM,
+            amount: new BigNumber(amount).toFixed(0, BigNumber.ROUND_DOWN),
+          }],
         },
       },
     );


### PR DESCRIPTION
`getStakeholderMapFromParsedIscnData` expect `totalLIKE` as number, but we actually use bignumber string as input
This PR fixes the error caused by type inconsitent, and the root cause would be to fix iscn-js  in https://github.com/likecoin/iscn-js/pull/26