### PR TITLE
🐛 Fix arweave id off by 1 when upload

### DIFF
--- a/src/routes/arweave/index.js
+++ b/src/routes/arweave/index.js
@@ -80,8 +80,9 @@ router.post('/upload',
         key,
         arweaveId: existingArweaveId,
         AR,
-        list: existingPriceList,
+        list: existingPriceListWithManifest,
       } = prices;
+      const [, ...existingFilesPriceList] = existingPriceListWithManifest;
 
       // shortcut for existing file without checking tx
       if (existingArweaveId) {
@@ -124,7 +125,8 @@ router.post('/upload',
         res.status(400).send('TX_AMOUNT_NOT_ENOUGH');
         return;
       }
-      const arweaveIdList = existingPriceList ? existingPriceList.map(l => l.arweaveId) : undefined;
+      const arweaveIdList = existingFilesPriceList
+        ? existingFilesPriceList.map(l => l.arweaveId) : undefined;
       const [{ arweaveId, list }] = await Promise.all([
         uploadFilesToArweave(arFiles, arweaveIdList, checkDuplicate),
         uploadFilesToIPFS(arFiles),

--- a/src/util/arweave.js
+++ b/src/util/arweave.js
@@ -280,7 +280,7 @@ export async function uploadFilesToArweave(files, arweaveIdList, checkDuplicate 
     if (checkDuplicate) {
       arweaveIds = await Promise.all(ipfsHashes.map(h => getArweaveIdFromHashes(h)));
     } else {
-      arweaveIds = [];
+      arweaveIds = new Array(files.length);
     }
   }
   const anchorId = (await arweave.api.get('/tx_anchor')).data;


### PR DESCRIPTION
`existingFilesPriceList` contained price for manifest file (line 154`prices.unshift(manifestPrice);`)
but `uploadFilesToArweave` expects only the prices of files not including manifest