### PR TITLE
🐛 Do not set isPendingClaim in metadata if false

### DIFF
--- a/src/routes/likernft/fiat/stripe.js
+++ b/src/routes/likernft/fiat/stripe.js
@@ -147,7 +147,7 @@ router.post(
           classId,
           iscnPrefix,
           paymentId,
-          isPendingClaim,
+          isPendingClaim: isPendingClaim ? 'true' : undefined,
         },
       });
       const { url, id: sessionId } = session;


### PR DESCRIPTION
we don't want to end up with `isPendingClaim: 'false'` and extra parsing