### PR TITLE
🚑️ Guard memo length by byte length on purchase

### DIFF
--- a/src/util/api/likernft/purchase.ts
+++ b/src/util/api/likernft/purchase.ts
@@ -354,7 +354,7 @@ export async function processNFTPurchase({
     } = {},
   } = classDoc.data();
   let memo = message.replaceAll('{collector}', buyerWallet) || '';
-  memo = memo.length > MAX_MEMO_LENGTH ? memo.substring(0, MAX_MEMO_LENGTH) : memo;
+  memo =  Buffer.byteLength(memo, 'utf8') > MAX_MEMO_LENGTH ? Buffer.from(memo).slice(0, MAX_MEMO_LENGTH).toString(); : memo;
   if (!iscnData) throw new ValidationError('CLASS_DATA_NOT_FOUND');
 
   // lock iscn nft

--- a/src/util/api/likernft/purchase.ts
+++ b/src/util/api/likernft/purchase.ts
@@ -354,7 +354,7 @@ export async function processNFTPurchase({
     } = {},
   } = classDoc.data();
   let memo = message.replaceAll('{collector}', buyerWallet) || '';
-  memo =  Buffer.byteLength(memo, 'utf8') > MAX_MEMO_LENGTH ? Buffer.from(memo).slice(0, MAX_MEMO_LENGTH).toString(); : memo;
+  memo = Buffer.byteLength(memo, 'utf8') > MAX_MEMO_LENGTH ? Buffer.from(memo).slice(0, MAX_MEMO_LENGTH).toString() : memo;
   if (!iscnData) throw new ValidationError('CLASS_DATA_NOT_FOUND');
 
   // lock iscn nft


### PR DESCRIPTION
Turns out we cannot use `.length` for this guard, we need to use byte length
example class triggering memo too large:
https://mainnet-node.like.co/cosmos/nft/v1beta1/classes/likenft129vhp8pwx635r0gksuaghvzev7jdpurq4kdl77uq80cp6yed8kjs2exhcr