### PR TITLE
🐛 Fix stakeholder reward precision should be 0dp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@cosmjs/stargate": "^0.28.4",
         "@google-cloud/pubsub": "^3.1.1",
         "@ipld/car": "^4.1.6",
-        "@likecoin/iscn-js": "0.4.2",
+        "@likecoin/iscn-js": "0.5.0",
         "@likecoin/likecoin-email-templates": "^1.2.2",
         "@likecoin/secretd-js": "^0.4.3",
         "@sendgrid/mail": "^6.5.5",
@@ -2117,9 +2117,9 @@
       }
     },
     "node_modules/@likecoin/iscn-js": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@likecoin/iscn-js/-/iscn-js-0.4.2.tgz",
-      "integrity": "sha512-yeBrW37APkkyfz4Y6WP4FYsB4KD2yxhOAaAD2IpU26rck1DZ6S1xUXnXzjaS+YyLZ/67Fqwx0uOsQtRF3NIS1Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@likecoin/iscn-js/-/iscn-js-0.5.0.tgz",
+      "integrity": "sha512-ej+hH7LymquLTCIBa1+g/O/dTrt+Udb0eqDeHGio9+KwsUj4FVZoGg7uGeJ+oFgJI4Bca41S8Re3JEokAgOnAQ==",
       "dependencies": {
         "@likecoin/iscn-message-types": "0.0.3",
         "axios": "^0.27.2",
@@ -20003,9 +20003,9 @@
       }
     },
     "@likecoin/iscn-js": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@likecoin/iscn-js/-/iscn-js-0.4.2.tgz",
-      "integrity": "sha512-yeBrW37APkkyfz4Y6WP4FYsB4KD2yxhOAaAD2IpU26rck1DZ6S1xUXnXzjaS+YyLZ/67Fqwx0uOsQtRF3NIS1Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@likecoin/iscn-js/-/iscn-js-0.5.0.tgz",
+      "integrity": "sha512-ej+hH7LymquLTCIBa1+g/O/dTrt+Udb0eqDeHGio9+KwsUj4FVZoGg7uGeJ+oFgJI4Bca41S8Re3JEokAgOnAQ==",
       "requires": {
         "@likecoin/iscn-message-types": "0.0.3",
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@cosmjs/stargate": "^0.28.4",
     "@google-cloud/pubsub": "^3.1.1",
     "@ipld/car": "^4.1.6",
-    "@likecoin/iscn-js": "0.4.2",
+    "@likecoin/iscn-js": "0.5.0",
     "@likecoin/likecoin-email-templates": "^1.2.2",
     "@likecoin/secretd-js": "^0.4.3",
     "@sendgrid/mail": "^6.5.5",

--- a/src/util/api/likernft/purchase.ts
+++ b/src/util/api/likernft/purchase.ts
@@ -240,7 +240,7 @@ export async function handleNFTPurchaseTransaction({
   const stakeholderMap = await parseAndCalculateStakeholderRewards(
     data,
     owner,
-    { totalAmount: stakeholdersAmount },
+    { totalAmount: stakeholdersAmount, precision: 0 },
   );
   stakeholderMap.forEach(({ amount }, wallet) => {
     transferMessages.push(


### PR DESCRIPTION
`precision` call `toFixed(precision)`, which sets dp
In this api we want nanolike to be integer, so `precision` should be 0 instead of default 9