### PR TITLE
🐛 Fix NFT custom description is not shown in metadata

### DIFF
--- a/src/routes/likernft/fiat/stripe.ts
+++ b/src/routes/likernft/fiat/stripe.ts
@@ -91,19 +91,10 @@ router.post(
       const [{
         price,
         // nextPriceLevel,
-      }, {
-        classData,
-        chainData,
-        dynamicData,
-      }] = await Promise.all([
+      }, { metadata }] = await Promise.all([
         getLatestNFTPriceAndInfo(iscnPrefix, classId),
         getClassMetadata({ classId, iscnPrefix }),
       ]);
-      const metadata = {
-        ...(classData.metadata || {}),
-        ...chainData,
-        ...dynamicData,
-      };
       let { name = '', description = '' } = metadata;
       const { image } = metadata;
       const gasFee = getGasPrice();

--- a/src/routes/likernft/metadata.ts
+++ b/src/routes/likernft/metadata.ts
@@ -30,10 +30,8 @@ router.get(
       const { classId, iscnPrefix } = res.locals;
       const {
         iscnOwner,
-        classData,
         iscnData,
-        chainData,
-        dynamicData,
+        metadata,
       } = await getClassMetadata({ classId, iscnPrefix });
       res.set('Cache-Control', `public, max-age=${60}, s-maxage=${60}, stale-if-error=${ONE_DAY_IN_S}`);
       res.json(filterLikeNFTMetadata({
@@ -41,9 +39,7 @@ router.get(
         iscnOwner,
         iscnStakeholders: iscnData.stakeholders,
         iscnRecordTimestamp: iscnData.recordTimestamp,
-        ...(classData.metadata || {}),
-        ...chainData,
-        ...dynamicData,
+        ...metadata,
       }));
     } catch (err) {
       next(err);

--- a/src/util/api/likernft/metadata.ts
+++ b/src/util/api/likernft/metadata.ts
@@ -158,11 +158,19 @@ export async function getClassMetadata({ classId, iscnPrefix }) {
   };
   const dynamicData = getLikerNFTDynamicData(classId, iscnDocData, classMetadata, iscnData);
   if (!dynamicData) throw new ValidationError('NFT_CLASS_NOT_REGISTERED');
+  const metadata = {
+    ...(classData.metadata || {}),
+    ...chainData,
+    ...dynamicData,
+    // allow custom description in chain data to override crawled data
+    description: chainData.description || dynamicData.description,
+  };
   return {
     iscnOwner,
     classData,
     iscnData,
     chainData: chainMetadata,
     dynamicData,
+    metadata,
   };
 }


### PR DESCRIPTION
Now metadata API always return the crawled description despite a custom one is set in NFT class data