### PR TITLE
👽️ Do not set empty description for stripe checkout

### DIFF
--- a/src/routes/likernft/fiat/stripe.ts
+++ b/src/routes/likernft/fiat/stripe.ts
@@ -184,6 +184,7 @@ router.post(
       const paymentId = uuidv4();
       name = name.length > 100 ? `${name.substring(0, 99)}…` : name;
       description = description.length > 200 ? `${description.substring(0, 199)}…` : description;
+      if (!description) { description = undefined; } // stripe does not like empty string
       const session = await stripe.checkout.sessions.create({
         mode: 'payment',
         success_url: `https://${LIKER_LAND_HOSTNAME}/nft/fiat/stripe?class_id=${classId}&payment_id=${paymentId}`,


### PR DESCRIPTION
To avoid
```
Error: You passed an empty string for 'line_items[0][price_data][product_data][description]'. We assume empty values are an attempt to unset a parameter; however 'line_items[0][price_data][product_data][description]' cannot be unset. You should remove 'line_items[0][price_data]
```