### PR TITLE
[TAS-544] 🐛 Should not return negative price from modifier

### DIFF
--- a/src/util/api/likernft/purchase.ts
+++ b/src/util/api/likernft/purchase.ts
@@ -643,10 +643,11 @@ async function updateDocsForMissingSoldNFT(t, {
 
 // NOTE: Stripe fee per order is 5.4% + 30 cents
 export function rewardModifier(priceInUSD: BigNumber) {
-  return priceInUSD
+  const modified = priceInUSD
     // deduct flat fee for each NFT
     .minus(LIKER_NFT_STRIPE_FEE_USD_INTERCEPT)
     .multipliedBy(1 - LIKER_NFT_STRIPE_FEE_USD_SLOPE);
+  return modified.isLessThan(0) ? new BigNumber(0) : modified;
 }
 
 export async function processNFTPurchase({


### PR DESCRIPTION
Fix the bug that induces https://github.com/likecoin/liker-land/pull/1358 issue