### PR TITLE
[TAS-1746] 🐛 Set claimToken to undefined if wallet exists

### DIFF
--- a/src/routes/likernft/fiat/stripe.ts
+++ b/src/routes/likernft/fiat/stripe.ts
@@ -113,7 +113,7 @@ router.post(
       const fiatPrice = Number(fiatPriceString);
       if (LIKEPrice === 0) throw new ValidationError('NFT_IS_FREE');
       const paymentId = uuidv4();
-      const claimToken = randomBytes(32).toString('base64url');
+      const claimToken = wallet ? '' : randomBytes(32).toString('base64url');
 
       const classIdLog = {};
       // Metadata can have up to 50 keys


### PR DESCRIPTION
Avoid adding the `claim_token` to the query string when redirecting if a wallet is exists

no claim_token
![截圖 2024-06-14 下午1 08 16](https://github.com/likecoin/likecoin-api-public/assets/75730405/a6cfb34f-d5bc-464b-87cc-5b81485bbeae)

has claim_token
![截圖 2024-06-14 下午1 09 25](https://github.com/likecoin/likecoin-api-public/assets/75730405/3324552e-dfc1-42a7-81bb-c4d70814fc14)
