### PR TITLE
[TAS-4593] 🐛 Remove stock validation for on-demand minting

### DIFF
--- a/src/routes/likernft/book/store.ts
+++ b/src/routes/likernft/book/store.ts
@@ -325,10 +325,6 @@ router.put(['/:classId/price/:priceIndex', '/class/:classId/price/:priceIndex'],
       throw new ValidationError('CANNOT_CHANGE_DELIVERY_METHOD_OF_AUTO_DELIVER_PRICE', 403);
     }
 
-    if (oldPriceInfo.isAutoDeliver && price.stock < oldPriceInfo.stock) {
-      throw new ValidationError('CANNOT_DECREASE_STOCK_OF_AUTO_DELIVERY_PRICE', 403);
-    }
-
     let expectedNFTCount = 0;
     if (price.isAutoDeliver) {
       expectedNFTCount = oldPriceInfo.isAutoDeliver


### PR DESCRIPTION
With auto-delivery using on-demand minting, we don’t need to check stock when updating the price.