### PR TITLE
[TAS-5280] 🌐 Make all email functions language-sensitive

### DIFF
--- a/src/routes/likernft/book/purchase.ts
+++ b/src/routes/likernft/book/purchase.ts
@@ -859,7 +859,7 @@ router.post(
           classId,
           bookName: className,
           paymentId,
-          claimToken,
+          claimToken: claimToken || '',
           from,
           isResend: true,
           displayName: recipientDisplayName,

--- a/src/util/api/likernft/book/cart.ts
+++ b/src/util/api/likernft/book/cart.ts
@@ -646,6 +646,13 @@ export async function processNFTBookCart(
         toEmail,
         message,
       } = cartGiftInfo;
+      let recipientLocale: string | undefined;
+      try {
+        if (toEmail) {
+          const recipientInfo = await fetchUserInfoByEmail(toEmail);
+          if (recipientInfo.locale) recipientLocale = recipientInfo.locale;
+        }
+      } catch { /* ignore */ }
       await sendNFTBookCartGiftPendingClaimEmail({
         fromName,
         toName,
@@ -655,7 +662,7 @@ export async function processNFTBookCart(
         bookNames,
         paymentId,
         claimToken,
-        language: language || 'zh',
+        language: recipientLocale || language || 'zh',
       });
     } else {
       await sendNFTBookCartPendingClaimEmail({

--- a/src/util/api/users/index.ts
+++ b/src/util/api/users/index.ts
@@ -460,4 +460,12 @@ export async function fetchUserDisplayNameByEmail(email: string) {
   return data.displayName || doc.id;
 }
 
+export async function fetchUserInfoByEmail(email: string) {
+  const snapshot = await dbRef.where('email', '==', email).limit(1).get();
+  if (!snapshot.size) return { displayName: '', locale: '' };
+  const [doc] = snapshot.docs;
+  const data = doc.data();
+  return { displayName: data.displayName || doc.id, locale: data.locale || '' };
+}
+
 export * from './getPublicInfo';

--- a/src/util/ses.ts
+++ b/src/util/ses.ts
@@ -134,7 +134,7 @@ export function sendNFTBookPendingClaimEmail({
   classId?: string;
   bookName: string;
   paymentId: string;
-  claimToken?: string;
+  claimToken: string;
   from?: string;
   isResend?: boolean;
   displayName?: string;
@@ -149,7 +149,7 @@ export function sendNFTBookPendingClaimEmail({
   const claimPageURL = getBook3NFTClaimPageURL({
     classId,
     paymentId,
-    token: claimToken || '',
+    token: claimToken,
     // NOTE: claimToken may be empty, resulting in an incomplete URL
     type: 'nft_book',
     language: lang,

--- a/src/util/ses.ts
+++ b/src/util/ses.ts
@@ -19,7 +19,6 @@ import {
   getNFTBookStoreClassPageURL,
   getNFTBookStoreSendPageURL,
 } from './api/likernft/book';
-import { fetchUserDisplayNameByEmail } from './api/users';
 import { TransactionFeeInfo } from './api/likernft/book/type';
 
 // eslint-disable-next-line import/no-dynamic-require, global-require
@@ -120,7 +119,7 @@ export function sendNFTBookListingEmail({
   return ses.sendEmail(params);
 }
 
-export async function sendNFTBookPendingClaimEmail({
+export function sendNFTBookPendingClaimEmail({
   email,
   classId = '',
   bookName,
@@ -128,34 +127,34 @@ export async function sendNFTBookPendingClaimEmail({
   claimToken,
   from = '',
   isResend = false,
+  displayName = '',
+  language = 'zh',
+}: {
+  email: string;
+  classId?: string;
+  bookName: string;
+  paymentId: string;
+  claimToken?: string;
+  from?: string;
+  isResend?: boolean;
+  displayName?: string;
+  language?: string;
 }) {
-  let receiverDisplayName = '';
-  try {
-    receiverDisplayName = await fetchUserDisplayNameByEmail(email);
-  } catch {
-    // Do nothing
-  }
-  const titleEn = `${isResend ? '(Reminder) ' : ''}Read your ebook`;
-  const titleZh = `${isResend ? '（提示）' : ''}閱讀你的電子書`;
-  const nftPageURLEn = getBook3NFTClassPageURL({ classId, language: 'en' });
-  const nftPageURLZh = getBook3NFTClassPageURL({ classId, language: 'zh-Hant' });
-  const claimPageURLEn = getBook3NFTClaimPageURL({
+  const isEn = language === 'en';
+  const lang = isEn ? 'en' : 'zh-Hant';
+  const title = isEn
+    ? `${isResend ? '(Reminder) ' : ''}Read your ebook`
+    : `${isResend ? '（提示）' : ''}閱讀你的電子書`;
+  const nftPageURL = getBook3NFTClassPageURL({ classId, language: lang });
+  const claimPageURL = getBook3NFTClaimPageURL({
     classId,
     paymentId,
-    token: claimToken,
+    token: claimToken || '',
+    // NOTE: claimToken may be empty, resulting in an incomplete URL
     type: 'nft_book',
-    language: 'en',
+    language: lang,
   });
-  const claimPageURLZh = getBook3NFTClaimPageURL({
-    classId,
-    paymentId,
-    token: claimToken,
-    type: 'nft_book',
-    language: 'zh-Hant',
-  });
-  const portfolioURLEn = getBook3PortfolioPageURL({ language: 'en' });
-  const portfolioURLZh = getBook3PortfolioPageURL({ language: 'zh-Hant' });
-  const subject = [titleZh, titleEn].join(' | ');
+  const portfolioURL = getBook3PortfolioPageURL({ language: lang });
   const params = {
     Source: SYSTEM_EMAIL,
     ReplyToAddresses: [CUSTOMER_SERVICE_EMAIL],
@@ -177,44 +176,45 @@ export async function sendNFTBookPendingClaimEmail({
     Message: {
       Subject: {
         Charset: 'UTF-8',
-        Data: TEST_MODE ? `(TESTNET) ${subject}` : subject,
+        Data: TEST_MODE ? `(TESTNET) ${title}` : title,
       },
       Body: {
         Html: {
           Charset: 'UTF-8',
-          Data: getNFTTwoContentWithMessageAndButtonTemplate({
-            title1: titleZh,
-            content1: `<p>親愛的${receiverDisplayName || '讀者'}：</p>
-            <p>感謝你${isResend ? '先前' : ''}購買<a href="${nftPageURLZh}">《${bookName}》</a>。</p>
-            <p>請在 3ook.com 書店，到「<a href="${claimPageURLZh}">我的書架</a>」閱讀你的電子書。
-            若你未註冊 3ook.com 帳號，請點擊<a href="${claimPageURLZh}">這裡</a>註冊。</p>
-            <p>若你購買的電子書需要作者親自簽發，請先點擊<a href="${claimPageURLZh}">這裡</a>登入 3ook.com 書店登記，然後耐心等待作者的發貨通知。
-            作者會在 1-3 個工作天內親手簽發你的電子書。
-            屆時請往你的 <a href="${portfolioURLZh}">3ook.com 書店的書架</a>查閱。</p>`,
-            buttonText1: titleZh,
-            buttonHref1: claimPageURLZh,
-            append1: `<p>如有任何疑問，歡迎<a href="${CUSTOMER_SERVICE_URL}">聯絡客服</a>查詢。
-            <br>感謝珍藏此書，願你享受閱讀的樂趣。</p>
-            <p>3ook.com 書店</p>
-            <p>[${from}]</p>`,
-
-            // English version
-            title2: titleEn,
-            content2: `<p>Dear ${receiverDisplayName || 'reader'},</p>
-            <p>Thanks for ${isResend ? 'previously' : ''} purchasing "<a href="${nftPageURLEn}">${bookName}</a>".</p>
-            <p>Please <a href="${claimPageURLEn}">login to Bookshelf on 3ook.com bookstore</a> to read your ebook.
-            If you have not registered an account on 3ook.com bookstore, please <a href="${claimPageURLEn}">click here</a> to register.</p>
+          Data: isEn
+            ? getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>Dear ${displayName || 'reader'},</p>
+            <p>Thanks for ${isResend ? 'previously ' : ''}purchasing "<a href="${nftPageURL}">${bookName}</a>".</p>
+            <p>Please <a href="${claimPageURL}">login to Bookshelf on 3ook.com bookstore</a> to read your ebook.
+            If you have not registered an account on 3ook.com bookstore, please <a href="${claimPageURL}">click here</a> to register.</p>
             <p>If the ebook you purchased requires the author's personal signature,
-            please first log in to 3ook.com bookstore and register by clicking <a href="${claimPageURLEn}">here</a>, and then patiently wait for the author's dispatch notification.
+            please first log in to 3ook.com bookstore and register by clicking <a href="${claimPageURL}">here</a>, and then patiently wait for the author's dispatch notification.
             The author will personally sign your ebook within 1-3 business days.
-            Please check your <a href="${portfolioURLEn}">Bookshelf on 3ook.com bookstore</a> at that time.</p>`,
-            buttonText2: titleEn,
-            buttonHref2: claimPageURLEn,
-            append2: `<p>If you have any questions, please feel free to contact our <a href="${CUSTOMER_SERVICE_URL}">Customer Service</a> for assistance.
+            Please check your <a href="${portfolioURL}">Bookshelf on 3ook.com bookstore</a> at that time.</p>`,
+              buttonText1: title,
+              buttonHref1: claimPageURL,
+              append1: `<p>If you have any questions, please feel free to contact our <a href="${CUSTOMER_SERVICE_URL}">Customer Service</a> for assistance.
             <br>Thank you for cherishing this book, and may you enjoy the pleasure of reading.</p>
             <p>3ook.com Bookstore</p>
             <p>[${from}]</p>`,
-          }).body,
+            }).body
+            : getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>親愛的${displayName || '讀者'}：</p>
+            <p>感謝你${isResend ? '先前' : ''}購買<a href="${nftPageURL}">《${bookName}》</a>。</p>
+            <p>請在 3ook.com 書店，到「<a href="${claimPageURL}">我的書架</a>」閱讀你的電子書。
+            若你未註冊 3ook.com 帳號，請點擊<a href="${claimPageURL}">這裡</a>註冊。</p>
+            <p>若你購買的電子書需要作者親自簽發，請先點擊<a href="${claimPageURL}">這裡</a>登入 3ook.com 書店登記，然後耐心等待作者的發貨通知。
+            作者會在 1-3 個工作天內親手簽發你的電子書。
+            屆時請往你的 <a href="${portfolioURL}">3ook.com 書店的書架</a>查閱。</p>`,
+              buttonText1: title,
+              buttonHref1: claimPageURL,
+              append1: `<p>如有任何疑問，歡迎<a href="${CUSTOMER_SERVICE_URL}">聯絡客服</a>查詢。
+            <br>感謝珍藏此書，願你享受閱讀的樂趣。</p>
+            <p>3ook.com 書店</p>
+            <p>[${from}]</p>`,
+            }).body,
         },
       },
     },
@@ -222,39 +222,36 @@ export async function sendNFTBookPendingClaimEmail({
   return ses.sendEmail(params);
 }
 
-export async function sendNFTBookCartPendingClaimEmail({
-  email,
+export function sendNFTBookCartPendingClaimEmail({
   cartId,
   bookNames,
   paymentId,
   claimToken,
   isResend = false,
+  displayName = '',
+  language = 'zh',
+}: {
+  cartId: string;
+  bookNames: string[];
+  paymentId: string;
+  claimToken: string;
+  isResend?: boolean;
+  displayName?: string;
+  language?: string;
 }) {
-  let receiverDisplayName = '';
-  try {
-    receiverDisplayName = await fetchUserDisplayNameByEmail(email);
-  } catch {
-    // Do nothing
-  }
-  const titleEn = `${isResend ? '(Reminder) ' : ''}Read your ebook`;
-  const titleZh = `${isResend ? '（提示）' : ''}閱讀你的電子書`;
-  const claimPageURLEn = getBook3NFTClaimPageURL({
+  const isEn = language === 'en';
+  const lang = isEn ? 'en' : 'zh-Hant';
+  const title = isEn
+    ? `${isResend ? '(Reminder) ' : ''}Read your ebook`
+    : `${isResend ? '（提示）' : ''}閱讀你的電子書`;
+  const claimPageURL = getBook3NFTClaimPageURL({
     cartId,
     paymentId,
     token: claimToken,
     type: 'nft_book',
-    language: 'en',
+    language: lang,
   });
-  const claimPageURLZh = getBook3NFTClaimPageURL({
-    cartId,
-    paymentId,
-    token: claimToken,
-    type: 'nft_book',
-    language: 'zh-Hant',
-  });
-  const portfolioURLEn = getBook3PortfolioPageURL({ language: 'en' });
-  const portfolioURLZh = getBook3PortfolioPageURL({ language: 'zh-Hant' });
-  const subject = [titleZh, titleEn].join(' | ');
+  const portfolioURL = getBook3PortfolioPageURL({ language: lang });
   const params = {
     Source: SYSTEM_EMAIL,
     ReplyToAddresses: [CUSTOMER_SERVICE_EMAIL],
@@ -276,46 +273,47 @@ export async function sendNFTBookCartPendingClaimEmail({
     Message: {
       Subject: {
         Charset: 'UTF-8',
-        Data: TEST_MODE ? `(TESTNET) ${subject}` : subject,
+        Data: TEST_MODE ? `(TESTNET) ${title}` : title,
       },
       Body: {
         Html: {
           Charset: 'UTF-8',
-          Data: getNFTTwoContentWithMessageAndButtonTemplate({
-            title1: titleZh,
-            content1: `<p>親愛的${receiverDisplayName || '讀者'}：</p>
-            <p>感謝${isResend ? '你先前' : ''}購買以下電子書</p>
-            <ul>${bookNames.map((name) => `<li>《${name}》</li>`).join('')}</ul>
-            <p>請在 3ook.com 書店，到「<a href="${claimPageURLZh}">我的書架</a>」閱讀你的電子書。
-            若你未註冊 3ook.com 帳號，請點擊<a href="${claimPageURLZh}">這裡</a>註冊。</p>
-            <p>若你購買的電子書需要作者親自簽發，請先點擊<a href="${claimPageURLZh}">這裡</a>登入 3ook.com 書店登記，然後耐心等待作者的發貨通知。
-            作者會在 1-3 個工作天內親手簽發你的電子書。
-            屆時請往你的 <a href="${portfolioURLZh}">3ook.com 書店的書架</a>查閱。</p>`,
-            buttonText1: titleZh,
-            buttonHref1: claimPageURLZh,
-            append1: `<p>如有任何疑問，歡迎<a href="${CUSTOMER_SERVICE_URL}">聯絡客服</a>查詢。
-            <br>感謝珍藏此書，願你享受閱讀的樂趣。</p>
-            <p>3ook.com 書店</p>
-            <p>[${paymentId}]</p>`,
-
-            // English version
-            title2: titleEn,
-            content2: `<p>Dear ${receiverDisplayName || 'reader'},</p>
-            <p>Thank you for ${isResend ? 'previously' : ''}purchasing the following ebook</p>
+          Data: isEn
+            ? getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>Dear ${displayName || 'reader'},</p>
+            <p>Thank you for ${isResend ? 'previously ' : ''}purchasing the following ebook</p>
             <ul>${bookNames.map((name) => `<li>"${name}"</li>`).join('')}</ul>
-            <p>Please <a href="${claimPageURLEn}">login to Bookshelf on 3ook.com bookstore</a> to read your ebook.
-            If you have not registered an account on 3ook.com bookstore, please <a href="${claimPageURLEn}">click here</a> to register.</p>
+            <p>Please <a href="${claimPageURL}">login to Bookshelf on 3ook.com bookstore</a> to read your ebook.
+            If you have not registered an account on 3ook.com bookstore, please <a href="${claimPageURL}">click here</a> to register.</p>
             <p>If the ebook you purchased requires the author's personal signature,
-            please log in to 3ook.com bookstore and register by clicking <a href="${claimPageURLEn}">here</a>, and then patiently wait for the author's dispatch notification.
+            please log in to 3ook.com bookstore and register by clicking <a href="${claimPageURL}">here</a>, and then patiently wait for the author's dispatch notification.
             The author will personally sign your ebook within 1-3 business days.
-            Please check your <a href="${portfolioURLEn}">Bookshelf on 3ook.com bookstore</a> at that time.</p>`,
-            buttonText2: titleEn,
-            buttonHref2: claimPageURLEn,
-            append2: `<p>If you have any questions, please feel free to contact our <a href="${CUSTOMER_SERVICE_URL}">Customer Service</a> for assistance.
+            Please check your <a href="${portfolioURL}">Bookshelf on 3ook.com bookstore</a> at that time.</p>`,
+              buttonText1: title,
+              buttonHref1: claimPageURL,
+              append1: `<p>If you have any questions, please feel free to contact our <a href="${CUSTOMER_SERVICE_URL}">Customer Service</a> for assistance.
             <br>Thank you for cherishing this book, and may you enjoy the pleasure of reading.</p>
             <p>3ook.com Bookstore</p>
             <p>[${paymentId}]</p>`,
-          }).body,
+            }).body
+            : getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>親愛的${displayName || '讀者'}：</p>
+            <p>感謝${isResend ? '你先前' : ''}購買以下電子書</p>
+            <ul>${bookNames.map((name) => `<li>《${name}》</li>`).join('')}</ul>
+            <p>請在 3ook.com 書店，到「<a href="${claimPageURL}">我的書架</a>」閱讀你的電子書。
+            若你未註冊 3ook.com 帳號，請點擊<a href="${claimPageURL}">這裡</a>註冊。</p>
+            <p>若你購買的電子書需要作者親自簽發，請先點擊<a href="${claimPageURL}">這裡</a>登入 3ook.com 書店登記，然後耐心等待作者的發貨通知。
+            作者會在 1-3 個工作天內親手簽發你的電子書。
+            屆時請往你的 <a href="${portfolioURL}">3ook.com 書店的書架</a>查閱。</p>`,
+              buttonText1: title,
+              buttonHref1: claimPageURL,
+              append1: `<p>如有任何疑問，歡迎<a href="${CUSTOMER_SERVICE_URL}">聯絡客服</a>查詢。
+            <br>感謝珍藏此書，願你享受閱讀的樂趣。</p>
+            <p>3ook.com 書店</p>
+            <p>[${paymentId}]</p>`,
+            }).body,
         },
       },
     },
@@ -333,28 +331,22 @@ export function sendNFTBookGiftPendingClaimEmail({
   paymentId,
   claimToken,
   isResend = false,
+  language = 'zh',
 }) {
-  const titleEn = `${isResend ? '(Reminder) ' : ''} ${fromName} has sent you an ebook gift from 3ook.com`;
-  const titleZh = `${isResend ? '（提示）' : ''} ${fromName} 送了一本電子書禮物給你`;
-  const nftPageURLEn = getBook3NFTClassPageURL({ classId, language: 'en' });
-  const nftPageURLZh = getBook3NFTClassPageURL({ classId, language: 'zh-Hant' });
-  const claimPageURLEn = getBook3NFTClaimPageURL({
+  const isEn = language === 'en';
+  const lang = isEn ? 'en' : 'zh-Hant';
+  const title = isEn
+    ? `${isResend ? '(Reminder) ' : ''}${fromName} has sent you an ebook gift from 3ook.com`
+    : `${isResend ? '（提示）' : ''}${fromName} 送了一本電子書禮物給你`;
+  const nftPageURL = getBook3NFTClassPageURL({ classId, language: lang });
+  const claimPageURL = getBook3NFTClaimPageURL({
     classId,
     paymentId,
     token: claimToken,
     type: 'nft_book',
-    language: 'en',
+    language: lang,
   });
-  const claimPageURLZh = getBook3NFTClaimPageURL({
-    classId,
-    paymentId,
-    token: claimToken,
-    type: 'nft_book',
-    language: 'zh-Hant',
-  });
-  const portfolioURLEn = getBook3PortfolioPageURL({ language: 'en' });
-  const portfolioURLZh = getBook3PortfolioPageURL({ language: 'zh-Hant' });
-  const subject = [titleZh, titleEn].join(' | ');
+  const portfolioURL = getBook3PortfolioPageURL({ language: lang });
   const params = {
     Source: SYSTEM_EMAIL,
     ReplyToAddresses: [CUSTOMER_SERVICE_EMAIL],
@@ -376,45 +368,46 @@ export function sendNFTBookGiftPendingClaimEmail({
     Message: {
       Subject: {
         Charset: 'UTF-8',
-        Data: TEST_MODE ? `(TESTNET) ${subject}` : subject,
+        Data: TEST_MODE ? `(TESTNET) ${title}` : title,
       },
       Body: {
         Html: {
           Charset: 'UTF-8',
-          Data: getNFTTwoContentWithMessageAndButtonTemplate({
-            title1: titleZh,
-            content1: `<p>親愛的 ${toName}：</p>
-            <p>${fromName} ${isResend ? '先前' : ''}贈送了一本 <a href="${nftPageURLZh}">《${bookName}》</a> 電子書給你作為禮物。</p>
-            <p>請根據網頁指示領取你的電子書，亦可按以下連結前往該頁面。完成步驟後，即可領取電子書。</p>
-            <p>若你收到的電子書需要作者親自簽發，請在完成步驟後，耐心等待作者發貨。
-            作者會在 1-3 個工作天內親手簽發你的電子書。
-            屆時請往你的 <a href="${portfolioURLZh}">3ook.com 書店的個人主頁</a>查閱。</p>`,
-            messageTitle1: `${fromName} 的留言`,
-            messageContent1: message,
-            buttonText1: '領取我的電子書',
-            buttonHref1: claimPageURLZh,
-            append1: `<p>如有任何疑問，歡迎<a href="${CUSTOMER_SERVICE_URL}">聯絡客服</a>查詢。
-            <br>感謝珍藏此書，願你享受閱讀的樂趣。</p>
-            <p>3ook.com 書店</p>`,
-
-            // English version
-            title2: titleEn,
-            content2: `<p>Dear reader,</p>
-            <p>${fromName} has ${isResend ? 'previously' : ''} sent an ebook <a href="${nftPageURLEn}">“${bookName}“</a>” to you as a gift.</p>
+          Data: isEn
+            ? getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>Dear reader,</p>
+            <p>${fromName} has ${isResend ? 'previously ' : ''}sent an ebook "<a href="${nftPageURL}">${bookName}</a>" to you as a gift.</p>
             <p>Please follow the steps on the web to claim your ebook.
             You can also click the button below to get a direct link to that page.
             Once the steps are completed, you can receive your ebook.</p>
             <p>If the ebook you received requires a personal signature from the author,
             please wait patiently for the author to dispatch it after completing the steps,
-            typically within 3 days. You can check the status of the ebook on your <a href="${portfolioURLEn}">Dashboard on 3ook.com bookstore</a>.</p>`,
-            messageTitle2: `${fromName}'s message`,
-            messageContent2: message,
-            buttonText2: 'Claim your ebook',
-            buttonHref2: claimPageURLEn,
-            append2: `<p>If you have any questions, please feel free to contact our <a href="${CUSTOMER_SERVICE_URL}">Customer Service</a> for assistance.
+            typically within 3 days. You can check the status of the ebook on your <a href="${portfolioURL}">Dashboard on 3ook.com bookstore</a>.</p>`,
+              messageTitle1: `${fromName}'s message`,
+              messageContent1: message,
+              buttonText1: 'Claim your ebook',
+              buttonHref1: claimPageURL,
+              append1: `<p>If you have any questions, please feel free to contact our <a href="${CUSTOMER_SERVICE_URL}">Customer Service</a> for assistance.
             <br>Thank you for cherishing this book, and may you enjoy the pleasure of reading.</p>
             <p>3ook.com Bookstore</p>`,
-          }).body,
+            }).body
+            : getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>親愛的 ${toName}：</p>
+            <p>${fromName} ${isResend ? '先前' : ''}贈送了一本 <a href="${nftPageURL}">《${bookName}》</a> 電子書給你作為禮物。</p>
+            <p>請根據網頁指示領取你的電子書，亦可按以下連結前往該頁面。完成步驟後，即可領取電子書。</p>
+            <p>若你收到的電子書需要作者親自簽發，請在完成步驟後，耐心等待作者發貨。
+            作者會在 1-3 個工作天內親手簽發你的電子書。
+            屆時請往你的 <a href="${portfolioURL}">3ook.com 書店的個人主頁</a>查閱。</p>`,
+              messageTitle1: `${fromName} 的留言`,
+              messageContent1: message,
+              buttonText1: '領取我的電子書',
+              buttonHref1: claimPageURL,
+              append1: `<p>如有任何疑問，歡迎<a href="${CUSTOMER_SERVICE_URL}">聯絡客服</a>查詢。
+            <br>感謝珍藏此書，願你享受閱讀的樂趣。</p>
+            <p>3ook.com 書店</p>`,
+            }).body,
         },
       },
     },
@@ -432,26 +425,21 @@ export function sendNFTBookCartGiftPendingClaimEmail({
   paymentId,
   claimToken,
   isResend = false,
+  language = 'zh',
 }) {
-  const titleEn = `${isResend ? '(Reminder) ' : ''}${fromName} has sent you an ebook gift from 3ook.com`;
-  const titleZh = `${isResend ? '（提示）' : ''}${fromName} 送了電子書禮物給你`;
-  const claimPageURLEn = getBook3NFTClaimPageURL({
+  const isEn = language === 'en';
+  const lang = isEn ? 'en' : 'zh-Hant';
+  const title = isEn
+    ? `${isResend ? '(Reminder) ' : ''}${fromName} has sent you an ebook gift from 3ook.com`
+    : `${isResend ? '（提示）' : ''}${fromName} 送了電子書禮物給你`;
+  const claimPageURL = getBook3NFTClaimPageURL({
     cartId,
     paymentId,
     token: claimToken,
     type: 'nft_book',
-    language: 'en',
+    language: lang,
   });
-  const claimPageURLZh = getBook3NFTClaimPageURL({
-    cartId,
-    paymentId,
-    token: claimToken,
-    type: 'nft_book',
-    language: 'zh-Hant',
-  });
-  const portfolioURLEn = getBook3PortfolioPageURL({ language: 'en' });
-  const portfolioURLZh = getBook3PortfolioPageURL({ language: 'zh-Hant' });
-  const subject = [titleZh, titleEn].join(' | ');
+  const portfolioURL = getBook3PortfolioPageURL({ language: lang });
   const params = {
     Source: SYSTEM_EMAIL,
     ReplyToAddresses: [CUSTOMER_SERVICE_EMAIL],
@@ -473,48 +461,49 @@ export function sendNFTBookCartGiftPendingClaimEmail({
     Message: {
       Subject: {
         Charset: 'UTF-8',
-        Data: TEST_MODE ? `(TESTNET) ${subject}` : subject,
+        Data: TEST_MODE ? `(TESTNET) ${title}` : title,
       },
       Body: {
         Html: {
           Charset: 'UTF-8',
-          Data: getNFTTwoContentWithMessageAndButtonTemplate({
-            title1: titleZh,
-            content1: `<p>親愛的 ${toName || '讀者'}：</p>
-            <p>${fromName} ${isResend ? '先前' : ''}贈送了以下電子書給你作為禮物。</p>
-            <ul>${bookNames.map((name) => `<li>《${name}》</li>`).join('')}</ul>
-            <p>請在 3ook.com 書店，到「<a href="${claimPageURLZh}">我的書架</a>」閱讀你的電子書。
-            若你未註冊 3ook.com 帳號，請點擊<a href="${claimPageURLZh}">這裡</a>註冊。</p>
-            <p>若你購買的電子書需要作者親自簽發，請先點擊<a href="${claimPageURLZh}">這裡</a>登入 3ook.com 書店登記，然後耐心等待作者的發貨通知。
-            作者會在 1-3 個工作天內親手簽發你的電子書。
-            屆時請往你的 <a href="${portfolioURLZh}">3ook.com 書店的書架</a>查閱。</p>`,
-            messageTitle1: `${fromName} 的留言`,
-            messageContent1: message,
-            buttonText1: '領取我的電子書',
-            buttonHref1: claimPageURLZh,
-            append1: `<p>如有任何疑問，歡迎<a href="${CUSTOMER_SERVICE_URL}">聯絡客服</a>查詢。
-            <br>感謝珍藏此書，願你享受閱讀的樂趣。</p>
-            <p>3ook.com 書店</p>`,
-
-            // English version
-            title2: titleEn,
-            content2: `<p>Dear ${toName || 'reader'},</p>
-            <p>${fromName} has ${isResend ? 'preivously' : ''} sent the following ebooks to you as a gift.</p>
+          Data: isEn
+            ? getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>Dear ${toName || 'reader'},</p>
+            <p>${fromName} has ${isResend ? 'previously ' : ''}sent the following ebooks to you as a gift.</p>
             <ul>${bookNames.map((name) => `<li>"${name}"</li>`).join('')}</ul>
-            <p>Please <a href="${claimPageURLEn}">login to Bookshelf on 3ook.com bookstore</a> to read your ebook.
-            If you have not registered an account on 3ook.com bookstore, please <a href="${claimPageURLEn}">click here</a> to register.</p>
+            <p>Please <a href="${claimPageURL}">login to Bookshelf on 3ook.com bookstore</a> to read your ebook.
+            If you have not registered an account on 3ook.com bookstore, please <a href="${claimPageURL}">click here</a> to register.</p>
             <p>If the ebook you purchased requires the author's personal signature,
-            please log in to 3ook.com bookstore and register by clicking <a href="${claimPageURLEn}">here</a>, and then patiently wait for the author's dispatch notification.
+            please log in to 3ook.com bookstore and register by clicking <a href="${claimPageURL}">here</a>, and then patiently wait for the author's dispatch notification.
             The author will personally sign your ebook within 1-3 business days.
-            Please check your <a href="${portfolioURLEn}">Bookshelf on 3ook.com bookstore</a> at that time.</p>`,
-            messageTitle2: `${fromName}'s message`,
-            messageContent2: message,
-            buttonText2: 'Claim your ebook',
-            buttonHref2: claimPageURLEn,
-            append2: `<p>If you have any questions, please feel free to contact our <a href="${CUSTOMER_SERVICE_URL}">Customer Service</a> for assistance.
+            Please check your <a href="${portfolioURL}">Bookshelf on 3ook.com bookstore</a> at that time.</p>`,
+              messageTitle1: `${fromName}'s message`,
+              messageContent1: message,
+              buttonText1: 'Claim your ebook',
+              buttonHref1: claimPageURL,
+              append1: `<p>If you have any questions, please feel free to contact our <a href="${CUSTOMER_SERVICE_URL}">Customer Service</a> for assistance.
             <br>Thank you for cherishing this book, and may you enjoy the pleasure of reading.</p>
             <p>3ook.com Bookstore</p>`,
-          }).body,
+            }).body
+            : getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>親愛的 ${toName || '讀者'}：</p>
+            <p>${fromName} ${isResend ? '先前' : ''}贈送了以下電子書給你作為禮物。</p>
+            <ul>${bookNames.map((name) => `<li>《${name}》</li>`).join('')}</ul>
+            <p>請在 3ook.com 書店，到「<a href="${claimPageURL}">我的書架</a>」閱讀你的電子書。
+            若你未註冊 3ook.com 帳號，請點擊<a href="${claimPageURL}">這裡</a>註冊。</p>
+            <p>若你購買的電子書需要作者親自簽發，請先點擊<a href="${claimPageURL}">這裡</a>登入 3ook.com 書店登記，然後耐心等待作者的發貨通知。
+            作者會在 1-3 個工作天內親手簽發你的電子書。
+            屆時請往你的 <a href="${portfolioURL}">3ook.com 書店的書架</a>查閱。</p>`,
+              messageTitle1: `${fromName} 的留言`,
+              messageContent1: message,
+              buttonText1: '領取我的電子書',
+              buttonHref1: claimPageURL,
+              append1: `<p>如有任何疑問，歡迎<a href="${CUSTOMER_SERVICE_URL}">聯絡客服</a>查詢。
+            <br>感謝珍藏此書，願你享受閱讀的樂趣。</p>
+            <p>3ook.com 書店</p>`,
+            }).body,
         },
       },
     },
@@ -527,10 +516,12 @@ export function sendNFTBookGiftClaimedEmail({
   fromEmail,
   fromName,
   toName,
+  language = 'zh',
 }) {
-  const titleEn = `${toName} has accepted your ebook gift ${bookName}`;
-  const titleZh = `${toName} 已接受你的禮物電子書 ${bookName}`;
-  const subject = [titleZh, titleEn].join(' | ');
+  const isEn = language === 'en';
+  const title = isEn
+    ? `${toName} has accepted your ebook gift ${bookName}`
+    : `${toName} 已接受你的禮物電子書 ${bookName}`;
   const params = {
     Source: SYSTEM_EMAIL,
     ReplyToAddresses: [CUSTOMER_SERVICE_EMAIL],
@@ -552,27 +543,28 @@ export function sendNFTBookGiftClaimedEmail({
     Message: {
       Subject: {
         Charset: 'UTF-8',
-        Data: TEST_MODE ? `(TESTNET) ${subject}` : subject,
+        Data: TEST_MODE ? `(TESTNET) ${title}` : title,
       },
       Body: {
         Html: {
           Charset: 'UTF-8',
-          Data: getNFTTwoContentWithMessageAndButtonTemplate({
-            title1: titleZh,
-            content1: `<p>親愛的 ${fromName}：</p>
-            <p>你送給 ${toName} 的《${bookName}》已被接受。
-            <br>作者將會在稍後簽署給發送電子書給 ${toName} </p>
-            <p>感謝你分享閱讀的樂趣</p>
-            <p>3ook.com 書店</p>`,
-
-            // English version
-            title2: titleEn,
-            content2: `<p>Dear ${fromName},</p>
+          Data: isEn
+            ? getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>Dear ${fromName},</p>
             <p>Your ebook gift of ${bookName} has been accepted by ${toName}.
             <br>Author will soon sign and send the ebook copy to ${toName}</p>
             <p>Thank you for sharing the joy of reading.</p>
             <p>3ook.com Bookstore</p>`,
-          }).body,
+            }).body
+            : getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>親愛的 ${fromName}：</p>
+            <p>你送給 ${toName} 的《${bookName}》已被接受。
+            <br>作者將會在稍後簽署給發送電子書給 ${toName} </p>
+            <p>感謝你分享閱讀的樂趣</p>
+            <p>3ook.com 書店</p>`,
+            }).body,
         },
       },
     },
@@ -586,10 +578,12 @@ export function sendNFTBookGiftSentEmail({
   toName,
   bookName,
   txHash,
+  language = 'zh',
 }) {
-  const titleEn = `Your ebook gift ${bookName} to ${toName} has been delivered`;
-  const titleZh = `你給 ${toName} 的禮物電子書 ${bookName} 已經發送`;
-  const subject = [titleZh, titleEn].join(' | ');
+  const isEn = language === 'en';
+  const title = isEn
+    ? `Your ebook gift ${bookName} to ${toName} has been delivered`
+    : `你給 ${toName} 的禮物電子書 ${bookName} 已經發送`;
   const txURL = `${CHAIN_EXPLORER_URL}/tx/${txHash}`;
   const params = {
     Source: SYSTEM_EMAIL,
@@ -612,27 +606,28 @@ export function sendNFTBookGiftSentEmail({
     Message: {
       Subject: {
         Charset: 'UTF-8',
-        Data: TEST_MODE ? `(TESTNET) ${subject}` : subject,
+        Data: TEST_MODE ? `(TESTNET) ${title}` : title,
       },
       Body: {
         Html: {
           Charset: 'UTF-8',
-          Data: getNFTTwoContentWithMessageAndButtonTemplate({
-            title1: titleZh,
-            content1: `<p>親愛的 ${fromName}：</p>
-            <p>你購買的 ${bookName} 已成功發送給 ${toName}。
-            <br>如需瀏覽技術細節，請按<a href="${txURL}">此連結</a></p>
-            <p>感謝你分享閱讀的樂趣</p>
-            <p>3ook.com 書店</p>`,
-
-            // English version
-            title2: titleEn,
-            content2: `<p>Dear ${fromName},</p>
+          Data: isEn
+            ? getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>Dear ${fromName},</p>
             <p>Your gift ${bookName} has been delivered to ${toName}.
             <br>For technical details, visit <a href="${txURL}">transaction detail page</a></p>
             <p>Thank you for sharing the joy of reading.</p>
             <p>3ook.com Bookstore</p>`,
-          }).body,
+            }).body
+            : getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>親愛的 ${fromName}：</p>
+            <p>你購買的 ${bookName} 已成功發送給 ${toName}。
+            <br>如需瀏覽技術細節，請按<a href="${txURL}">此連結</a></p>
+            <p>感謝你分享閱讀的樂趣</p>
+            <p>3ook.com 書店</p>`,
+            }).body,
         },
       },
     },
@@ -640,30 +635,28 @@ export function sendNFTBookGiftSentEmail({
   return ses.sendEmail(params);
 }
 
-export async function sendNFTBookManualDeliverSentEmail({
+export function sendNFTBookManualDeliverSentEmail({
   email,
   classId,
   bookName,
   txHash,
+  displayName = '',
+  language = 'zh',
 }: {
   email: string;
   classId: string;
   bookName: string;
   txHash: string;
+  displayName?: string;
+  language?: string;
 }) {
-  let receiverDisplayName = '';
-  try {
-    receiverDisplayName = await fetchUserDisplayNameByEmail(email);
-  } catch {
-    // Do nothing
-  }
-  const titleEn = `Your ebook ${bookName} has been delivered`;
-  const titleZh = `你的電子書《${bookName}》已經發送`;
-  const subject = [titleZh, titleEn].join(' | ');
-  const nftPageURLEn = getBook3NFTClassPageURL({ classId, language: 'en' });
-  const nftPageURLZh = getBook3NFTClassPageURL({ classId, language: 'zh-Hant' });
-  const portfolioURLEn = getBook3PortfolioPageURL({ language: 'en' });
-  const portfolioURLZh = getBook3PortfolioPageURL({ language: 'zh-Hant' });
+  const isEn = language === 'en';
+  const lang = isEn ? 'en' : 'zh-Hant';
+  const title = isEn
+    ? `Your ebook ${bookName} has been delivered`
+    : `你的電子書《${bookName}》已經發送`;
+  const nftPageURL = getBook3NFTClassPageURL({ classId, language: lang });
+  const portfolioURL = getBook3PortfolioPageURL({ language: lang });
   const txURL = `${CHAIN_EXPLORER_URL}/tx/${txHash}`;
   const params = {
     Source: SYSTEM_EMAIL,
@@ -686,33 +679,34 @@ export async function sendNFTBookManualDeliverSentEmail({
     Message: {
       Subject: {
         Charset: 'UTF-8',
-        Data: TEST_MODE ? `(TESTNET) ${subject}` : subject,
+        Data: TEST_MODE ? `(TESTNET) ${title}` : title,
       },
       Body: {
         Html: {
           Charset: 'UTF-8',
-          Data: getNFTTwoContentWithMessageAndButtonTemplate({
-            title1: titleZh,
-            content1: `<p>親愛的 ${receiverDisplayName || '讀者'}：</p>
-            <p>你購買的 <a href="${nftPageURLZh}">《${bookName}》</a> 已經由作者親手簽發。</p>
-            <p>請到你的 <a href="${portfolioURLZh}">3ook.com 書店的書架</a>閱讀你的電子書。如需瀏覽技術細節，請按<a href="${txURL}">此連結</a>。</p>`,
-            buttonText1: '前往我的書架',
-            buttonHref1: portfolioURLZh,
-            append1: `<p>如有任何疑問，歡迎<a href="${CUSTOMER_SERVICE_URL}">聯絡客服</a>查詢。
-            <br>感謝珍藏此書，願你享受閱讀的樂趣。</p>
-            <p>3ook.com 書店</p>`,
-
-            // English version
-            title2: titleEn,
-            content2: `<p>Dear ${receiverDisplayName || 'reader'},</p>
-            <p>Your ebook "<a href="${nftPageURLEn}">${bookName}</a>" has been personally signed and delivered by the author.</p>
-            <p>Please visit your <a href="${portfolioURLEn}">Bookshelf on 3ook.com bookstore</a> to read your ebook. For technical details, visit <a href="${txURL}">transaction detail page</a>.</p>`,
-            buttonText2: 'Go to my Bookshelf',
-            buttonHref2: portfolioURLEn,
-            append2: `<p>If you have any questions, please feel free to contact our <a href="${CUSTOMER_SERVICE_URL}">Customer Service</a> for assistance.
+          Data: isEn
+            ? getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>Dear ${displayName || 'reader'},</p>
+            <p>Your ebook "<a href="${nftPageURL}">${bookName}</a>" has been personally signed and delivered by the author.</p>
+            <p>Please visit your <a href="${portfolioURL}">Bookshelf on 3ook.com bookstore</a> to read your ebook. For technical details, visit <a href="${txURL}">transaction detail page</a>.</p>`,
+              buttonText1: 'Go to my Bookshelf',
+              buttonHref1: portfolioURL,
+              append1: `<p>If you have any questions, please feel free to contact our <a href="${CUSTOMER_SERVICE_URL}">Customer Service</a> for assistance.
             <br>Thank you for cherishing this book, and may you enjoy the pleasure of reading.</p>
             <p>3ook.com Bookstore</p>`,
-          }).body,
+            }).body
+            : getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>親愛的 ${displayName || '讀者'}：</p>
+            <p>你購買的 <a href="${nftPageURL}">《${bookName}》</a> 已經由作者親手簽發。</p>
+            <p>請到你的 <a href="${portfolioURL}">3ook.com 書店的書架</a>閱讀你的電子書。如需瀏覽技術細節，請按<a href="${txURL}">此連結</a>。</p>`,
+              buttonText1: '前往我的書架',
+              buttonHref1: portfolioURL,
+              append1: `<p>如有任何疑問，歡迎<a href="${CUSTOMER_SERVICE_URL}">聯絡客服</a>查詢。
+            <br>感謝珍藏此書，願你享受閱讀的樂趣。</p>
+            <p>3ook.com 書店</p>`,
+            }).body,
         },
       },
     },
@@ -730,6 +724,7 @@ export function sendAutoDeliverNFTBookSalesEmail({
   wallet,
   coupon,
   from,
+  language = 'zh',
 }: {
   email: string;
   classId: string;
@@ -741,7 +736,9 @@ export function sendAutoDeliverNFTBookSalesEmail({
   wallet: string;
   coupon?: string;
   from?: string;
+  language?: string;
 }) {
+  const isEn = language === 'en';
   const {
     priceInDecimal,
     originalPriceInDecimal,
@@ -755,24 +752,47 @@ export function sendAutoDeliverNFTBookSalesEmail({
   const totalRevenue = royaltyToSplit + channelCommission + customPriceDiffAfterFee;
   const fxVarianceDiff = priceInDecimal - customPriceDiffInDecimal - originalPriceInDecimal;
   const hasFxVariance = Math.round(fxVarianceDiff * 100) !== 0;
-  const fxVarianceNote = hasFxVariance ? '（包含讀者貨幣的滙率差）,' : '';
-  const title = `《${bookName}》訂單`;
-  let content = `<p>恭喜，收到《${bookName}》的訂單，作品已經自動發送。</p>`;
-  if (coupon) content += `<p>優惠碼：${coupon}</p>`;
-  content += '<table>';
-  content += `<tr><td>售價：</td><td>USD ${formatEmailDecimalNumber(priceInDecimal - customPriceDiffInDecimal)}（${fxVarianceNote}原價：USD ${formatEmailDecimalNumber(originalPriceInDecimal)}）</td></tr>`;
-  if (customPriceDiffAfterFee) content += `<tr><td></td><td>USD ${formatEmailDecimalNumber(customPriceDiffAfterFee)}（讀者額外支持）</td></tr>`;
-  content += `<tr><td>收益：</td><td>USD ${formatEmailDecimalNumber(royaltyToSplit)}（權利金）</td></tr>`;
-  if (from) content += `<tr><td></td><td>USD ${formatEmailDecimalNumber(channelCommission)}（通路：${from}）</td></tr>`;
-  content += `<tr><td>總計：</td><td>USD ${formatEmailDecimalNumber(totalRevenue)}</td></tr>`;
-  content += '</table>';
 
-  if (buyerEmail !== claimerEmail) {
-    content += `<p>買家電郵：${buyerEmail}</p>`;
+  let title: string;
+  let content: string;
+  if (isEn) {
+    const fxVarianceNote = hasFxVariance ? 'includes FX variance, ' : '';
+    title = `Order for "${bookName}"`;
+    content = `<p>Congratulations! An order for "${bookName}" has been received and automatically delivered.</p>`;
+    if (coupon) content += `<p>Coupon: ${coupon}</p>`;
+    content += '<table>';
+    content += `<tr><td>Price:</td><td>USD ${formatEmailDecimalNumber(priceInDecimal - customPriceDiffInDecimal)} (${fxVarianceNote}original: USD ${formatEmailDecimalNumber(originalPriceInDecimal)})</td></tr>`;
+    if (customPriceDiffAfterFee) content += `<tr><td></td><td>USD ${formatEmailDecimalNumber(customPriceDiffAfterFee)} (extra reader support)</td></tr>`;
+    content += `<tr><td>Revenue:</td><td>USD ${formatEmailDecimalNumber(royaltyToSplit)} (royalty)</td></tr>`;
+    if (from) content += `<tr><td></td><td>USD ${formatEmailDecimalNumber(channelCommission)} (channel: ${from})</td></tr>`;
+    content += `<tr><td>Total:</td><td>USD ${formatEmailDecimalNumber(totalRevenue)}</td></tr>`;
+    content += '</table>';
+    if (buyerEmail !== claimerEmail) {
+      content += `<p>Buyer email: ${buyerEmail}</p>`;
+    }
+    content += `<p>Reader email: ${claimerEmail}</p>`;
+    content += `<p>Reader wallet: ${wallet}</p>`;
+    content += `<p><a href="${getNFTBookStoreClassPageURL(classId)}">[Manage Orders]</a></p>`;
+  } else {
+    const fxVarianceNote = hasFxVariance ? '（包含讀者貨幣的滙率差）,' : '';
+    title = `《${bookName}》訂單`;
+    content = `<p>恭喜，收到《${bookName}》的訂單，作品已經自動發送。</p>`;
+    if (coupon) content += `<p>優惠碼：${coupon}</p>`;
+    content += '<table>';
+    content += `<tr><td>售價：</td><td>USD ${formatEmailDecimalNumber(priceInDecimal - customPriceDiffInDecimal)}（${fxVarianceNote}原價：USD ${formatEmailDecimalNumber(originalPriceInDecimal)}）</td></tr>`;
+    if (customPriceDiffAfterFee) content += `<tr><td></td><td>USD ${formatEmailDecimalNumber(customPriceDiffAfterFee)}（讀者額外支持）</td></tr>`;
+    content += `<tr><td>收益：</td><td>USD ${formatEmailDecimalNumber(royaltyToSplit)}（權利金）</td></tr>`;
+    if (from) content += `<tr><td></td><td>USD ${formatEmailDecimalNumber(channelCommission)}（通路：${from}）</td></tr>`;
+    content += `<tr><td>總計：</td><td>USD ${formatEmailDecimalNumber(totalRevenue)}</td></tr>`;
+    content += '</table>';
+    if (buyerEmail !== claimerEmail) {
+      content += `<p>買家電郵：${buyerEmail}</p>`;
+    }
+    content += `<p>讀者電郵：${claimerEmail}</p>`;
+    content += `<p>讀者錢包：${wallet}</p>`;
+    content += `<p><a href="${getNFTBookStoreClassPageURL(classId)}">[管理訂單]</a></p>`;
   }
-  content += `<p>讀者電郵：${claimerEmail}</p>`;
-  content += `<p>讀者錢包：${wallet}</p>`;
-  content += `<p><a href="${getNFTBookStoreClassPageURL(classId)}">[管理訂單]</a></p>`;
+
   const params = {
     Source: SYSTEM_EMAIL,
     ReplyToAddresses: [CUSTOMER_SERVICE_EMAIL],
@@ -818,34 +838,58 @@ export function sendNFTBookSalePaymentsEmail({
   email,
   bookName,
   payments,
+  language = 'zh',
 }) {
+  const isEn = language === 'en';
   const hasRoyalty = payments.some(({ type }) => type === 'connectedWallet');
   const totalAmount = payments.reduce((acc, { amount }) => acc + amount, 0);
-  const nftPageURLEn = getBook3NFTClassPageURL({ classId });
-  const paymentTypeLabel = hasRoyalty ? 'Royalty' : 'Commission';
-  const title = `${paymentTypeLabel} Received: US$${formatEmailDecimalNumber(totalAmount * 100)} for ${bookName}`;
+  const lang = isEn ? 'en' : 'zh-Hant';
+  const nftPageURL = getBook3NFTClassPageURL({ classId, language: lang });
 
-  let content = '<p>Dear Book Lover,</p>';
-  content += '<p>Congratulations!</p>';
-  content += `<p>Someone has just purchased the book <a href="${nftPageURLEn}">${bookName}</a>.</p>`;
-  content += '<p>As a result, you have received the following payment:</p>';
-  content += '<table>';
-
-  const labelMap: { [key: string]: string } = {
-    connectedWallet: 'Royalty:',
-    channelCommission: 'Commission:',
-  };
-
-  payments.forEach(({ amount, type }) => {
-    const label = labelMap[type] || 'Other:';
-    content += `<tr><td>${label}</td><td>US$${formatEmailDecimalNumber(amount * 100)}</td></tr>`;
-  });
-
-  content += '</table>';
-  content += `<p>Reference ID: ${paymentId}</p>`;
-  content += '<p>Thank you for being part of the community.</p>';
-  content += '<p>Warm regards,</p>';
-  content += '<p>3ook.com</p>';
+  let title: string;
+  let content: string;
+  if (isEn) {
+    const paymentTypeLabel = hasRoyalty ? 'Royalty' : 'Commission';
+    title = `${paymentTypeLabel} Received: US$${formatEmailDecimalNumber(totalAmount * 100)} for ${bookName}`;
+    content = '<p>Dear Book Lover,</p>';
+    content += '<p>Congratulations!</p>';
+    content += `<p>Someone has just purchased the book <a href="${nftPageURL}">${bookName}</a>.</p>`;
+    content += '<p>As a result, you have received the following payment:</p>';
+    content += '<table>';
+    const labelMap: { [key: string]: string } = {
+      connectedWallet: 'Royalty:',
+      channelCommission: 'Commission:',
+    };
+    payments.forEach(({ amount, type }) => {
+      const label = labelMap[type] || 'Other:';
+      content += `<tr><td>${label}</td><td>US$${formatEmailDecimalNumber(amount * 100)}</td></tr>`;
+    });
+    content += '</table>';
+    content += `<p>Reference ID: ${paymentId}</p>`;
+    content += '<p>Thank you for being part of the community.</p>';
+    content += '<p>Warm regards,</p>';
+    content += '<p>3ook.com</p>';
+  } else {
+    const paymentTypeLabel = hasRoyalty ? '版稅' : '佣金';
+    title = `收到${paymentTypeLabel}：US$${formatEmailDecimalNumber(totalAmount * 100)}（${bookName}）`;
+    content = '<p>親愛的書友：</p>';
+    content += '<p>恭喜！</p>';
+    content += `<p>有人剛剛購買了 <a href="${nftPageURL}">${bookName}</a>。</p>`;
+    content += '<p>因此，你收到了以下款項：</p>';
+    content += '<table>';
+    const labelMap: { [key: string]: string } = {
+      connectedWallet: '版稅：',
+      channelCommission: '佣金：',
+    };
+    payments.forEach(({ amount, type }) => {
+      const label = labelMap[type] || '其他：';
+      content += `<tr><td>${label}</td><td>US$${formatEmailDecimalNumber(amount * 100)}</td></tr>`;
+    });
+    content += '</table>';
+    content += `<p>參考編號：${paymentId}</p>`;
+    content += '<p>感謝你成為社區的一分子。</p>';
+    content += '<p>3ook.com</p>';
+  }
 
   const params = {
     Source: SYSTEM_EMAIL,
@@ -895,6 +939,7 @@ export function sendManualNFTBookSalesEmail({
   wallet,
   coupon,
   from,
+  language = 'zh',
 }: {
   email: string;
   classId: string;
@@ -906,7 +951,9 @@ export function sendManualNFTBookSalesEmail({
   wallet: string;
   coupon?: string;
   from?: string;
+  language?: string;
 }) {
+  const isEn = language === 'en';
   const {
     priceInDecimal,
     originalPriceInDecimal,
@@ -920,24 +967,47 @@ export function sendManualNFTBookSalesEmail({
   const totalRevenue = royaltyToSplit + channelCommission + customPriceDiffAfterFee;
   const fxVarianceDiff = priceInDecimal - customPriceDiffInDecimal - originalPriceInDecimal;
   const hasFxVariance = Math.round(fxVarianceDiff * 100) !== 0;
-  const fxVarianceNote = hasFxVariance ? '（包含讀者貨幣的滙率差）,' : '';
-  const title = `收到訂單，請簽發《${bookName}》訂單`;
-  let content = `<p>恭喜，收到《${bookName}》的訂單，請到作者管理介面簽發。</p>`;
-  if (coupon) content += `<p>優惠碼：${coupon}</p>`;
-  content += '<table>';
-  content += `<tr><td>售價：</td><td>USD ${formatEmailDecimalNumber(priceInDecimal - customPriceDiffInDecimal)}（${fxVarianceNote}原價：USD ${formatEmailDecimalNumber(originalPriceInDecimal)}）</td></tr>`;
-  if (customPriceDiffAfterFee) content += `<tr><td></td><td>USD ${formatEmailDecimalNumber(customPriceDiffAfterFee)}（讀者額外支持）</td></tr>`;
-  content += `<tr><td>收益：</td><td>USD ${formatEmailDecimalNumber(royaltyToSplit)}（權利金）</td></tr>`;
-  if (from) content += `<tr><td></td><td>USD ${formatEmailDecimalNumber(channelCommission)}（通路：${from}）</td></tr>`;
-  content += `<tr><td>總計：</td><td>USD ${formatEmailDecimalNumber(totalRevenue)}</td></tr>`;
-  content += '</table>';
 
-  if (buyerEmail !== claimerEmail) {
-    content += `<p>買家電郵：${buyerEmail}</p>`;
+  let title: string;
+  let content: string;
+  if (isEn) {
+    const fxVarianceNote = hasFxVariance ? 'includes FX variance, ' : '';
+    title = `Order received — please sign and deliver "${bookName}"`;
+    content = `<p>Congratulations! An order for "${bookName}" has been received. Please go to the author management page to sign and deliver.</p>`;
+    if (coupon) content += `<p>Coupon: ${coupon}</p>`;
+    content += '<table>';
+    content += `<tr><td>Price:</td><td>USD ${formatEmailDecimalNumber(priceInDecimal - customPriceDiffInDecimal)} (${fxVarianceNote}original: USD ${formatEmailDecimalNumber(originalPriceInDecimal)})</td></tr>`;
+    if (customPriceDiffAfterFee) content += `<tr><td></td><td>USD ${formatEmailDecimalNumber(customPriceDiffAfterFee)} (extra reader support)</td></tr>`;
+    content += `<tr><td>Revenue:</td><td>USD ${formatEmailDecimalNumber(royaltyToSplit)} (royalty)</td></tr>`;
+    if (from) content += `<tr><td></td><td>USD ${formatEmailDecimalNumber(channelCommission)} (channel: ${from})</td></tr>`;
+    content += `<tr><td>Total:</td><td>USD ${formatEmailDecimalNumber(totalRevenue)}</td></tr>`;
+    content += '</table>';
+    if (buyerEmail !== claimerEmail) {
+      content += `<p>Buyer email: ${buyerEmail}</p>`;
+    }
+    content += `<p>Reader email: ${claimerEmail}</p>`;
+    content += `<p>Reader wallet: ${wallet}</p>`;
+    content += `<p><a href="${getNFTBookStoreSendPageURL(classId, paymentId)}">[Sign & Deliver]</a></p>`;
+  } else {
+    const fxVarianceNote = hasFxVariance ? '（包含讀者貨幣的滙率差）,' : '';
+    title = `收到訂單，請簽發《${bookName}》訂單`;
+    content = `<p>恭喜，收到《${bookName}》的訂單，請到作者管理介面簽發。</p>`;
+    if (coupon) content += `<p>優惠碼：${coupon}</p>`;
+    content += '<table>';
+    content += `<tr><td>售價：</td><td>USD ${formatEmailDecimalNumber(priceInDecimal - customPriceDiffInDecimal)}（${fxVarianceNote}原價：USD ${formatEmailDecimalNumber(originalPriceInDecimal)}）</td></tr>`;
+    if (customPriceDiffAfterFee) content += `<tr><td></td><td>USD ${formatEmailDecimalNumber(customPriceDiffAfterFee)}（讀者額外支持）</td></tr>`;
+    content += `<tr><td>收益：</td><td>USD ${formatEmailDecimalNumber(royaltyToSplit)}（權利金）</td></tr>`;
+    if (from) content += `<tr><td></td><td>USD ${formatEmailDecimalNumber(channelCommission)}（通路：${from}）</td></tr>`;
+    content += `<tr><td>總計：</td><td>USD ${formatEmailDecimalNumber(totalRevenue)}</td></tr>`;
+    content += '</table>';
+    if (buyerEmail !== claimerEmail) {
+      content += `<p>買家電郵：${buyerEmail}</p>`;
+    }
+    content += `<p>讀者電郵：${claimerEmail}</p>`;
+    content += `<p>讀者錢包：${wallet}</p>`;
+    content += `<p><a href="${getNFTBookStoreSendPageURL(classId, paymentId)}">[簽發作品]</a></p>`;
   }
-  content += `<p>讀者電郵：${claimerEmail}</p>`;
-  content += `<p>讀者錢包：${wallet}</p>`;
-  content += `<p><a href="${getNFTBookStoreSendPageURL(classId, paymentId)}">[簽發作品]</a></p>`;
+
   const params = {
     Source: SYSTEM_EMAIL,
     ReplyToAddresses: [CUSTOMER_SERVICE_EMAIL],
@@ -982,17 +1052,29 @@ export function sendNFTBookOutOfStockEmail({
   classId = '',
   bookName,
   priceName,
+  language = 'zh',
 }) {
   if (!email) return Promise.resolve();
-  const title = `Your book ${bookName} ${priceName} is sold out`;
+  const isEn = language === 'en';
   const url = getNFTBookStoreClassPageURL(classId);
-  const content = `<p>Dear Creator,</p>
+  const title = isEn
+    ? `Your book ${bookName} ${priceName} is sold out`
+    : `你的書籍 ${bookName} ${priceName} 已售罄`;
+  const content = isEn
+    ? `<p>Dear Creator,</p>
   <br/>
-  <p>Congratulation!</p>
+  <p>Congratulations!</p>
   <p>Your book ${bookName} ${priceName} is sold out.</p>
   <p>Please <a href="${url}">restock your book</a> to continue selling.</p>
   <br/>
-  <p>3ook.com Bookstore</p>`;
+  <p>3ook.com Bookstore</p>`
+    : `<p>親愛的創作者：</p>
+  <br/>
+  <p>恭喜！</p>
+  <p>你的書籍 ${bookName} ${priceName} 已售罄。</p>
+  <p>請<a href="${url}">補貨</a>以繼續銷售。</p>
+  <br/>
+  <p>3ook.com 書店</p>`;
   const params = {
     Source: SYSTEM_EMAIL,
     ConfigurationSetName: 'likeco_ses',
@@ -1039,13 +1121,18 @@ export function sendPlusGiftPendingClaimEmail({
   paymentId,
   claimToken,
   isResend = false,
+  language = 'zh',
 }) {
-  const titleZh = `${isResend ? '（提示）' : ''}${fromName} 送贈了 Plus 會籍給你`;
-  const claimPageURLZh = getPlusGiftPageClaimURL({
+  const isEn = language === 'en';
+  const lang = isEn ? 'en' : 'zh-Hant';
+  const title = isEn
+    ? `${isResend ? '(Reminder) ' : ''}${fromName} has gifted you a Plus membership`
+    : `${isResend ? '（提示）' : ''}${fromName} 送贈了 Plus 會籍給你`;
+  const claimPageURL = getPlusGiftPageClaimURL({
     cartId,
     paymentId,
     token: claimToken,
-    language: 'zh-Hant',
+    language: lang,
   });
   const ccAddresses: string[] = [];
   if (fromEmail) {
@@ -1073,24 +1160,38 @@ export function sendPlusGiftPendingClaimEmail({
     Message: {
       Subject: {
         Charset: 'UTF-8',
-        Data: TEST_MODE ? `(TESTNET) ${titleZh}` : titleZh,
+        Data: TEST_MODE ? `(TESTNET) ${title}` : title,
       },
       Body: {
         Html: {
           Charset: 'UTF-8',
-          Data: getNFTTwoContentWithMessageAndButtonTemplate({
-            title1: titleZh,
-            content1: `<p>親愛的 ${toName || '讀者'}：</p>
+          Data: isEn
+            ? getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>Dear ${toName || 'reader'},</p>
+            <p>${fromName} has ${isResend ? 'previously ' : ''}gifted you a Plus membership.</p>
+            <p>Please register at <a href="${claimPageURL}">3ook.com bookstore</a> to claim your membership and start your AI reading journey.</p>`,
+              messageTitle1: `${fromName}'s message`,
+              messageContent1: message,
+              buttonText1: 'Claim my Plus membership',
+              buttonHref1: claimPageURL,
+              append1: `<p>If you have any questions, please feel free to contact our <a href="${CUSTOMER_SERVICE_URL}">Customer Service</a> for assistance.
+            <br>May you enjoy the pleasure of reading.</p>
+            <p>3ook.com Bookstore</p>`,
+            }).body
+            : getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>親愛的 ${toName || '讀者'}：</p>
             <p>${fromName} ${isResend ? '先前' : ''}送贈了 Plus 會籍給你。</p>
-            <p>請在 <a href="${claimPageURLZh}">3ook.com 書店</a>註冊獲取會籍，開始你的 AI 閱讀之旅。</p>`,
-            messageTitle1: `${fromName} 的留言`,
-            messageContent1: message,
-            buttonText1: '領取我的 Plus 會籍',
-            buttonHref1: claimPageURLZh,
-            append1: `<p>如有任何疑問，歡迎<a href="${CUSTOMER_SERVICE_URL}">聯絡客服</a>查詢。
+            <p>請在 <a href="${claimPageURL}">3ook.com 書店</a>註冊獲取會籍，開始你的 AI 閱讀之旅。</p>`,
+              messageTitle1: `${fromName} 的留言`,
+              messageContent1: message,
+              buttonText1: '領取我的 Plus 會籍',
+              buttonHref1: claimPageURL,
+              append1: `<p>如有任何疑問，歡迎<a href="${CUSTOMER_SERVICE_URL}">聯絡客服</a>查詢。
             <br>願你享受閱讀的樂趣。</p>
             <p>3ook.com 書店</p>`,
-          }).body,
+            }).body,
         },
       },
     },
@@ -1102,8 +1203,12 @@ export function sendPlusGiftClaimedEmail({
   fromEmail,
   fromName,
   toName,
+  language = 'zh',
 }) {
-  const titleZh = `${toName} 已接受你送贈的 Plus 會籍`;
+  const isEn = language === 'en';
+  const title = isEn
+    ? `${toName} has accepted your Plus membership gift`
+    : `${toName} 已接受你送贈的 Plus 會籍`;
   const params = {
     Source: SYSTEM_EMAIL,
     ReplyToAddresses: [CUSTOMER_SERVICE_EMAIL],
@@ -1125,18 +1230,26 @@ export function sendPlusGiftClaimedEmail({
     Message: {
       Subject: {
         Charset: 'UTF-8',
-        Data: TEST_MODE ? `(TESTNET) ${titleZh}` : titleZh,
+        Data: TEST_MODE ? `(TESTNET) ${title}` : title,
       },
       Body: {
         Html: {
           Charset: 'UTF-8',
-          Data: getNFTTwoContentWithMessageAndButtonTemplate({
-            title1: titleZh,
-            content1: `<p>親愛的 ${fromName}：</p>
+          Data: isEn
+            ? getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>Dear ${fromName},</p>
+            <p>Your Plus membership gift to ${toName} has been accepted.</p>
+            <p>Thank you for sharing the joy of reading.</p>
+            <p>3ook.com Bookstore</p>`,
+            }).body
+            : getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>親愛的 ${fromName}：</p>
             <p>你送贈給 ${toName} 的 Plus 會籍已被接收。</p>
             <p>感謝你分享閱讀的樂趣</p>
             <p>3ook.com 書店</p>`,
-          }).body,
+            }).body,
         },
       },
     },


### PR DESCRIPTION
Refactor 13 email functions in ses.ts to send emails in a single language based on recipient preference instead of bilingual/hardcoded. Language resolution: user locale → Stripe checkout language → 'zh'.

- Add fetchUserInfoByEmail helper for locale/displayName lookup
- Thread language through Stripe metadata, cart processing, and claim chains
- Remove all user info fetching from ses.ts; pass displayName from callers
- Add English variants to zh-only emails, zh variants to en-only emails
- Convert bilingual emails to single-language based on resolved locale