### PR TITLE
[TAS-5358] ✨ Add isAdultOnly flag for 18+ content declaration

### DIFF
--- a/src/routes/likernft/book/store.ts
+++ b/src/routes/likernft/book/store.ts
@@ -484,6 +484,7 @@ router.post(['/:classId/new', '/class/:classId/new'], jwtAuth('write:nftbook'), 
       hideUpsell = false,
       enableCustomMessagePage = false,
       tableOfContents,
+      isAdultOnly = false,
     } = req.body;
 
     let ownerWallet = '';
@@ -535,6 +536,7 @@ router.post(['/:classId/new', '/class/:classId/new'], jwtAuth('write:nftbook'), 
       hideDownload,
       hideAudio,
       hideUpsell,
+      isAdultOnly,
 
       // From ISCN content metadata
       inLanguage,
@@ -597,6 +599,7 @@ router.post(['/:classId/new', '/class/:classId/new'], jwtAuth('write:nftbook'), 
         className,
         prices,
         isAutoApproved,
+        isAdultOnly,
         fileRecords,
         contentFingerprints,
       }),
@@ -635,6 +638,7 @@ router.post(['/:classId/new', '/class/:classId/new'], jwtAuth('write:nftbook'), 
       hideAudio,
       hideUpsell,
       enableCustomMessagePage,
+      isAdultOnly,
       totalPrices: prices.length,
       autoDeliverTotalStock,
       manualDeliverTotalStock,
@@ -667,6 +671,7 @@ router.post(['/:classId/settings', '/class/:classId/settings'], jwtAuth('write:n
       hideUpsell,
       enableCustomMessagePage,
       tableOfContents,
+      isAdultOnly,
     } = req.body;
     const bookInfo = await getNftBookInfo(classId);
     if (!bookInfo) throw new ValidationError('CLASS_ID_NOT_FOUND', 404);
@@ -685,6 +690,7 @@ router.post(['/:classId/settings', '/class/:classId/settings'], jwtAuth('write:n
       hideUpsell,
       enableCustomMessagePage,
       tableOfContents,
+      isAdultOnly,
     });
 
     publisher.publish(PUBSUB_TOPIC_MISC, req, {
@@ -696,6 +702,7 @@ router.post(['/:classId/settings', '/class/:classId/settings'], jwtAuth('write:n
       hideAudio,
       hideUpsell,
       enableCustomMessagePage,
+      isAdultOnly,
       moderatorWalletCount: moderatorWallets ? moderatorWallets.length : 0,
       connectedWalletCount: connectedWallets ? connectedWallets.length : 0,
     });

--- a/src/routes/slack/book.ts
+++ b/src/routes/slack/book.ts
@@ -25,6 +25,7 @@ async function approveBook(classId: string, action: string, slackUserId: string)
 
   const bookData = bookDoc.data();
   const className = bookData?.name || classId;
+  const { isAdultOnly } = bookData || {};
 
   let approvalUpdate: any = {};
 
@@ -34,7 +35,7 @@ async function approveBook(classId: string, action: string, slackUserId: string)
         isHidden: false,
         isApprovedForSale: true,
         isApprovedForIndexing: true,
-        isApprovedForAds: true,
+        isApprovedForAds: !isAdultOnly,
         approvalStatus: 'approved',
       };
       break;

--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -166,6 +166,7 @@ export interface NFTBookListingInfo {
   genre?: string;
   timestamp?: { toMillis: () => number };
   isHidden?: boolean;
+  isAdultOnly?: boolean;
   isLikerLandArt?: boolean;
   isApprovedForSale?: boolean;
   isApprovedForIndexing?: boolean;
@@ -212,6 +213,7 @@ export interface NFTBookListingInfoFiltered {
   genre?: string;
   timestamp?: number;
   isHidden?: boolean;
+  isAdultOnly?: boolean;
   sold?: number;
   pendingNFTCount?: number;
   moderatorWallets?: string[];

--- a/src/util/ValidationHelper.ts
+++ b/src/util/ValidationHelper.ts
@@ -605,6 +605,7 @@ export function filterNFTBookListingInfo(
     genre,
     timestamp,
     isHidden,
+    isAdultOnly,
     isApprovedForSale,
     isApprovedForIndexing,
     isApprovedForAds,
@@ -649,6 +650,7 @@ export function filterNFTBookListingInfo(
     genre,
     timestamp: timestamp?.toMillis(),
     isHidden,
+    isAdultOnly,
     // Approval flags - default to true for backward compatibility with existing books
     isApprovedForSale: isApprovedForSale !== undefined ? isApprovedForSale : true,
     isApprovedForIndexing: isApprovedForIndexing !== undefined ? isApprovedForIndexing : true,

--- a/src/util/api/likernft/book/index.ts
+++ b/src/util/api/likernft/book/index.ts
@@ -238,6 +238,7 @@ export async function newNftBookInfo(
     genre,
 
     image,
+    isAdultOnly,
   } = data;
 
   const stripeProducts = await Promise.all(prices
@@ -266,7 +267,7 @@ export async function newNftBookInfo(
     chain: isEVMClassId(classId) ? 'base' : 'like',
     isApprovedForSale: isTrustedPublisher || isFree,
     isApprovedForIndexing: true,
-    isApprovedForAds: isTrustedPublisher,
+    isApprovedForAds: (isAdultOnly ? false : isTrustedPublisher),
     approvalStatus: isTrustedPublisher ? 'approved' : 'pending',
   };
   if (image) payload.image = image;
@@ -295,6 +296,7 @@ export async function newNftBookInfo(
   if (enableSignatureImage !== undefined) payload.enableSignatureImage = enableSignatureImage;
   if (signedMessageText !== undefined) payload.signedMessageText = signedMessageText;
   if (tableOfContents) payload.tableOfContents = tableOfContents;
+  if (isAdultOnly !== undefined) payload.isAdultOnly = isAdultOnly;
   await likeNFTBookCollection.doc(classId).create(payload);
   return {
     isAutoApproved: isTrustedPublisher,
@@ -418,6 +420,7 @@ export async function updateNftBookInfo(classId: string, {
   enableSignatureImage,
   signedMessageText,
   tableOfContents,
+  isAdultOnly,
 }: {
   prices?: NFTBookPrice[];
   moderatorWallets?: string[];
@@ -430,6 +433,7 @@ export async function updateNftBookInfo(classId: string, {
   enableSignatureImage?: boolean;
   signedMessageText?: string;
   tableOfContents?: string;
+  isAdultOnly?: boolean;
 } = {}) {
   const timestamp = FieldValue.serverTimestamp();
   const payload: any = {
@@ -452,6 +456,10 @@ export async function updateNftBookInfo(classId: string, {
   if (enableSignatureImage !== undefined) { payload.enableSignatureImage = enableSignatureImage; }
   if (signedMessageText !== undefined) { payload.signedMessageText = signedMessageText; }
   if (tableOfContents !== undefined) { payload.tableOfContents = tableOfContents; }
+  if (isAdultOnly !== undefined) {
+    payload.isAdultOnly = isAdultOnly;
+    if (isAdultOnly) { payload.isApprovedForAds = false; }
+  }
   await likeNFTBookCollection.doc(classId).update(payload);
   await syncNFTBookInfoWithISCN(classId);
 }

--- a/src/util/slack.ts
+++ b/src/util/slack.ts
@@ -23,6 +23,7 @@ export async function sendNFTBookNewListingSlackNotification({
   className,
   prices,
   isAutoApproved = false,
+  isAdultOnly = false,
   fileRecords,
   contentFingerprints,
 }: {
@@ -31,6 +32,7 @@ export async function sendNFTBookNewListingSlackNotification({
   className: string;
   prices: NFTBookPrice[];
   isAutoApproved?: boolean;
+  isAdultOnly?: boolean;
   fileRecords?: {
     url: string;
     name?: string;
@@ -68,6 +70,7 @@ export async function sendNFTBookNewListingSlackNotification({
       editions,
       classId,
       approvalStatus: approvalStatusText,
+      ...(isAdultOnly ? { adultOnly: '🔞 Adult Content (18+)' } : {}),
       files: filesText,
       fingerprints: fingerprintsText,
     };


### PR DESCRIPTION
Allow publishers to declare adult content. When isAdultOnly is true, books are excluded from ads. Slack approval also respects this flag.