### PR TITLE
🔧 Increase EVM baseFeeMultiplier to 3 and make it configurable

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -38,6 +38,7 @@ config.LIKE_NFT_EVM_INDEXER_API = 'https://likenft-indexer.pandawork.com/api';
 config.LIKE_NFT_EVM_INDEXER_API_KEY = '';
 
 config.EVM_RPC_ENDPOINT_OVERRIDE = '';
+config.EVM_BASE_FEE_MULTIPLIER = 3;
 
 config.LIKER_PLUS_TRIAL_CONVERSION_RATE = 0.2;
 config.LIKER_PLUS_PRODUCT_ID = '';

--- a/src/util/evm/client.ts
+++ b/src/util/evm/client.ts
@@ -20,17 +20,19 @@ import config from '../../../config/config';
 let client: PublicClient<HttpTransport, Chain, undefined>;
 let walletClient: WalletClient<HttpTransport, Chain, LocalAccount>;
 
+const baseFeeMultiplier = config.EVM_BASE_FEE_MULTIPLIER || 3;
+
 const baseWithFee = defineChain({
   ...base,
   fees: {
-    baseFeeMultiplier: 2,
+    baseFeeMultiplier,
   },
 });
 
 const baseSepoliaWithFee = defineChain({
   ...baseSepolia,
   fees: {
-    baseFeeMultiplier: 2,
+    baseFeeMultiplier,
   },
 });
 


### PR DESCRIPTION
Move baseFeeMultiplier to config.EVM_BASE_FEE_MULTIPLIER so it can be tuned without code changes. Default raised from 2 to 3 to reduce stuck transactions during Base network congestion.