### PR TITLE
[TAS-5417] 🐛 Fix cart claim race condition by setting wallet in transaction

### DIFF
--- a/src/util/api/likernft/book/cart.ts
+++ b/src/util/api/likernft/book/cart.ts
@@ -246,6 +246,7 @@ export async function claimNFTBookCart(
 
     t.update(cartRef, {
       status: 'pending',
+      wallet,
     });
     return docData;
   });
@@ -293,6 +294,7 @@ export async function claimNFTBookCart(
   } else {
     await cartRef.update({
       status: oldStatus,
+      wallet,
       errors,
       loginMethod: loginMethod || '',
     });


### PR DESCRIPTION
Set wallet field atomically alongside status in Firestore transaction during cart claim, preventing CART_ALREADY_CLAIMED errors when server auto-claim races with frontend claim request.