### PR TITLE
🐛 Fix gift cart auto-claim using sender wallet instead of receiver

### DIFF
--- a/src/util/api/likernft/book/cart.ts
+++ b/src/util/api/likernft/book/cart.ts
@@ -696,7 +696,8 @@ export async function processNFTBookCart(
     });
 
     // Attempt to claim the cart immediately if the user is logged in
-    if (evmWallet) {
+    // Skip auto-claim for gifts — the receiver should claim via the email link
+    if (evmWallet && !cartIsGift) {
       const {
         allItemsAutoClaimed,
       } = await claimNFTBookCart(


### PR DESCRIPTION
Skip auto-claim when the cart is a gift so the receiver can claim via the email link with their own wallet.