### PR TITLE
✨ Add PostHog events for subscription cancellation, trial end, renewa…

### DIFF
--- a/src/routes/likernft/fiat/stripe.ts
+++ b/src/routes/likernft/fiat/stripe.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../../config/config';
 import { processNFTBookCartStripePurchase } from '../../../util/api/likernft/book/cart';
 import { handleNFTBookStripeSessionCustomer } from '../../../util/api/likernft/book/user';
-import { processStripeSubscriptionCancellation, processStripeSubscriptionInvoice } from '../../../util/api/plus';
+import { processStripeSubscriptionCancellation, processStripeSubscriptionInvoice, processStripePaymentFailure } from '../../../util/api/plus';
 import { processPlusGiftStripePurchase } from '../../../util/api/plus/gift';
 
 const router = Router();
@@ -67,6 +67,11 @@ router.post('/webhook', bodyParser.raw({ type: 'application/json' }), async (req
       case 'customer.subscription.deleted': {
         const subscription: Stripe.Subscription = event.data.object;
         await processStripeSubscriptionCancellation(subscription);
+        break;
+      }
+      case 'invoice.payment_failed': {
+        const invoice: Stripe.Invoice = event.data.object;
+        await processStripePaymentFailure(invoice);
         break;
       }
       default: {

--- a/src/util/analyticsEvents.ts
+++ b/src/util/analyticsEvents.ts
@@ -1,4 +1,12 @@
-export type ServerEventName = 'Purchase' | 'InitiateCheckout' | 'StartTrial' | 'Subscribe';
+export type ServerEventName =
+  | 'Purchase'
+  | 'InitiateCheckout'
+  | 'StartTrial'
+  | 'Subscribe'
+  | 'SubscriptionCancelled'
+  | 'TrialEnded'
+  | 'SubscriptionRenewed'
+  | 'PaymentFailed';
 
 export interface AnalyticsItem {
   productId: string;
@@ -11,6 +19,10 @@ export const SERVER_EVENT_MAP: Record<ServerEventName, string> = {
   InitiateCheckout: 'begin_checkout',
   StartTrial: 'start_trial',
   Subscribe: 'subscribe',
+  SubscriptionCancelled: 'subscription_cancelled',
+  TrialEnded: 'trial_ended',
+  SubscriptionRenewed: 'subscription_renewed',
+  PaymentFailed: 'payment_failed',
 };
 
 export function buildItemId(productId: string, priceIndex?: number): string {

--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -209,6 +209,22 @@ export async function processStripeSubscriptionInvoice(
       gaClientId,
       gaSessionId,
     });
+  } else if (billingReason === 'subscription_cycle' && amountPaid > 0) {
+    await logServerEvents('SubscriptionRenewed', {
+      evmWallet,
+      email: user.email || stripeCustomer.email || undefined,
+      value: amountPaid,
+      currency,
+      paymentId,
+      items: [{
+        productId: `plus-${period}ly`,
+        quantity: 1,
+      }],
+      extraProperties: {
+        subscription_id: subscriptionId,
+        period,
+      },
+    });
   }
 
   await Promise.all([
@@ -481,18 +497,64 @@ export async function processStripeSubscriptionCancellation(
       is_liker_plus_trial: false,
     });
 
+    const period = subscription.items?.data[0]?.plan?.interval;
     if (isTrialEnd) {
-      await sendIntercomEvent({
-        userId: likerId,
-        eventName: 'plus_trial_end',
-      });
+      await Promise.all([
+        sendIntercomEvent({
+          userId: likerId,
+          eventName: 'plus_trial_end',
+        }),
+        logServerEvents('TrialEnded', {
+          evmWallet,
+          paymentId: subscriptionId,
+          extraProperties: {
+            subscription_id: subscriptionId,
+            period,
+          },
+        }),
+      ]);
     } else {
-      await sendIntercomEvent({
-        userId: likerId,
-        eventName: 'plus_subscription_end',
-      });
+      await Promise.all([
+        sendIntercomEvent({
+          userId: likerId,
+          eventName: 'plus_subscription_end',
+        }),
+        logServerEvents('SubscriptionCancelled', {
+          evmWallet,
+          paymentId: subscriptionId,
+          extraProperties: {
+            subscription_id: subscriptionId,
+            period,
+            cancel_reason: subscription.cancellation_details?.reason,
+          },
+        }),
+      ]);
     }
   }
+}
+
+export async function processStripePaymentFailure(
+  invoice: Stripe.Invoice,
+) {
+  const subscriptionDetails = invoice.parent?.type === 'subscription_details'
+    ? invoice.parent.subscription_details : null;
+  const subscriptionId = subscriptionDetails?.subscription as string;
+  if (!subscriptionId) return;
+  const { evmWallet } = subscriptionDetails?.metadata || {};
+  if (!evmWallet) return;
+  const lastError = invoice.last_finalization_error;
+  await logServerEvents('PaymentFailed', {
+    evmWallet,
+    paymentId: invoice.id,
+    value: (invoice.amount_remaining ?? invoice.amount_due ?? 0) / 100,
+    currency: invoice.currency?.toUpperCase(),
+    extraProperties: {
+      subscription_id: subscriptionId,
+      attempt_count: invoice.attempt_count,
+      failure_code: lastError?.code,
+      failure_type: lastError?.type,
+    },
+  });
 }
 
 export async function updateSubscriptionPeriod(

--- a/src/util/logServerEvents.ts
+++ b/src/util/logServerEvents.ts
@@ -12,20 +12,24 @@ export default async function logServerEvents(
     items?: AnalyticsItem[];
     userAgent?: string;
     clientIp?: string;
-    value: number;
+    value?: number;
     predictedLTV?: number;
-    currency: string;
+    currency?: string;
     paymentId?: string;
     referrer?: string;
     fbClickId?: string;
     evmWallet?: string;
     gaClientId?: string;
     gaSessionId?: string;
+    extraProperties?: Record<string, unknown>;
   },
 ): Promise<void> {
   logPostHogEvents(event, options);
+  if (options.value == null || options.currency == null) {
+    return;
+  }
   await Promise.allSettled([
-    logPixelEvents(event, options),
-    logGA4Events(event, options),
+    logPixelEvents(event, options as typeof options & { value: number; currency: string }),
+    logGA4Events(event, options as typeof options & { value: number; currency: string }),
   ]);
 }

--- a/src/util/posthog.ts
+++ b/src/util/posthog.ts
@@ -38,14 +38,16 @@ export default function logPostHogEvents(event: ServerEventName, {
   predictedLTV,
   currency,
   paymentId,
+  extraProperties,
 }: {
   evmWallet?: string;
   email?: string;
   items?: AnalyticsItem[];
-  value: number;
+  value?: number;
   predictedLTV?: number;
-  currency: string;
+  currency?: string;
   paymentId?: string;
+  extraProperties?: Record<string, unknown>;
 }) {
   const client = getPostHogClient();
   if (!client) {
@@ -65,6 +67,7 @@ export default function logPostHogEvents(event: ServerEventName, {
       distinctId: evmWallet,
       event: posthogEvent,
       properties: {
+        ...extraProperties,
         $set: email ? { email } : undefined,
         $insert_id: paymentId ? `${posthogEvent}_${paymentId}` : undefined,
         value,


### PR DESCRIPTION
…l, and payment failure

Track subscription lifecycle events (SubscriptionCancelled, TrialEnded, SubscriptionRenewed, PaymentFailed) to PostHog for churn and retention analytics. Adds invoice.payment_failed Stripe webhook handler.