### PR TITLE
✨ Add subscription status tracking and payment retry endpoint

### DIFF
--- a/src/routes/likernft/fiat/stripe.ts
+++ b/src/routes/likernft/fiat/stripe.ts
@@ -8,7 +8,12 @@ import {
 } from '../../../../config/config';
 import { processNFTBookCartStripePurchase } from '../../../util/api/likernft/book/cart';
 import { handleNFTBookStripeSessionCustomer } from '../../../util/api/likernft/book/user';
-import { processStripeSubscriptionCancellation, processStripeSubscriptionInvoice, processStripePaymentFailure } from '../../../util/api/plus';
+import {
+  processStripeSubscriptionCancellation,
+  processStripeSubscriptionInvoice,
+  processStripePaymentFailure,
+  processStripeSubscriptionStatusUpdate,
+} from '../../../util/api/plus';
 import { processPlusGiftStripePurchase } from '../../../util/api/plus/gift';
 
 const router = Router();
@@ -72,6 +77,11 @@ router.post('/webhook', bodyParser.raw({ type: 'application/json' }), async (req
       case 'invoice.payment_failed': {
         const invoice: Stripe.Invoice = event.data.object;
         await processStripePaymentFailure(invoice);
+        break;
+      }
+      case 'customer.subscription.updated': {
+        const subscription: Stripe.Subscription = event.data.object;
+        await processStripeSubscriptionStatusUpdate(subscription);
         break;
       }
       default: {

--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -419,4 +419,34 @@ router.post('/portal', jwtAuth('write:plus'), async (req, res, next) => {
   }
 });
 
+router.post('/retry', jwtAuth('write:plus'), async (req, res, next) => {
+  try {
+    const { wallet } = req.user;
+    const userInfo = await getUserWithCivicLikerPropertiesByWallet(wallet);
+    if (!userInfo?.likerPlus) {
+      throw new ValidationError('No Liker Plus subscription found for this user.', 404);
+    }
+    const { subscriptionId, subscriptionStatus } = userInfo.likerPlus;
+    if (!subscriptionId) {
+      throw new ValidationError('No subscription found for this user.', 404);
+    }
+    if (subscriptionStatus && subscriptionStatus !== 'past_due') {
+      throw new ValidationError('Subscription is not in past_due status.', 400);
+    }
+    const stripe = getStripeClient();
+    const invoices = await stripe.invoices.list({
+      subscription: subscriptionId,
+      status: 'open',
+      limit: 1,
+    });
+    if (!invoices.data.length) {
+      throw new ValidationError('No open invoice found for this subscription.', 404);
+    }
+    await stripe.invoices.pay(invoices.data[0].id);
+    res.sendStatus(200);
+  } catch (error) {
+    next(error);
+  }
+});
+
 export default router;

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -8,6 +8,8 @@ export interface CivicLikerData {
   civicLikerVersion?: number;
 }
 
+export type LikerPlusSubscriptionStatus = 'active' | 'past_due' | 'canceled';
+
 export interface LikerPlusData {
   currentPeriodStart: number;
   currentPeriodEnd: number;
@@ -16,6 +18,7 @@ export interface LikerPlusData {
   period?: string;
   subscriptionId?: string;
   customerId?: string;
+  subscriptionStatus?: LikerPlusSubscriptionStatus;
 }
 
 export interface UserData {
@@ -90,4 +93,5 @@ export interface UserCivicLikerProperties extends UserData {
   isLikerPlusTrial?: boolean;
   isExpiredLikerPlus?: boolean;
   likerPlusPeriod?: string;
+  likerPlusSubscriptionStatus?: LikerPlusSubscriptionStatus;
 }

--- a/src/types/validation.d.ts
+++ b/src/types/validation.d.ts
@@ -1,4 +1,4 @@
-import type { UserCivicLikerProperties } from './user';
+import type { UserCivicLikerProperties, LikerPlusSubscriptionStatus } from './user';
 import type { SupportedLocale } from '../locales';
 import type { AppMeta } from './firestore';
 
@@ -23,6 +23,7 @@ export interface UserDataMin extends Pick<UserCivicLikerProperties,
 
 export interface UserDataScopedFiltered extends UserDataMin {
   likerPlusPeriod?: any;
+  likerPlusSubscriptionStatus?: LikerPlusSubscriptionStatus;
   email?: string;
   isExpiredCivicLiker?: boolean;
   isCivicLikerRenewalPeriod?: boolean;

--- a/src/util/ValidationHelper.ts
+++ b/src/util/ValidationHelper.ts
@@ -87,6 +87,7 @@ export function filterUserData(u: UserCivicLikerProperties): UserDataFiltered {
     isLikerPlusTrial,
     isExpiredLikerPlus,
     likerPlusPeriod,
+    likerPlusSubscriptionStatus,
     locale,
   } = u;
   return {
@@ -118,6 +119,7 @@ export function filterUserData(u: UserCivicLikerProperties): UserDataFiltered {
     isLikerPlusTrial,
     isExpiredLikerPlus,
     likerPlusPeriod,
+    likerPlusSubscriptionStatus,
     locale,
   };
 }
@@ -177,6 +179,7 @@ export function filterUserDataScoped(
   let output: UserDataScopedFiltered = filterUserDataMin(u);
   if (scope.includes('read:plus')) {
     output.likerPlusPeriod = user.likerPlusPeriod;
+    output.likerPlusSubscriptionStatus = user.likerPlusSubscriptionStatus;
   }
   if (scope.includes('email')) output.email = user.email;
   if (scope.includes('read:civic_liker')) {

--- a/src/util/api/likernft/book/cart.ts
+++ b/src/util/api/likernft/book/cart.ts
@@ -1146,7 +1146,7 @@ export async function formatCartItemsWithInfo(items: CartItem[]) {
       stripePriceId,
       chain,
       isAutoDeliver,
-      isUnlisted
+      isUnlisted,
     } = info;
 
     name = name.length > 80 ? `${name.substring(0, 79)}…` : name;

--- a/src/util/api/likernft/book/index.ts
+++ b/src/util/api/likernft/book/index.ts
@@ -376,7 +376,9 @@ export async function syncNFTBookInfoWithISCN(classId) {
   }
 
   try {
-    const { ownerWallet, hideDownload, isHidden, isAdultOnly } = bookInfo;
+    const {
+      ownerWallet, hideDownload, isHidden, isAdultOnly,
+    } = bookInfo;
     const minPrice = prices.reduce((min, p) => Math.min(min, p.priceInDecimal), Infinity) / 100;
     const maxPrice = prices.reduce((max, p) => Math.max(max, p.priceInDecimal), 0) / 100;
     await updateAirtablePublicationRecord({

--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -1,4 +1,5 @@
 import type Stripe from 'stripe';
+import type { LikerPlusSubscriptionStatus } from '../../../types/user';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
@@ -164,6 +165,7 @@ export async function processStripeSubscriptionInvoice(
       currentType: isTrial ? 'trial' : 'paid',
       subscriptionId,
       customerId,
+      subscriptionStatus: 'active',
     },
   });
 
@@ -488,6 +490,7 @@ export async function processStripeSubscriptionCancellation(
         likerPlus: {
           ...user.likerPlus,
           currentPeriodEnd: Date.now(),
+          subscriptionStatus: 'canceled',
         },
       });
     }
@@ -543,10 +546,11 @@ export async function processStripePaymentFailure(
   const { evmWallet } = subscriptionDetails?.metadata || {};
   if (!evmWallet) return;
   const lastError = invoice.last_finalization_error;
-  await logServerEvents('PaymentFailed', {
+  const value = (invoice.amount_remaining ?? invoice.amount_due ?? 0) / 100;
+  const logPromise = logServerEvents('PaymentFailed', {
     evmWallet,
     paymentId: invoice.id,
-    value: (invoice.amount_remaining ?? invoice.amount_due ?? 0) / 100,
+    value,
     currency: invoice.currency?.toUpperCase(),
     extraProperties: {
       subscription_id: subscriptionId,
@@ -554,6 +558,56 @@ export async function processStripePaymentFailure(
       failure_code: lastError?.code,
       failure_type: lastError?.type,
     },
+  }).catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error('Failed to log PaymentFailed event:', err);
+  });
+  await getUserWithCivicLikerPropertiesByWallet(evmWallet).then((user) => {
+    if (user) {
+      return userCollection.doc(user.user).update({
+        'likerPlus.subscriptionStatus': 'past_due',
+      });
+    }
+    return undefined;
+  });
+  await logPromise;
+}
+
+const STRIPE_TO_SUBSCRIPTION_STATUS: Partial<Record<
+  Stripe.Subscription.Status, LikerPlusSubscriptionStatus
+>> = {
+  active: 'active',
+  trialing: 'active',
+  past_due: 'past_due',
+  canceled: 'canceled',
+  unpaid: 'canceled',
+  incomplete_expired: 'canceled',
+};
+
+export async function processStripeSubscriptionStatusUpdate(
+  subscription: Stripe.Subscription,
+) {
+  const { status } = subscription;
+  const { evmWallet, likeWallet } = subscription.metadata || {};
+  if (!evmWallet && !likeWallet) {
+    // eslint-disable-next-line no-console
+    console.warn(`Subscription ${subscription.id} has no wallet in metadata`);
+    return;
+  }
+  const subscriptionStatus = STRIPE_TO_SUBSCRIPTION_STATUS[status];
+  if (!subscriptionStatus) {
+    // eslint-disable-next-line no-console
+    console.warn(`Unhandled Stripe subscription status ${status} for subscription ${subscription.id}`, {
+      evmWallet,
+      likeWallet,
+    });
+    return;
+  }
+  const user = await getUserWithCivicLikerPropertiesByWallet(evmWallet || likeWallet);
+  if (!user) return;
+  if (user.likerPlus?.subscriptionStatus === subscriptionStatus) return;
+  await userCollection.doc(user.user).update({
+    'likerPlus.subscriptionStatus': subscriptionStatus,
   });
 }
 

--- a/src/util/api/users/getPublicInfo.ts
+++ b/src/util/api/users/getPublicInfo.ts
@@ -89,8 +89,10 @@ export function formatUserCivicLikerProperies(
       payload.isLikerPlusTrial = currentType === 'trial';
       payload.isSubscribedCivicLiker = true;
       payload.likerPlusPeriod = period;
+      payload.likerPlusSubscriptionStatus = likerPlus.subscriptionStatus || 'active';
     } else if (now > renewalLast) {
       payload.isExpiredLikerPlus = true;
+      payload.likerPlusSubscriptionStatus = likerPlus.subscriptionStatus || 'canceled';
     }
   }
 


### PR DESCRIPTION
- Track subscriptionStatus (active/past_due/canceled) in likerPlus data
- Handle customer.subscription.updated webhook for status sync
- Add POST /plus/retry to retry failed subscription payments
- Expose likerPlusSubscriptionStatus in user public info and scoped APIs
- Extract LikerPlusSubscriptionStatus type alias to reduce duplication
- Parallelize analytics and DB update in payment failure handler