### PR TITLE
🐛 Normalize NFT classId to lowercase across all entry points

### DIFF
--- a/src/middleware/likernft.ts
+++ b/src/middleware/likernft.ts
@@ -10,6 +10,16 @@ import {
 
 import { WNFT_BATCH_PURCHASE_LIMIT } from '../../config/config';
 
+export const normalizeClassIdParam = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+  classId: string,
+): void => {
+  req.params.classId = classId.toLowerCase();
+  next();
+};
+
 export const fetchISCNPrefixAndClassId = async (
   req: Request,
   res: Response,
@@ -18,6 +28,7 @@ export const fetchISCNPrefixAndClassId = async (
   try {
     const { iscn_id: iscnId } = req.query;
     let { class_id: classId } = req.query;
+    if (typeof classId === 'string') classId = classId.toLowerCase();
     if (!iscnId && !classId) throw new ValidationError('MISSING_ISCN_OR_CLASS_ID');
     let iscnPrefix;
     if (!iscnId) {
@@ -27,6 +38,7 @@ export const fetchISCNPrefixAndClassId = async (
     }
     if (!classId) {
       classId = await getCurrentClassIdByISCNId(iscnPrefix);
+      if (typeof classId === 'string') classId = classId.toLowerCase();
     }
     res.locals.iscnPrefix = iscnPrefix;
     res.locals.classId = classId;
@@ -45,7 +57,8 @@ export const fetchISCNPrefixes = async (
   try {
     const { class_id: classId } = req.query;
     if (!classId) throw new ValidationError('MISSING_ISCN_OR_CLASS_ID');
-    const classIds = Array.isArray(classId) ? classId : [classId];
+    const classIds = (Array.isArray(classId) ? classId : [classId])
+      .map((id) => (id as string).toLowerCase());
     if (classIds.length !== new Set(classIds).size) throw new ValidationError('CANNOT_PURCHASE_SAME_CLASS', 422);
     if (classIds.length > WNFT_BATCH_PURCHASE_LIMIT) throw new ValidationError(`CLASS_NUMBER_EXCESS_${WNFT_BATCH_PURCHASE_LIMIT}`, 422);
     const iscnPrefixes = await Promise.all(classIds.map((id) => getISCNPrefixByClassId(id)));
@@ -63,7 +76,8 @@ export const fetchISCNPrefixFromChain = async (
   next: NextFunction,
 ): Promise<void> => {
   try {
-    const { class_id: classId } = req.query;
+    let { class_id: classId } = req.query;
+    if (typeof classId === 'string') classId = classId.toLowerCase();
     if (!classId) throw new ValidationError('MISSING_CLASS_ID');
     const iscnPrefix = await getISCNPrefixByClassIdFromChain(classId);
     res.locals.iscnPrefix = iscnPrefix;

--- a/src/routes/likerland/nft/metadata.ts
+++ b/src/routes/likerland/nft/metadata.ts
@@ -152,7 +152,8 @@ async function getNFTClassBookstoreInfo(classId) {
 
 router.get('/metadata', async (req, res, next) => {
   try {
-    const { class_id: classId, data: inputSelected } = req.query;
+    const { class_id: rawClassId, data: inputSelected } = req.query;
+    const classId = typeof rawClassId === 'string' ? rawClassId.toLowerCase() : rawClassId;
     if (!classId) {
       res.status(400).send('MISSING_CLASS_ID');
       return;

--- a/src/routes/likernft/book/purchase.ts
+++ b/src/routes/likernft/book/purchase.ts
@@ -41,8 +41,11 @@ import { isValidEVMAddress } from '../../../util/evm';
 import { isValidLikeAddress } from '../../../util/cosmos';
 import { claimFreeBooks, getFreeBooksForUser } from '../../../util/api/likernft/book/free';
 import { fetchUserInfoByEmail } from '../../../util/api/users';
+import { normalizeClassIdParam } from '../../../middleware/likernft';
 
 const router = Router();
+
+router.param('classId', normalizeClassIdParam);
 
 router.get(
   '/cart/:cartId/status',

--- a/src/routes/likernft/book/store.ts
+++ b/src/routes/likernft/book/store.ts
@@ -36,8 +36,12 @@ import { filterNFTBookListingInfo, filterNFTBookPricesInfo } from '../../../util
 import type { NFTBookListingInfo, NFTBookPrice } from '../../../types/book';
 import { uploadImageBufferToCache } from '../../../util/fileupload';
 import { convertUSDPriceToCurrency } from '../../../util/pricing';
+import { normalizeClassIdParam } from '../../../middleware/likernft';
 
 const router = Router();
+
+router.param('classId', normalizeClassIdParam);
+
 const pngUpload = multer({
   limits: {
     fileSize: MAX_PNG_FILE_SIZE,

--- a/src/routes/likernft/metadata.ts
+++ b/src/routes/likernft/metadata.ts
@@ -14,12 +14,14 @@ import {
   parseImageURLFromMetadata,
 } from '../../util/api/likernft/metadata';
 import { getNFTClassDataById, getNFTISCNData } from '../../util/cosmos/nft';
-import { fetchISCNPrefixAndClassId } from '../../middleware/likernft';
+import { fetchISCNPrefixAndClassId, normalizeClassIdParam } from '../../middleware/likernft';
 import { ValidationError } from '../../util/ValidationError';
 import { sleep } from '../../util/misc';
 import { BOOK_MODEL_GLTF, CLASS_ID_PLACEHOLDER, IMAGE_URI_PLACEHOLDER } from '../../constant/model';
 
 const router = Router();
+
+router.param('classId', normalizeClassIdParam);
 
 router.get(
   '/metadata',


### PR DESCRIPTION
Ensures case-insensitive classId matching by lowercasing values from both query params (middleware) and route params (shared router.param helper) to prevent duplicate or missed lookups.