### PR TITLE
✨ Add isApp flag to disable promotion codes in app checkout sessions

### DIFF
--- a/src/routes/likernft/book/purchase.ts
+++ b/src/routes/likernft/book/purchase.ts
@@ -144,6 +144,7 @@ router.post('/cart/new', jwtOptionalAuth('read:nftbook'), async (req, res, next)
       giftInfo,
       cancelPage,
       language,
+      isApp,
     } = req.body;
 
     if (!items?.length) {
@@ -206,6 +207,7 @@ router.post('/cart/new', jwtOptionalAuth('read:nftbook'), async (req, res, next)
         from: from as string,
       }),
       language,
+      isApp,
     });
     res.json({ paymentId, url });
 
@@ -275,6 +277,7 @@ router.get(['/:classId/new', '/class/:classId/new'], jwtOptionalAuth('read:nftbo
       currency,
       fbclid: fbClickId = '',
       payment_method: paymentMethodQs,
+      is_app: isApp,
     } = req.query;
     const priceIndex = Number(priceIndexString) || 0;
     const quantity = parseInt(inputQuantity as string, 10) || 1;
@@ -346,6 +349,7 @@ router.get(['/:classId/new', '/class/:classId/new'], jwtOptionalAuth('read:nftbo
         gadSource: gadSource as string,
         from: from as string,
       }),
+      isApp: isApp === '1' || isApp === 'true',
     });
     res.redirect(url);
 
@@ -423,6 +427,7 @@ router.post(['/:classId/new', '/class/:classId/new'], jwtOptionalAuth('read:nftb
       referrer: inputReferrer,
       customPriceInDecimal,
       language,
+      isApp,
     } = req.body;
     let {
       quantity = 1,
@@ -492,6 +497,7 @@ router.post(['/:classId/new', '/class/:classId/new'], jwtOptionalAuth('read:nftb
         from: from as string,
       }),
       language,
+      isApp,
     });
     res.json({ paymentId, url });
 

--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -38,6 +38,7 @@ router.post('/new', jwtAuth('write:plus'), async (req, res, next) => {
     mustCollectPaymentMethod,
     giftClassId,
     giftPriceIndex = '0',
+    isApp,
   } = req.body;
   try {
     // Ensure period is either 'monthly' or 'yearly'
@@ -73,6 +74,7 @@ router.post('/new', jwtAuth('write:plus'), async (req, res, next) => {
         giftPriceIndex,
         coupon,
         currency: checkoutCurrency,
+        isApp,
       },
       {
         from: from as string,
@@ -167,6 +169,7 @@ router.post('/gift/new', jwtAuth('write:plus'), async (req, res, next) => {
     utmTerm,
     coupon,
     giftInfo,
+    isApp,
   } = req.body;
   try {
     if (period !== 'monthly' && period !== 'yearly') {
@@ -195,6 +198,7 @@ router.post('/gift/new', jwtAuth('write:plus'), async (req, res, next) => {
         giftInfo,
         coupon,
         currency: checkoutCurrency,
+        isApp,
       },
       {
         from: from as string,

--- a/src/util/api/likernft/book/cart.ts
+++ b/src/util/api/likernft/book/cart.ts
@@ -1334,6 +1334,7 @@ export async function handleNewCartStripeCheckout(inputItems: CartItem[], {
   httpMethod = 'POST',
   cancelUrl,
   language,
+  isApp,
 }: {
   gaClientId?: string,
   gaSessionId?: string,
@@ -1366,6 +1367,7 @@ export async function handleNewCartStripeCheckout(inputItems: CartItem[], {
   httpMethod?: 'GET' | 'POST',
   cancelUrl?: string,
   language?: string,
+  isApp?: boolean,
 } = {}) {
   let from: string = inputFrom as string || '';
   if (!from) {
@@ -1478,6 +1480,7 @@ export async function handleNewCartStripeCheckout(inputItems: CartItem[], {
     clientIp,
     httpMethod,
     language,
+    isApp,
   }, itemInfos, {
     successUrl,
     cancelUrl: cancelUrl || getBook3CartURL({

--- a/src/util/api/likernft/book/purchase.ts
+++ b/src/util/api/likernft/book/purchase.ts
@@ -520,6 +520,7 @@ export async function formatStripeCheckoutSession({
   userAgent,
   clientIp,
   language,
+  isApp,
 }: {
   classId?: string,
   iscnPrefix?: string,
@@ -558,6 +559,7 @@ export async function formatStripeCheckoutSession({
   userAgent?: string,
   clientIp?: string,
   language?: string,
+  isApp?: boolean,
 }, items: CartItemWithInfo[], {
   successUrl,
   cancelUrl,
@@ -750,7 +752,7 @@ export async function formatStripeCheckoutSession({
   }
   if (discounts.length) {
     checkoutPayload.discounts = discounts;
-  } else {
+  } else if (!isApp) {
     checkoutPayload.allow_promotion_codes = true;
   }
   if (likeWallet || evmWallet) {

--- a/src/util/api/plus/gift.ts
+++ b/src/util/api/plus/gift.ts
@@ -30,12 +30,14 @@ export async function createPlusGiftCheckoutSession(
     coupon,
     language,
     currency,
+    isApp,
   }: {
     period: 'monthly' | 'yearly',
     giftInfo: BookGiftInfo,
     coupon?: string,
     language?: 'en' | 'zh',
     currency?: SupportedPlusCurrency,
+    isApp?: boolean,
   },
   {
     from,
@@ -179,7 +181,7 @@ export async function createPlusGiftCheckoutSession(
   };
   if (discounts.length) {
     payload.discounts = discounts;
-  } else {
+  } else if (!isApp) {
     payload.allow_promotion_codes = true;
   }
   if (customerId) {

--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -341,6 +341,7 @@ export async function createNewPlusCheckoutSession(
     giftPriceIndex,
     coupon,
     currency,
+    isApp,
   }: {
     period: 'monthly' | 'yearly',
     trialPeriodDays?: number,
@@ -349,6 +350,7 @@ export async function createNewPlusCheckoutSession(
     giftPriceIndex?: string,
     coupon?: string,
     currency?: SupportedPlusCurrency,
+    isApp?: boolean,
   },
   {
     from,
@@ -511,7 +513,7 @@ export async function createNewPlusCheckoutSession(
   };
   if (discounts.length) {
     payload.discounts = discounts;
-  } else {
+  } else if (!isApp) {
     payload.allow_promotion_codes = true;
   }
   if (customerId) {


### PR DESCRIPTION
Thread isApp parameter through NFT book purchase, cart, Plus subscription, and Plus gift checkout flows. When isApp is true, Stripe checkout sessions omit allow_promotion_codes to comply with app store policies.