### PR TITLE
[TAS-5558] ✨ Add affiliate gift config for Plus checkout and subscription

### DIFF
--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { jwtAuth, jwtOptionalAuth } from '../../middleware/jwt';
 import { ValidationError } from '../../util/ValidationError';
-import { getBookUserInfoFromWallet } from '../../util/api/likernft/book/user';
+import { getBookUserInfoFromWallet, getBookUserInfoFromLikerId } from '../../util/api/likernft/book/user';
 import { getStripeClient } from '../../util/stripe';
 import {
   BOOK3_HOSTNAME, PLUS_MONTHLY_PRICE, PLUS_YEARLY_PRICE, PUBSUB_TOPIC_MISC,
@@ -374,12 +374,40 @@ router.get('/gift', jwtAuth('read:plus'), async (req, res, next) => {
       giftCartId,
       giftPaymentId,
       giftClaimToken,
+      affiliateVoiceId,
+      affiliateVoiceName,
+      affiliateVoiceLanguage,
+      affiliateFrom,
     } = metadata;
     res.json({
       giftClassId,
       giftCartId,
       giftPaymentId,
       giftClaimToken,
+      affiliateVoiceId,
+      affiliateVoiceName,
+      affiliateVoiceLanguage,
+      affiliateFrom,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/affiliate/:likerId', async (req, res, next) => {
+  try {
+    const { likerId } = req.params;
+    const normalizedLikerId = likerId.startsWith('@') ? likerId.substring(1) : likerId;
+    const userInfo = await getBookUserInfoFromLikerId(normalizedLikerId);
+    const affiliateConfig = userInfo?.bookUserInfo?.affiliateConfig;
+    if (!affiliateConfig?.active) {
+      res.json({ active: false });
+      return;
+    }
+    res.json({
+      active: true,
+      giftClassId: affiliateConfig.giftClassId,
+      customVoiceName: affiliateConfig.customVoiceName,
     });
   } catch (error) {
     next(error);

--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -14,7 +14,7 @@ import { claimPlusGiftCart, createPlusGiftCheckoutSession, getPlusGiftCartData }
 import publisher from '../../util/gcloudPub';
 import { getUserWithCivicLikerPropertiesByWallet } from '../../util/api/users';
 import logServerEvents from '../../util/logServerEvents';
-import { checkUserNameValid, filterPlusGiftCartData } from '../../util/ValidationHelper';
+import { checkUserNameValid, filterPlusGiftCartData, normalizeLikerId } from '../../util/ValidationHelper';
 
 const router = Router();
 
@@ -391,7 +391,7 @@ router.get('/gift', jwtAuth('read:plus'), async (req, res, next) => {
 router.get('/affiliate/:likerId', async (req, res, next) => {
   try {
     const { likerId } = req.params;
-    const normalizedLikerId = likerId.startsWith('@') ? likerId.substring(1) : likerId;
+    const normalizedLikerId = normalizeLikerId(likerId);
     if (!checkUserNameValid(normalizedLikerId)) {
       throw new ValidationError('Invalid likerId', 400);
     }

--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -374,9 +374,6 @@ router.get('/gift', jwtAuth('read:plus'), async (req, res, next) => {
       giftCartId,
       giftPaymentId,
       giftClaimToken,
-      affiliateVoiceId,
-      affiliateVoiceName,
-      affiliateVoiceLanguage,
       affiliateFrom,
     } = metadata;
     res.json({
@@ -384,9 +381,6 @@ router.get('/gift', jwtAuth('read:plus'), async (req, res, next) => {
       giftCartId,
       giftPaymentId,
       giftClaimToken,
-      affiliateVoiceId,
-      affiliateVoiceName,
-      affiliateVoiceLanguage,
       affiliateFrom,
     });
   } catch (error) {
@@ -406,8 +400,15 @@ router.get('/affiliate/:likerId', async (req, res, next) => {
     }
     res.json({
       active: true,
+      affiliateClassIds: affiliateConfig.affiliateClassIds || [],
       giftClassId: affiliateConfig.giftClassId,
-      customVoiceName: affiliateConfig.customVoiceName,
+      customVoices: (affiliateConfig.customVoices || []).map((v) => ({
+        id: v.id,
+        name: v.name,
+        language: v.language,
+        avatarUrl: v.avatarUrl,
+        providerVoiceId: v.providerVoiceId,
+      })),
     });
   } catch (error) {
     next(error);

--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -14,7 +14,7 @@ import { claimPlusGiftCart, createPlusGiftCheckoutSession, getPlusGiftCartData }
 import publisher from '../../util/gcloudPub';
 import { getUserWithCivicLikerPropertiesByWallet } from '../../util/api/users';
 import logServerEvents from '../../util/logServerEvents';
-import { filterPlusGiftCartData } from '../../util/ValidationHelper';
+import { checkUserNameValid, filterPlusGiftCartData } from '../../util/ValidationHelper';
 
 const router = Router();
 
@@ -392,6 +392,9 @@ router.get('/affiliate/:likerId', async (req, res, next) => {
   try {
     const { likerId } = req.params;
     const normalizedLikerId = likerId.startsWith('@') ? likerId.substring(1) : likerId;
+    if (!checkUserNameValid(normalizedLikerId)) {
+      throw new ValidationError('Invalid likerId', 400);
+    }
     const userInfo = await getBookUserInfoFromLikerId(normalizedLikerId);
     const affiliateConfig = userInfo?.bookUserInfo?.affiliateConfig;
     if (!affiliateConfig?.active) {
@@ -402,6 +405,8 @@ router.get('/affiliate/:likerId', async (req, res, next) => {
       active: true,
       affiliateClassIds: affiliateConfig.affiliateClassIds || [],
       giftClassId: affiliateConfig.giftClassId,
+      giftPriceIndex: affiliateConfig.giftPriceIndex || 0,
+      giftOnTrial: !!affiliateConfig.giftOnTrial,
       customVoices: (affiliateConfig.customVoices || []).map((v) => ({
         id: v.id,
         name: v.name,

--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -228,6 +228,16 @@ export interface NFTBookListingInfoFiltered {
   plusPromoEnabled?: boolean;
 }
 
+export interface AffiliateConfig {
+  giftClassId: string;
+  giftPriceIndex: number;
+  customVoiceId?: string;
+  customVoiceName?: string;
+  customVoiceLanguage?: string;
+  giftOnTrial: boolean;
+  active: boolean;
+}
+
 export interface NFTBookUserData {
   userId?: string;
   classId?: string;
@@ -244,6 +254,7 @@ export interface NFTBookUserData {
   sponsoredUploadCount?: number;
   sponsoredUploadETH?: string;
   lastSponsoredUploadDate?: string;
+  affiliateConfig?: AffiliateConfig;
   [key: string]: any;
 }
 

--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -228,14 +228,25 @@ export interface NFTBookListingInfoFiltered {
   plusPromoEnabled?: boolean;
 }
 
+export interface AffiliateCustomVoice {
+  id: string;
+  name: string;
+  language?: string;
+  avatarUrl?: string;
+  providerVoiceId: string;
+}
+
 export interface AffiliateConfig {
-  giftClassId: string;
-  giftPriceIndex: number;
-  customVoiceId?: string;
-  customVoiceName?: string;
-  customVoiceLanguage?: string;
-  giftOnTrial: boolean;
   active: boolean;
+  /** Book classes where this affiliate's custom voices can be used.
+   *  Must include `giftClassId` when set. */
+  affiliateClassIds: string[];
+  /** The class currently being gifted at checkout; must be a member of
+   *  `affiliateClassIds`. */
+  giftClassId?: string;
+  giftPriceIndex: number;
+  giftOnTrial: boolean;
+  customVoices: AffiliateCustomVoice[];
 }
 
 export interface NFTBookUserData {

--- a/src/types/firestore.d.ts
+++ b/src/types/firestore.d.ts
@@ -2,6 +2,7 @@
 // These represent the raw data structures stored in Firestore collections
 
 import type { UserCivicLikerProperties } from './user';
+import type { NFTBookUserData } from './book';
 
 export interface UserAuthData {
   platforms: Record<string, any>;
@@ -149,16 +150,8 @@ export interface FollowData {
   ts: number;
 }
 
-export interface BookUserInfo {
-  stripeConnectAccountId?: string;
-  isStripeConnectReady?: boolean;
-  stripeCustomerId?: string;
-  isTrustedPublisher?: boolean;
-  [key: string]: unknown;
-}
-
 export interface BookUserInfoResult {
   wallet: string;
-  bookUserInfo: BookUserInfo | null;
+  bookUserInfo: NFTBookUserData | null;
   likerUserInfo: UserCivicLikerProperties | null;
 }

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -94,4 +94,5 @@ export interface UserCivicLikerProperties extends UserData {
   isExpiredLikerPlus?: boolean;
   likerPlusPeriod?: string;
   likerPlusSubscriptionStatus?: LikerPlusSubscriptionStatus;
+  plusAffiliateFrom?: string;
 }

--- a/src/types/validation.d.ts
+++ b/src/types/validation.d.ts
@@ -24,6 +24,7 @@ export interface UserDataMin extends Pick<UserCivicLikerProperties,
 export interface UserDataScopedFiltered extends UserDataMin {
   likerPlusPeriod?: any;
   likerPlusSubscriptionStatus?: LikerPlusSubscriptionStatus;
+  plusAffiliateFrom?: string;
   email?: string;
   isExpiredCivicLiker?: boolean;
   isCivicLikerRenewalPeriod?: boolean;

--- a/src/util/ValidationHelper.ts
+++ b/src/util/ValidationHelper.ts
@@ -88,6 +88,7 @@ export function filterUserData(u: UserCivicLikerProperties): UserDataFiltered {
     isExpiredLikerPlus,
     likerPlusPeriod,
     likerPlusSubscriptionStatus,
+    plusAffiliateFrom,
     locale,
   } = u;
   return {
@@ -120,6 +121,7 @@ export function filterUserData(u: UserCivicLikerProperties): UserDataFiltered {
     isExpiredLikerPlus,
     likerPlusPeriod,
     likerPlusSubscriptionStatus,
+    plusAffiliateFrom,
     locale,
   };
 }
@@ -180,6 +182,7 @@ export function filterUserDataScoped(
   if (scope.includes('read:plus')) {
     output.likerPlusPeriod = user.likerPlusPeriod;
     output.likerPlusSubscriptionStatus = user.likerPlusSubscriptionStatus;
+    output.plusAffiliateFrom = user.plusAffiliateFrom;
   }
   if (scope.includes('email')) output.email = user.email;
   if (scope.includes('read:civic_liker')) {

--- a/src/util/ValidationHelper.ts
+++ b/src/util/ValidationHelper.ts
@@ -46,6 +46,10 @@ export function checkUserNameValid(user: string): boolean {
   return !!user && (/^[a-z0-9-_]+$/.test(user) && user.length >= MIN_USER_ID_LENGTH && user.length <= MAX_USER_ID_LENGTH);
 }
 
+export function normalizeLikerId(likerId: string): string {
+  return likerId.startsWith('@') ? likerId.substring(1) : likerId;
+}
+
 export function checkCosmosAddressValid(addr: string, prefix = 'cosmos'): boolean {
   if (!addr.startsWith(prefix) && addr.length === 45) {
     return false;

--- a/src/util/api/likernft/book/cart.ts
+++ b/src/util/api/likernft/book/cart.ts
@@ -341,6 +341,7 @@ type ProcessNFTBookCartMeta = {
   giftFromName?: string;
   evmWallet?: string;
   language?: string;
+  isPlusGiftCart?: boolean;
 };
 
 type ProcessNFTBookCartPayment = {
@@ -380,6 +381,7 @@ export async function processNFTBookCart(
     giftFromName,
     evmWallet,
     language,
+    isPlusGiftCart,
   }: ProcessNFTBookCartMeta,
   {
     amountTotal,
@@ -690,7 +692,9 @@ export async function processNFTBookCart(
 
       // Send Plus promo code email for self-purchases of promo-eligible books.
       // Skip silently if we can't verify the buyer isn't already a Plus subscriber.
-      if (email && LIKER_PLUS_BOOK_PROMO_COUPON_CODE) {
+      // Also skip when the cart is a gift book issued from a Plus subscription,
+      // since the buyer is already Plus.
+      if (email && LIKER_PLUS_BOOK_PROMO_COUPON_CODE && !isPlusGiftCart) {
         const promoBookNames = infoList
           .map((info, idx) => ({ info, name: bookNames[idx] }))
           .filter((x) => (x.info.listingData as any)?.plusPromoEnabled === true)
@@ -990,6 +994,7 @@ export async function createFreeBookCartFromSubscription({
     utmCampaign,
     utmSource,
     utmMedium,
+    isPlusGiftCart: true,
   }, {
     amountTotal: 0,
     email,

--- a/src/util/api/likernft/book/cart.ts
+++ b/src/util/api/likernft/book/cart.ts
@@ -944,6 +944,7 @@ export async function createFreeBookCartFromSubscription({
   cartId,
   priceIndex,
   amountPaid,
+  isTrialGift = false,
 }, {
   evmWallet,
   email,
@@ -963,7 +964,7 @@ export async function createFreeBookCartFromSubscription({
     console.warn('Free book cart item price is not less than the plus yearly price, skipping cart creation.');
     return null;
   }
-  if (itemInfos[0].originalPriceInDecimal > amountPaid * 100) {
+  if (!isTrialGift && itemInfos[0].originalPriceInDecimal > amountPaid * 100) {
     // eslint-disable-next-line no-console
     console.warn('Free book cart item price is not less than the amount paid');
   }

--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -27,6 +27,7 @@ import { sendPlusSubscriptionSlackNotification } from '../../slack';
 import { createAirtableSubscriptionPaymentRecord } from '../../airtable';
 import { createFreeBookCartFromSubscription } from '../likernft/book/cart';
 import { ValidationError } from '../../ValidationError';
+import { checkUserNameValid } from '../../ValidationHelper';
 import logServerEvents from '../../logServerEvents';
 import { updateIntercomUserAttributes, sendIntercomEvent } from '../../intercom';
 
@@ -437,16 +438,18 @@ export async function createNewPlusCheckoutSession(
   if (from && !giftClassId && period === 'yearly') {
     try {
       const normalizedFrom = from.startsWith('@') ? from.substring(1) : from;
-      const affiliateUserInfo = await getBookUserInfoFromLikerId(normalizedFrom);
-      if (affiliateUserInfo?.wallet) {
-        const affiliateConfig = affiliateUserInfo.bookUserInfo?.affiliateConfig?.active
-          ? affiliateUserInfo.bookUserInfo.affiliateConfig
-          : null;
-        if (affiliateConfig?.giftClassId) {
-          resolvedGiftClassId = affiliateConfig.giftClassId;
-          resolvedGiftPriceIndex = String(affiliateConfig.giftPriceIndex || 0);
-          subscriptionMetadata.affiliateGiftOnTrial = affiliateConfig.giftOnTrial ? 'true' : 'false';
-          subscriptionMetadata.affiliateFrom = from;
+      if (checkUserNameValid(normalizedFrom)) {
+        const affiliateUserInfo = await getBookUserInfoFromLikerId(normalizedFrom);
+        if (affiliateUserInfo?.wallet) {
+          const affiliateConfig = affiliateUserInfo.bookUserInfo?.affiliateConfig?.active
+            ? affiliateUserInfo.bookUserInfo.affiliateConfig
+            : null;
+          if (affiliateConfig?.giftClassId) {
+            resolvedGiftClassId = affiliateConfig.giftClassId;
+            resolvedGiftPriceIndex = String(affiliateConfig.giftPriceIndex || 0);
+            subscriptionMetadata.affiliateGiftOnTrial = affiliateConfig.giftOnTrial ? 'true' : 'false';
+            subscriptionMetadata.affiliateFrom = from;
+          }
         }
       }
     } catch (err) {

--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -27,7 +27,7 @@ import { sendPlusSubscriptionSlackNotification } from '../../slack';
 import { createAirtableSubscriptionPaymentRecord } from '../../airtable';
 import { createFreeBookCartFromSubscription } from '../likernft/book/cart';
 import { ValidationError } from '../../ValidationError';
-import { checkUserNameValid } from '../../ValidationHelper';
+import { checkUserNameValid, normalizeLikerId } from '../../ValidationHelper';
 import logServerEvents from '../../logServerEvents';
 import { updateIntercomUserAttributes, sendIntercomEvent } from '../../intercom';
 
@@ -174,6 +174,7 @@ export async function processStripeSubscriptionInvoice(
         classId: giftClassId,
         priceIndex: parseInt(giftPriceIndex, 10) || 0,
         amountPaid,
+        isTrialGift: isAffiliateGiftOnTrial && isTrial,
       }, {
         evmWallet,
         email: stripeCustomer.email,
@@ -205,13 +206,7 @@ export async function processStripeSubscriptionInvoice(
   const since = startDate * 1000; // Convert to milliseconds
   const currentPeriodStart = item.current_period_start * 1000; // Convert to milliseconds
   const currentPeriodEnd = item.current_period_end * 1000; // Convert to milliseconds
-  let normalizedAffiliateFrom: string | undefined;
-  if (isSubscriptionCreation && affiliateFrom) {
-    normalizedAffiliateFrom = affiliateFrom.startsWith('@')
-      ? affiliateFrom.substring(1)
-      : affiliateFrom;
-  }
-  await userCollection.doc(likerId).update({
+  const userUpdate: Record<string, unknown> = {
     likerPlus: {
       period,
       since,
@@ -222,8 +217,11 @@ export async function processStripeSubscriptionInvoice(
       customerId,
       subscriptionStatus: 'active',
     },
-    ...(normalizedAffiliateFrom && { plusAffiliateFrom: normalizedAffiliateFrom }),
-  });
+  };
+  if (isSubscriptionCreation && affiliateFrom) {
+    userUpdate.plusAffiliateFrom = normalizeLikerId(affiliateFrom);
+  }
+  await userCollection.doc(likerId).update(userUpdate);
 
   await updateIntercomUserAttributes(likerId, {
     is_liker_plus: true,
@@ -432,13 +430,12 @@ export async function createNewPlusCheckoutSession(
   if (from) subscriptionMetadata.from = from;
   if (paymentId) subscriptionMetadata.paymentId = paymentId;
 
-  // Record affiliate attribution whenever `from` resolves to a valid affiliate user.
-  // Auto-resolve gift config only when no explicit giftClassId was passed and period is yearly.
+  // Require the `@` prefix so plain UTM/channel values don't trigger affiliate lookups.
   let resolvedGiftClassId = giftClassId;
   let resolvedGiftPriceIndex = giftPriceIndex;
-  if (from) {
+  if (from && from.startsWith('@')) {
     try {
-      const normalizedFrom = from.startsWith('@') ? from.substring(1) : from;
+      const normalizedFrom = normalizeLikerId(from);
       if (checkUserNameValid(normalizedFrom)) {
         const affiliateUserInfo = await getBookUserInfoFromLikerId(normalizedFrom);
         const affiliateConfig = affiliateUserInfo?.wallet

--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -432,23 +432,25 @@ export async function createNewPlusCheckoutSession(
   if (from) subscriptionMetadata.from = from;
   if (paymentId) subscriptionMetadata.paymentId = paymentId;
 
-  // Auto-resolve affiliate config when from is present and no explicit giftClassId
+  // Record affiliate attribution whenever `from` resolves to a valid affiliate user.
+  // Auto-resolve gift config only when no explicit giftClassId was passed and period is yearly.
   let resolvedGiftClassId = giftClassId;
   let resolvedGiftPriceIndex = giftPriceIndex;
-  if (from && !giftClassId && period === 'yearly') {
+  if (from) {
     try {
       const normalizedFrom = from.startsWith('@') ? from.substring(1) : from;
       if (checkUserNameValid(normalizedFrom)) {
         const affiliateUserInfo = await getBookUserInfoFromLikerId(normalizedFrom);
-        if (affiliateUserInfo?.wallet) {
-          const affiliateConfig = affiliateUserInfo.bookUserInfo?.affiliateConfig?.active
-            ? affiliateUserInfo.bookUserInfo.affiliateConfig
-            : null;
-          if (affiliateConfig?.giftClassId) {
+        const affiliateConfig = affiliateUserInfo?.wallet
+          && affiliateUserInfo.bookUserInfo?.affiliateConfig?.active
+          ? affiliateUserInfo.bookUserInfo.affiliateConfig
+          : null;
+        if (affiliateConfig) {
+          subscriptionMetadata.affiliateFrom = from;
+          if (!giftClassId && affiliateConfig.giftClassId && period === 'yearly') {
             resolvedGiftClassId = affiliateConfig.giftClassId;
             resolvedGiftPriceIndex = String(affiliateConfig.giftPriceIndex || 0);
             subscriptionMetadata.affiliateGiftOnTrial = affiliateConfig.giftOnTrial ? 'true' : 'false';
-            subscriptionMetadata.affiliateFrom = from;
           }
         }
       }

--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../constant';
 import type { SupportedPlusCurrency } from '../../../constant';
 import { convertUSDPriceToCurrency } from '../../pricing';
-import { getBookUserInfoFromWallet } from '../likernft/book/user';
+import { getBookUserInfoFromWallet, getBookUserInfoFromLikerId } from '../likernft/book/user';
 import { getStripeClient, getStripePromotionFromCode } from '../../stripe';
 import { userCollection } from '../../firebase';
 import publisher from '../../gcloudPub';
@@ -92,6 +92,7 @@ export async function processStripeSubscriptionInvoice(
     fbClickId,
     gaClientId,
     gaSessionId,
+    affiliateGiftOnTrial,
   } = subscriptionMetadata || {};
   const productId = item.price.product as string;
   if (productId !== LIKER_PLUS_PRODUCT_ID) {
@@ -149,12 +150,14 @@ export async function processStripeSubscriptionInvoice(
   let giftCartId = '';
   const isTrialToPaidUpgrade = subscription.trial_end
     && subscription.trial_end === item.current_period_start;
+  const isAffiliateGiftOnTrial = affiliateGiftOnTrial === 'true';
+  const canCreateGiftCart = (!isTrial && amountPaid > 0)
+    || (isAffiliateGiftOnTrial && isSubscriptionCreation);
   if ((isSubscriptionCreation || isTrialToPaidUpgrade || isUpgradingPrice)
       && isYearlySubscription
       && giftClassId
       && !existingGiftCartId
-      && !isTrial
-      && amountPaid > 0) {
+      && canCreateGiftCart) {
     try {
       giftCartId = uuidv4();
       const metadata: Stripe.MetadataParam = {
@@ -419,8 +422,44 @@ export async function createNewPlusCheckoutSession(
   if (evmWallet) subscriptionMetadata.evmWallet = evmWallet;
   if (from) subscriptionMetadata.from = from;
   if (paymentId) subscriptionMetadata.paymentId = paymentId;
-  if (giftClassId) subscriptionMetadata.giftClassId = giftClassId;
-  if (giftPriceIndex !== undefined) subscriptionMetadata.giftPriceIndex = giftPriceIndex;
+
+  // Auto-resolve affiliate config when from is present and no explicit giftClassId
+  let resolvedGiftClassId = giftClassId;
+  let resolvedGiftPriceIndex = giftPriceIndex;
+  if (from && !giftClassId && period === 'yearly') {
+    try {
+      const normalizedFrom = from.startsWith('@') ? from.substring(1) : from;
+      const affiliateUserInfo = await getBookUserInfoFromLikerId(normalizedFrom);
+      if (affiliateUserInfo?.wallet) {
+        const affiliateConfig = affiliateUserInfo.bookUserInfo?.affiliateConfig?.active
+          ? affiliateUserInfo.bookUserInfo.affiliateConfig
+          : null;
+        if (affiliateConfig) {
+          resolvedGiftClassId = affiliateConfig.giftClassId;
+          resolvedGiftPriceIndex = String(affiliateConfig.giftPriceIndex || 0);
+          if (affiliateConfig.customVoiceId) {
+            subscriptionMetadata.affiliateVoiceId = affiliateConfig.customVoiceId;
+          }
+          if (affiliateConfig.customVoiceName) {
+            subscriptionMetadata.affiliateVoiceName = affiliateConfig.customVoiceName;
+          }
+          if (affiliateConfig.customVoiceLanguage) {
+            subscriptionMetadata.affiliateVoiceLanguage = affiliateConfig.customVoiceLanguage;
+          }
+          subscriptionMetadata.affiliateGiftOnTrial = affiliateConfig.giftOnTrial ? 'true' : 'false';
+          subscriptionMetadata.affiliateFrom = from;
+        }
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn('Error resolving affiliate config for from:', from, err);
+    }
+  }
+
+  if (resolvedGiftClassId) subscriptionMetadata.giftClassId = resolvedGiftClassId;
+  if (resolvedGiftPriceIndex !== undefined) {
+    subscriptionMetadata.giftPriceIndex = resolvedGiftPriceIndex;
+  }
   if (utm?.campaign) subscriptionMetadata.utmCampaign = utm.campaign;
   if (utm?.source) subscriptionMetadata.utmSource = utm.source;
   if (utm?.medium) subscriptionMetadata.utmMedium = utm.medium;

--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -93,6 +93,7 @@ export async function processStripeSubscriptionInvoice(
     gaClientId,
     gaSessionId,
     affiliateGiftOnTrial,
+    affiliateFrom,
   } = subscriptionMetadata || {};
   const productId = item.price.product as string;
   if (productId !== LIKER_PLUS_PRODUCT_ID) {
@@ -203,6 +204,12 @@ export async function processStripeSubscriptionInvoice(
   const since = startDate * 1000; // Convert to milliseconds
   const currentPeriodStart = item.current_period_start * 1000; // Convert to milliseconds
   const currentPeriodEnd = item.current_period_end * 1000; // Convert to milliseconds
+  let normalizedAffiliateFrom: string | undefined;
+  if (isSubscriptionCreation && affiliateFrom) {
+    normalizedAffiliateFrom = affiliateFrom.startsWith('@')
+      ? affiliateFrom.substring(1)
+      : affiliateFrom;
+  }
   await userCollection.doc(likerId).update({
     likerPlus: {
       period,
@@ -214,6 +221,7 @@ export async function processStripeSubscriptionInvoice(
       customerId,
       subscriptionStatus: 'active',
     },
+    ...(normalizedAffiliateFrom && { plusAffiliateFrom: normalizedAffiliateFrom }),
   });
 
   await updateIntercomUserAttributes(likerId, {
@@ -434,18 +442,9 @@ export async function createNewPlusCheckoutSession(
         const affiliateConfig = affiliateUserInfo.bookUserInfo?.affiliateConfig?.active
           ? affiliateUserInfo.bookUserInfo.affiliateConfig
           : null;
-        if (affiliateConfig) {
+        if (affiliateConfig?.giftClassId) {
           resolvedGiftClassId = affiliateConfig.giftClassId;
           resolvedGiftPriceIndex = String(affiliateConfig.giftPriceIndex || 0);
-          if (affiliateConfig.customVoiceId) {
-            subscriptionMetadata.affiliateVoiceId = affiliateConfig.customVoiceId;
-          }
-          if (affiliateConfig.customVoiceName) {
-            subscriptionMetadata.affiliateVoiceName = affiliateConfig.customVoiceName;
-          }
-          if (affiliateConfig.customVoiceLanguage) {
-            subscriptionMetadata.affiliateVoiceLanguage = affiliateConfig.customVoiceLanguage;
-          }
           subscriptionMetadata.affiliateGiftOnTrial = affiliateConfig.giftOnTrial ? 'true' : 'false';
           subscriptionMetadata.affiliateFrom = from;
         }


### PR DESCRIPTION
Auto-resolve affiliate config from likerId during yearly checkout, attach custom voice and gift-on-trial metadata to Stripe subscriptions, and expose affiliate config via new /plus/affiliate/:likerId endpoint.