### PR TITLE
[TAS-5620] ✨ Send Plus promo code email after eligible book purchases

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -47,6 +47,7 @@ config.LIKER_PLUS_MONTHLY_PRICE_ID = '';
 config.LIKER_PLUS_YEARLY_PRICE_ID = '';
 config.LIKER_PLUS_GIFT_MONTHLY_PRICE_ID = '';
 config.LIKER_PLUS_GIFT_YEARLY_PRICE_ID = '';
+config.LIKER_PLUS_BOOK_PROMO_COUPON_CODE = '';
 
 config.ARWEAVE_EVM_TARGET_ADDRESS = '';
 config.IPFS_ENDPOINT = 'https://ipfs.infura.io:5001/api/v0';

--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -173,6 +173,7 @@ export interface NFTBookListingInfo {
   isApprovedForIndexing?: boolean;
   isApprovedForAds?: boolean;
   approvalStatus?: string;
+  plusPromoEnabled?: boolean;
   successUrl?: string;
   cancelUrl?: string;
 }
@@ -224,6 +225,7 @@ export interface NFTBookListingInfoFiltered {
   isApprovedForIndexing: boolean;
   isApprovedForAds: boolean;
   approvalStatus?: string;
+  plusPromoEnabled?: boolean;
 }
 
 export interface NFTBookUserData {

--- a/src/util/ValidationHelper.ts
+++ b/src/util/ValidationHelper.ts
@@ -618,6 +618,7 @@ export function filterNFTBookListingInfo(
     isApprovedForIndexing,
     isApprovedForAds,
     approvalStatus,
+    plusPromoEnabled,
   } = bookInfo;
   const { stock, sold, prices } = filterNFTBookPricesInfo(inputPrices, isOwner);
   const id = inputId || classId;
@@ -664,6 +665,7 @@ export function filterNFTBookListingInfo(
     isApprovedForSale: isApprovedForSale !== undefined ? isApprovedForSale : true,
     isApprovedForIndexing: isApprovedForIndexing !== undefined ? isApprovedForIndexing : true,
     isApprovedForAds: isApprovedForAds !== undefined ? isApprovedForAds : true,
+    plusPromoEnabled,
   };
   if (isOwner) {
     payload.sold = sold;

--- a/src/util/api/likernft/book/cart.ts
+++ b/src/util/api/likernft/book/cart.ts
@@ -46,12 +46,14 @@ import {
   sendNFTBookCartGiftPendingClaimEmail,
   sendNFTBookCartPendingClaimEmail,
   sendNFTBookOutOfStockEmail,
+  sendPlusBookPromoCodeEmail,
 } from '../../../ses';
 import logServerEvents from '../../../logServerEvents';
 import { getBookUserInfoFromWallet } from './user';
 import {
   SLACK_OUT_OF_STOCK_NOTIFICATION_THRESHOLD,
   LIKER_PLUS_20_COUPON_ID,
+  LIKER_PLUS_BOOK_PROMO_COUPON_CODE,
 } from '../../../../../config/config';
 import {
   CartItem, CartItemWithInfo, ItemPriceInfo, TransactionFeeInfo,
@@ -641,6 +643,8 @@ export async function processNFTBookCart(
     } catch { /* ignore */ }
     const emailLanguage = buyerLocale || language || 'zh';
 
+    let buyerUserInfo: Awaited<ReturnType<typeof getUserWithCivicLikerPropertiesByWallet>> = null;
+
     if (cartIsGift && cartGiftInfo) {
       const {
         fromName,
@@ -675,6 +679,42 @@ export async function processNFTBookCart(
         displayName: buyerDisplayName,
         language: emailLanguage,
       });
+
+      // Send Plus promo code email for self-purchases of promo-eligible books.
+      // Skip silently if we can't verify the buyer isn't already a Plus subscriber.
+      if (email && LIKER_PLUS_BOOK_PROMO_COUPON_CODE) {
+        const promoBookNames = infoList
+          .map((info, idx) => ({ info, name: bookNames[idx] }))
+          .filter((x) => (x.info.listingData as any)?.plusPromoEnabled === true)
+          .map((x) => x.name);
+        if (promoBookNames.length > 0) {
+          try {
+            if (evmWallet) {
+              buyerUserInfo = await getUserWithCivicLikerPropertiesByWallet(evmWallet);
+            }
+            if (!buyerUserInfo?.isLikerPlus) {
+              await sendPlusBookPromoCodeEmail({
+                email,
+                code: LIKER_PLUS_BOOK_PROMO_COUPON_CODE,
+                bookNames: promoBookNames,
+                displayName: buyerDisplayName,
+                language: emailLanguage,
+              });
+              publisher.publish(PUBSUB_TOPIC_MISC, req, {
+                logType: 'PlusBookPromoCodeEmailSent',
+                paymentId,
+                cartId,
+                email,
+                evmWallet,
+                bookNames: promoBookNames,
+              });
+            }
+          } catch (promoErr) {
+            // eslint-disable-next-line no-console
+            console.error('Failed to send Plus promo code email:', promoErr);
+          }
+        }
+      }
     }
     await logServerEvents('Purchase', {
       email: email || undefined,
@@ -728,7 +768,8 @@ export async function processNFTBookCart(
         if (hasFreeBooks) attributes.has_claimed_free_book = true;
         if (hasPaidBooks) attributes.has_purchased_paid_book = true;
 
-        const userInfo = await getUserWithCivicLikerPropertiesByWallet(evmWallet);
+        const userInfo = buyerUserInfo
+          ?? await getUserWithCivicLikerPropertiesByWallet(evmWallet);
         const likerId = userInfo?.user;
         if (likerId) {
           await updateIntercomUserAttributes(likerId, attributes);

--- a/src/util/liker-land.ts
+++ b/src/util/liker-land.ts
@@ -324,6 +324,8 @@ export const getBook3NFTGiftPageURL = ({
 export const getPlusPageURL = ({
   language,
   coupon,
+  plan,
+  trial,
   utmCampaign,
   utmSource,
   utmMedium,
@@ -334,6 +336,8 @@ export const getPlusPageURL = ({
 }: {
   language?: string;
   coupon?: string;
+  plan?: 'monthly' | 'yearly';
+  trial?: '0' | '0d' | '1d' | '3d' | '5d' | '7d' | '14d' | '30d';
   utmCampaign?: string;
   utmSource?: string;
   utmMedium?: string;
@@ -345,6 +349,12 @@ export const getPlusPageURL = ({
   const qsPayload: any = {};
   if (coupon) {
     qsPayload.coupon = coupon;
+  }
+  if (plan) {
+    qsPayload.plan = plan;
+  }
+  if (trial) {
+    qsPayload.trial = trial;
   }
   if (utmCampaign) {
     qsPayload.utm_campaign = utmCampaign;

--- a/src/util/liker-land.ts
+++ b/src/util/liker-land.ts
@@ -323,6 +323,7 @@ export const getBook3NFTGiftPageURL = ({
 
 export const getPlusPageURL = ({
   language,
+  coupon,
   utmCampaign,
   utmSource,
   utmMedium,
@@ -332,6 +333,7 @@ export const getPlusPageURL = ({
   gadSource,
 }: {
   language?: string;
+  coupon?: string;
   utmCampaign?: string;
   utmSource?: string;
   utmMedium?: string;
@@ -341,6 +343,9 @@ export const getPlusPageURL = ({
   gadSource?: string;
 }) => {
   const qsPayload: any = {};
+  if (coupon) {
+    qsPayload.coupon = coupon;
+  }
   if (utmCampaign) {
     qsPayload.utm_campaign = utmCampaign;
   }

--- a/src/util/ses.ts
+++ b/src/util/ses.ts
@@ -11,6 +11,7 @@ import {
 } from '../constant';
 import {
   getPlusGiftPageClaimURL,
+  getPlusPageURL,
   getBook3NFTClaimPageURL,
   getBook3NFTClassPageURL,
   getBook3PortfolioPageURL,
@@ -1069,6 +1070,93 @@ export function sendNFTBookOutOfStockEmail({
             title,
             content,
           }).body,
+        },
+      },
+    },
+  };
+  return ses.sendEmail(params);
+}
+
+export function sendPlusBookPromoCodeEmail({
+  email,
+  code,
+  bookNames,
+  displayName = '',
+  language = 'zh',
+}: {
+  email: string;
+  code: string;
+  bookNames: string[];
+  displayName?: string;
+  language?: string;
+}) {
+  const isEn = language === 'en';
+  const lang = isEn ? 'en' : 'zh-Hant';
+  const title = isEn
+    ? 'Get 1 month of 3ook.com Plus, free'
+    : '免費獲得一個月 3ook.com Plus';
+  const plusPageURL = getPlusPageURL({
+    language: lang,
+    coupon: code,
+    utmCampaign: 'book-plus-promo',
+    utmSource: 'book-promo',
+    utmMedium: 'email',
+  });
+  const params = {
+    Source: SYSTEM_EMAIL,
+    ReplyToAddresses: [CUSTOMER_SERVICE_EMAIL],
+    ConfigurationSetName: 'likeco_ses',
+    Tags: [
+      {
+        Name: 'Function',
+        Value: 'sendPlusBookPromoCodeEmail',
+      },
+      {
+        Name: 'Environment',
+        Value: TEST_MODE ? 'testnet' : 'mainnet',
+      },
+    ],
+    Destination: {
+      ToAddresses: [email],
+      ...(TEST_MODE ? {} : { BccAddresses: [SALES_EMAIL] }),
+    },
+    Message: {
+      Subject: {
+        Charset: 'UTF-8',
+        Data: TEST_MODE ? `(TESTNET) ${title}` : title,
+      },
+      Body: {
+        Html: {
+          Charset: 'UTF-8',
+          Data: isEn
+            ? getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>Dear ${displayName || 'reader'},</p>
+            <p>Thank you for purchasing the following ebook${bookNames.length > 1 ? 's' : ''}:</p>
+            <ul>${bookNames.map((name) => `<li>"${name}"</li>`).join('')}</ul>
+            <p>As a thank-you, here is <strong>1 month of 3ook.com Plus for free</strong>. Plus unlocks AI-powered reading features across your entire library.</p>
+            <p>Click the button below to activate your free month. Your subscription will renew automatically at the regular price after the first month — you can cancel anytime.</p>`,
+              buttonText1: 'Activate my free month',
+              buttonHref1: plusPageURL,
+              append1: `<p>Promo code: <strong>${code}</strong></p>
+            <p>If you have any questions, please contact our <a href="${CUSTOMER_SERVICE_URL}">Customer Service</a>.
+            <br>May you enjoy the pleasure of reading.</p>
+            <p>3ook.com Bookstore</p>`,
+            }).body
+            : getNFTTwoContentWithMessageAndButtonTemplate({
+              title1: title,
+              content1: `<p>親愛的${displayName || '讀者'}：</p>
+            <p>感謝你購買以下電子書：</p>
+            <ul>${bookNames.map((name) => `<li>《${name}》</li>`).join('')}</ul>
+            <p>為答謝你的支持，我們送上<strong>一個月免費的 3ook.com Plus 會籍</strong>。Plus 會籍將為你的整個書庫解鎖 AI 閱讀功能。</p>
+            <p>按以下按鈕啟用你的免費會籍。首月過後，會籍將按正常價格自動續訂，你可以隨時取消。</p>`,
+              buttonText1: '啟用我的免費會籍',
+              buttonHref1: plusPageURL,
+              append1: `<p>優惠碼：<strong>${code}</strong></p>
+            <p>如有任何疑問，歡迎<a href="${CUSTOMER_SERVICE_URL}">聯絡客服</a>查詢。
+            <br>願你享受閱讀的樂趣。</p>
+            <p>3ook.com 書店</p>`,
+            }).body,
         },
       },
     },

--- a/src/util/ses.ts
+++ b/src/util/ses.ts
@@ -1098,6 +1098,8 @@ export function sendPlusBookPromoCodeEmail({
   const plusPageURL = getPlusPageURL({
     language: lang,
     coupon: code,
+    plan: 'monthly',
+    trial: '0',
     utmCampaign: 'book-plus-promo',
     utmSource: 'book-promo',
     utmMedium: 'email',


### PR DESCRIPTION
Books flagged with plusPromoEnabled in Firestore trigger a follow-up email offering a first-month-free Plus coupon to self-purchase buyers. Skips gift purchases and existing Plus subscribers, and reuses the buyer user info lookup already needed by the Intercom update to avoid a duplicate Firestore read.
<img width="581" height="548" alt="image" src="https://github.com/user-attachments/assets/e320816b-2580-41b0-9ebf-4c95dc3c0e6b" />
