### PR TITLE
✨ Track first/last paid timestamps and emit customer_type to Meta CAPI

### DIFF
--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -1,3 +1,4 @@
+import type { Timestamp } from '@google-cloud/firestore';
 import type { SupportedLocale } from '../locales';
 
 export interface CivicLikerData {
@@ -65,6 +66,10 @@ export interface UserData {
   // Subscription fields
   civicLiker?: CivicLikerData;
   likerPlus?: LikerPlusData;
+
+  // Purchase history
+  firstPaidAt?: Timestamp;
+  lastPaidAt?: Timestamp;
 
   // Metadata fields
   locale?: SupportedLocale;

--- a/src/util/api/likernft/book/cart.ts
+++ b/src/util/api/likernft/book/cart.ts
@@ -61,7 +61,7 @@ import {
 } from './type';
 import { isLikeNFTClassId } from '../../../cosmos/nft';
 import { getUserWithCivicLikerPropertiesByWallet, fetchUserInfoByEmail } from '../../users';
-import getPaymentUpdateFields from '../../users/payment';
+import { getCustomerType, getPaymentUpdateFields } from '../../users/payment';
 
 export async function createNewNFTBookCartPayment(cartId: string, paymentId: string, {
   type,
@@ -735,6 +735,10 @@ export async function processNFTBookCart(
         }
       }
     }
+    if (evmWallet && !buyerUserInfo) {
+      buyerUserInfo = await getUserWithCivicLikerPropertiesByWallet(evmWallet);
+    }
+
     await logServerEvents('Purchase', {
       email: email || undefined,
       items: infoList.map((item) => ({
@@ -754,15 +758,12 @@ export async function processNFTBookCart(
       evmWallet,
       gaClientId,
       gaSessionId,
+      customerType: getCustomerType(buyerUserInfo),
     });
 
-    if (evmWallet && (amountTotal || 0) > 0) {
-      buyerUserInfo = buyerUserInfo
-        ?? await getUserWithCivicLikerPropertiesByWallet(evmWallet);
-      if (buyerUserInfo) {
-        await userCollection.doc(buyerUserInfo.user)
-          .update(getPaymentUpdateFields(!!buyerUserInfo.firstPaidAt));
-      }
+    if (buyerUserInfo && (amountTotal || 0) > 0) {
+      await userCollection.doc(buyerUserInfo.user)
+        .update(getPaymentUpdateFields(!!buyerUserInfo.firstPaidAt));
     }
 
     // Attempt to claim the cart immediately if the user is logged in

--- a/src/util/api/likernft/book/cart.ts
+++ b/src/util/api/likernft/book/cart.ts
@@ -32,6 +32,7 @@ import {
   FieldValue,
   likeNFTBookCartCollection,
   likeNFTBookCollection,
+  userCollection,
 } from '../../../firebase';
 import { getStripeClient, getStripeFeeFromCheckoutSession, getStripePromotoionCodesFromCheckoutSession } from '../../../stripe';
 import {
@@ -60,6 +61,7 @@ import {
 } from './type';
 import { isLikeNFTClassId } from '../../../cosmos/nft';
 import { getUserWithCivicLikerPropertiesByWallet, fetchUserInfoByEmail } from '../../users';
+import getPaymentUpdateFields from '../../users/payment';
 
 export async function createNewNFTBookCartPayment(cartId: string, paymentId: string, {
   type,
@@ -753,6 +755,15 @@ export async function processNFTBookCart(
       gaClientId,
       gaSessionId,
     });
+
+    if (evmWallet && (amountTotal || 0) > 0) {
+      buyerUserInfo = buyerUserInfo
+        ?? await getUserWithCivicLikerPropertiesByWallet(evmWallet);
+      if (buyerUserInfo) {
+        await userCollection.doc(buyerUserInfo.user)
+          .update(getPaymentUpdateFields(!!buyerUserInfo.firstPaidAt));
+      }
+    }
 
     // Attempt to claim the cart immediately if the user is logged in
     // Skip auto-claim for gifts — the receiver should claim via the email link

--- a/src/util/api/plus/gift.ts
+++ b/src/util/api/plus/gift.ts
@@ -16,6 +16,8 @@ import { ValidationError } from '../../ValidationError';
 import { sendPlusGiftClaimedEmail, sendPlusGiftPendingClaimEmail } from '../../ses';
 import { getBookUserInfoFromWallet } from '../likernft/book/user';
 import { fetchUserInfoByEmail } from '../users';
+import { getUserWithCivicLikerPropertiesByWallet } from '../users/getPublicInfo';
+import getPaymentUpdateFields from '../users/payment';
 import { getPlusGiftPageURL, getPlusPageURL } from '../../liker-land';
 import type { BookGiftInfo } from '../../../types/book';
 import type { SupportedPlusCurrency } from '../../../constant';
@@ -520,4 +522,12 @@ export async function processPlusGiftStripePurchase(
     gaClientId,
     gaSessionId,
   });
+
+  if (evmWallet && (amountTotal || 0) > 0) {
+    const buyer = await getUserWithCivicLikerPropertiesByWallet(evmWallet);
+    if (buyer) {
+      await userCollection.doc(buyer.user)
+        .update(getPaymentUpdateFields(!!buyer.firstPaidAt));
+    }
+  }
 }

--- a/src/util/api/plus/gift.ts
+++ b/src/util/api/plus/gift.ts
@@ -17,7 +17,7 @@ import { sendPlusGiftClaimedEmail, sendPlusGiftPendingClaimEmail } from '../../s
 import { getBookUserInfoFromWallet } from '../likernft/book/user';
 import { fetchUserInfoByEmail } from '../users';
 import { getUserWithCivicLikerPropertiesByWallet } from '../users/getPublicInfo';
-import getPaymentUpdateFields from '../users/payment';
+import { getCustomerType, getPaymentUpdateFields } from '../users/payment';
 import { getPlusGiftPageURL, getPlusPageURL } from '../../liker-land';
 import type { BookGiftInfo } from '../../../types/book';
 import type { SupportedPlusCurrency } from '../../../constant';
@@ -503,6 +503,10 @@ export async function processPlusGiftStripePurchase(
     language: metadataLanguage || 'zh',
   });
 
+  const buyer = evmWallet
+    ? await getUserWithCivicLikerPropertiesByWallet(evmWallet)
+    : null;
+
   await logServerEvents('Purchase', {
     email: email || undefined,
     items: [{
@@ -521,13 +525,11 @@ export async function processPlusGiftStripePurchase(
     evmWallet,
     gaClientId,
     gaSessionId,
+    customerType: getCustomerType(buyer),
   });
 
-  if (evmWallet && (amountTotal || 0) > 0) {
-    const buyer = await getUserWithCivicLikerPropertiesByWallet(evmWallet);
-    if (buyer) {
-      await userCollection.doc(buyer.user)
-        .update(getPaymentUpdateFields(!!buyer.firstPaidAt));
-    }
+  if (buyer && (amountTotal || 0) > 0) {
+    await userCollection.doc(buyer.user)
+      .update(getPaymentUpdateFields(!!buyer.firstPaidAt));
   }
 }

--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -14,6 +14,7 @@ import { convertUSDPriceToCurrency } from '../../pricing';
 import { getBookUserInfoFromWallet, getBookUserInfoFromLikerId } from '../likernft/book/user';
 import { getStripeClient, getStripePromotionFromCode } from '../../stripe';
 import { userCollection } from '../../firebase';
+import getPaymentUpdateFields from '../users/payment';
 import publisher from '../../gcloudPub';
 
 import {
@@ -224,6 +225,9 @@ export async function processStripeSubscriptionInvoice(
   if (isSubscriptionCreation && affiliateFrom) {
     userUpdate.plusAffiliateFrom = normalizeLikerId(affiliateFrom);
   }
+  if (amountPaid > 0) {
+    Object.assign(userUpdate, getPaymentUpdateFields(!!user.firstPaidAt));
+  }
   await userCollection.doc(likerId).update(userUpdate);
 
   await updateIntercomUserAttributes(likerId, {
@@ -274,6 +278,7 @@ export async function processStripeSubscriptionInvoice(
       predictedLTV,
       gaClientId,
       gaSessionId,
+      customerType: isNewSubscription ? 'new' : 'returning',
       extraProperties: {
         subscription_id: subscriptionId,
         period,

--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -14,7 +14,7 @@ import { convertUSDPriceToCurrency } from '../../pricing';
 import { getBookUserInfoFromWallet, getBookUserInfoFromLikerId } from '../likernft/book/user';
 import { getStripeClient, getStripePromotionFromCode } from '../../stripe';
 import { userCollection } from '../../firebase';
-import getPaymentUpdateFields from '../users/payment';
+import { getCustomerType, getPaymentUpdateFields } from '../users/payment';
 import publisher from '../../gcloudPub';
 
 import {
@@ -278,7 +278,7 @@ export async function processStripeSubscriptionInvoice(
       predictedLTV,
       gaClientId,
       gaSessionId,
-      customerType: isNewSubscription ? 'new' : 'returning',
+      customerType: isNewSubscription ? getCustomerType(user) : 'returning',
       extraProperties: {
         subscription_id: subscriptionId,
         period,
@@ -296,6 +296,7 @@ export async function processStripeSubscriptionInvoice(
         productId: `plus-${period}ly`,
         quantity: 1,
       }],
+      customerType: 'returning',
       extraProperties: {
         subscription_id: subscriptionId,
         period,

--- a/src/util/api/users/payment.ts
+++ b/src/util/api/users/payment.ts
@@ -1,0 +1,11 @@
+import { FieldValue } from '../../firebase';
+
+export default function getPaymentUpdateFields(hasPriorPayment: boolean): Record<string, unknown> {
+  const fields: Record<string, unknown> = {
+    lastPaidAt: FieldValue.serverTimestamp(),
+  };
+  if (!hasPriorPayment) {
+    fields.firstPaidAt = FieldValue.serverTimestamp();
+  }
+  return fields;
+}

--- a/src/util/api/users/payment.ts
+++ b/src/util/api/users/payment.ts
@@ -1,6 +1,6 @@
 import { FieldValue } from '../../firebase';
 
-export default function getPaymentUpdateFields(hasPriorPayment: boolean): Record<string, unknown> {
+export function getPaymentUpdateFields(hasPriorPayment: boolean): Record<string, unknown> {
   const fields: Record<string, unknown> = {
     lastPaidAt: FieldValue.serverTimestamp(),
   };
@@ -8,4 +8,10 @@ export default function getPaymentUpdateFields(hasPriorPayment: boolean): Record
     fields.firstPaidAt = FieldValue.serverTimestamp();
   }
   return fields;
+}
+
+export function getCustomerType(
+  user: { firstPaidAt?: unknown } | null | undefined,
+): 'new' | 'returning' {
+  return user?.firstPaidAt ? 'returning' : 'new';
 }

--- a/src/util/fbq.ts
+++ b/src/util/fbq.ts
@@ -29,6 +29,7 @@ export default async function logPixelEvents(event: ServerEventName, {
   fbp,
   fbc,
   evmWallet,
+  customerType,
 }: {
   email?: string;
   items?: AnalyticsItem[];
@@ -44,6 +45,7 @@ export default async function logPixelEvents(event: ServerEventName, {
   fbp?: string;
   fbc?: string;
   evmWallet?: string;
+  customerType?: 'new' | 'returning';
 }) {
   if (!FB_PIXEL_ID || !FB_ACCESS_TOKEN) {
     return;
@@ -79,6 +81,7 @@ export default async function logPixelEvents(event: ServerEventName, {
               predicted_ltv: predictedLTV,
               currency,
               order_id: paymentId,
+              customer_type: customerType,
               content_type: 'product',
               content_ids: items
                 ? items.map((item) => buildItemId(item.productId, item.priceIndex))

--- a/src/util/logServerEvents.ts
+++ b/src/util/logServerEvents.ts
@@ -23,6 +23,7 @@ export default async function logServerEvents(
     evmWallet?: string;
     gaClientId?: string;
     gaSessionId?: string;
+    customerType?: 'new' | 'returning';
     extraProperties?: Record<string, unknown>;
   },
 ): Promise<void> {


### PR DESCRIPTION
Denormalize firstPaidAt/lastPaidAt as Firestore Timestamps on the user doc from all three paid-event webhooks (Plus invoice, Plus gift, book cart). Emit customer_type 'new'/'returning' to Meta CAPI custom_data on Plus Subscribe/StartTrial events using the existing isNewSubscription flag; book/gift events can adopt the signal once firstPaidAt backfills.