### PR TITLE
📈 Store IP-derived country on Stripe metadata and payment records

### DIFF
--- a/src/routes/likernft/book/purchase.ts
+++ b/src/routes/likernft/book/purchase.ts
@@ -164,6 +164,7 @@ router.post('/cart/new', jwtOptionalAuth('read:nftbook'), async (req, res, next)
 
     const referrer = inputReferrer;
     const clientIp = req.headers['x-real-ip'] as string || req.ip;
+    const ipCountry = ((req.headers['cf-ipcountry'] as string) || (req.body?.ipCountry as string) || '').toUpperCase() || undefined;
     const userAgent = req.get('User-Agent');
     const {
       url,
@@ -197,6 +198,7 @@ router.post('/cart/new', jwtOptionalAuth('read:nftbook'), async (req, res, next)
       referrer,
       userAgent,
       clientIp,
+      ipCountry,
       cancelUrl: getBook3CartURL({
         type: 'book',
         utmCampaign,
@@ -290,6 +292,7 @@ router.get(['/:classId/new', '/class/:classId/new'], jwtOptionalAuth('read:nftbo
     const httpMethod = 'GET';
     const referrer = (inputReferrer || req.get('Referrer')) as string;
     const clientIp = req.headers['x-real-ip'] as string || req.ip;
+    const ipCountry = ((req.headers['cf-ipcountry'] as string) || '').toUpperCase() || undefined;
     const userAgent = req.get('User-Agent');
     const customPriceInDecimal = parseInt(inputCustomPriceInDecimal as string, 10) || undefined;
 
@@ -334,6 +337,7 @@ router.get(['/:classId/new', '/class/:classId/new'], jwtOptionalAuth('read:nftbo
       evmWallet: req.user?.evmWallet,
       from: from as string,
       clientIp,
+      ipCountry,
       referrer,
       utm: {
         campaign: utmCampaign as string,
@@ -454,6 +458,7 @@ router.post(['/:classId/new', '/class/:classId/new'], jwtOptionalAuth('read:nftb
     const httpMethod = 'POST';
     const referrer = inputReferrer;
     const clientIp = req.headers['x-real-ip'] as string || req.ip;
+    const ipCountry = ((req.headers['cf-ipcountry'] as string) || (req.body?.ipCountry as string) || '').toUpperCase() || undefined;
     const userAgent = req.get('User-Agent');
     const {
       url,
@@ -494,6 +499,7 @@ router.post(['/:classId/new', '/class/:classId/new'], jwtOptionalAuth('read:nftb
       httpMethod,
       userAgent,
       clientIp,
+      ipCountry,
       cancelUrl: getBook3NFTClassPageURL({
         classId,
         utmCampaign,

--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -69,6 +69,7 @@ router.post('/new', jwtAuth('write:plus'), async (req, res, next) => {
     }
     const checkoutCurrency = (currency as SupportedPlusCurrency) || 'usd';
     const clientIp = req.headers['x-real-ip'] as string || req.ip;
+    const ipCountry = ((req.headers['cf-ipcountry'] as string) || (req.body?.ipCountry as string) || '').toUpperCase() || undefined;
     const userAgent = req.get('User-Agent');
     const {
       session,
@@ -98,6 +99,7 @@ router.post('/new', jwtAuth('write:plus'), async (req, res, next) => {
         referrer,
         userAgent,
         clientIp,
+        ipCountry,
         utm: {
           campaign: utmCampaign,
           source: utmSource,
@@ -206,6 +208,7 @@ router.post('/gift/new', jwtAuth('write:plus'), async (req, res, next) => {
     }
     const checkoutCurrency = (currency as SupportedPlusCurrency) || 'usd';
     const clientIp = req.headers['x-real-ip'] as string || req.ip;
+    const ipCountry = ((req.headers['cf-ipcountry'] as string) || (req.body?.ipCountry as string) || '').toUpperCase() || undefined;
     const userAgent = req.get('User-Agent');
     const {
       session,
@@ -231,6 +234,7 @@ router.post('/gift/new', jwtAuth('write:plus'), async (req, res, next) => {
         referrer,
         userAgent,
         clientIp,
+        ipCountry,
         utm: {
           campaign: utmCampaign,
           source: utmSource,

--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -62,6 +62,7 @@ export interface PlusGiftCartData {
   period: string;
   giftInfo: BookGiftInfo;
   claimToken: string;
+  ipCountry?: string;
   timestamp: { toMillis: () => number };
   claimTimestamp?: { toMillis: () => number };
 }

--- a/src/util/api/likernft/book/cart.ts
+++ b/src/util/api/likernft/book/cart.ts
@@ -74,6 +74,7 @@ export async function createNewNFTBookCartPayment(cartId: string, paymentId: str
   itemInfos,
   feeInfo,
   coupon,
+  ipCountry,
 }: {
   type: string;
   email?: string;
@@ -90,6 +91,7 @@ export async function createNewNFTBookCartPayment(cartId: string, paymentId: str
   itemInfos: CartItemWithInfo[];
   feeInfo: TransactionFeeInfo,
   coupon?: string,
+  ipCountry?: string,
 }): Promise<void> {
   const classIdsWithPrice = itemPrices.filter((item) => !!item.classId).map((item) => ({
     classId: item.classId,
@@ -124,6 +126,7 @@ export async function createNewNFTBookCartPayment(cartId: string, paymentId: str
     feeInfo,
   };
   if (coupon) payload.coupon = coupon;
+  if (ipCountry) payload.ipCountry = ipCountry;
   const isGift = !!giftInfo;
   if (isGift) {
     const {
@@ -199,6 +202,7 @@ export async function createNewNFTBookCartPayment(cartId: string, paymentId: str
         from: itemFrom || from,
         itemPrices: [item],
         feeInfo: itemFeeInfo,
+        ipCountry,
       });
     }
     throw new ValidationError('ITEM_ID_NOT_SET');
@@ -326,6 +330,7 @@ type ProcessNFTBookCartMeta = {
   sessionId?: string;
   userAgent?: string;
   clientIp?: string;
+  ipCountry?: string;
   referrer?: string;
   fbClickId?: string;
   fbp?: string;
@@ -368,6 +373,7 @@ export async function processNFTBookCart(
     sessionId,
     userAgent,
     clientIp,
+    ipCountry,
     referrer,
     fbClickId,
     fbp,
@@ -412,6 +418,7 @@ export async function processNFTBookCart(
     itemPrices,
     feeInfo: totalFeeInfo,
     coupon,
+    ipCountry,
   });
 
   try {
@@ -1406,6 +1413,7 @@ export async function handleNewCartStripeCheckout(inputItems: CartItem[], {
   referrer,
   userAgent,
   clientIp,
+  ipCountry,
   paymentMethods,
   httpMethod = 'POST',
   cancelUrl,
@@ -1441,6 +1449,7 @@ export async function handleNewCartStripeCheckout(inputItems: CartItem[], {
   referrer?: string,
   userAgent?: string,
   clientIp?: string,
+  ipCountry?: string,
   paymentMethods?: string[],
   httpMethod?: 'GET' | 'POST',
   cancelUrl?: string,
@@ -1558,6 +1567,7 @@ export async function handleNewCartStripeCheckout(inputItems: CartItem[], {
     referrer,
     userAgent,
     clientIp,
+    ipCountry,
     httpMethod,
     language,
     isApp,

--- a/src/util/api/likernft/book/purchase.ts
+++ b/src/util/api/likernft/book/purchase.ts
@@ -353,6 +353,7 @@ export async function createNewNFTBookPayment(classId, paymentId, {
   from = '',
   itemPrices,
   feeInfo,
+  ipCountry,
 }: {
   type: string;
   cartId?: string;
@@ -374,6 +375,7 @@ export async function createNewNFTBookPayment(classId, paymentId, {
   };
   itemPrices?: any[],
   feeInfo?: TransactionFeeInfo,
+  ipCountry?: string,
 }) {
   const payload: any = {
     type,
@@ -398,6 +400,7 @@ export async function createNewNFTBookPayment(classId, paymentId, {
   if (coupon) payload.coupon = coupon;
   if (itemPrices) payload.itemPrices = itemPrices;
   if (feeInfo) payload.feeInfo = feeInfo;
+  if (ipCountry) payload.ipCountry = ipCountry;
 
   const isGift = !!giftInfo;
 
@@ -521,6 +524,7 @@ export async function formatStripeCheckoutSession({
   httpMethod,
   userAgent,
   clientIp,
+  ipCountry,
   language,
   isApp,
 }: {
@@ -562,6 +566,7 @@ export async function formatStripeCheckoutSession({
   httpMethod?: 'GET' | 'POST',
   userAgent?: string,
   clientIp?: string,
+  ipCountry?: string,
   language?: string,
   isApp?: boolean,
 }, items: CartItemWithInfo[], {
@@ -603,6 +608,7 @@ export async function formatStripeCheckoutSession({
   if (referrer) sessionMetadata.referrer = referrer.substring(0, 500);
   if (userAgent) sessionMetadata.userAgent = userAgent;
   if (clientIp) sessionMetadata.clientIp = clientIp;
+  if (ipCountry) sessionMetadata.ipCountry = ipCountry;
   if (fbClickId) sessionMetadata.fbClickId = fbClickId;
   if (fbp) sessionMetadata.fbp = fbp.substring(0, 255);
   if (fbc) sessionMetadata.fbc = fbc.substring(0, 255);

--- a/src/util/api/plus/gift.ts
+++ b/src/util/api/plus/gift.ts
@@ -53,6 +53,7 @@ export async function createPlusGiftCheckoutSession(
     referrer,
     userAgent,
     clientIp,
+    ipCountry,
     utm,
   }: {
     from?: string,
@@ -66,6 +67,7 @@ export async function createPlusGiftCheckoutSession(
     referrer?: string,
     userAgent?: string,
     clientIp?: string,
+    ipCountry?: string,
     utm?: {
       campaign?: string,
       source?: string,
@@ -121,6 +123,7 @@ export async function createPlusGiftCheckoutSession(
   if (utm?.term) sessionMetadata.utmTerm = utm.term;
   if (userAgent) sessionMetadata.userAgent = userAgent;
   if (clientIp) sessionMetadata.clientIp = clientIp;
+  if (ipCountry) sessionMetadata.ipCountry = ipCountry;
   if (fbClickId) sessionMetadata.fbClickId = fbClickId;
   if (fbp) sessionMetadata.fbp = fbp.substring(0, 255);
   if (fbc) sessionMetadata.fbc = fbc.substring(0, 255);
@@ -230,8 +233,17 @@ export async function createPlusGiftCart({
   paymentId,
   sessionId,
   claimToken,
+  ipCountry,
+}: {
+  period?: 'monthly' | 'yearly',
+  giftInfo: BookGiftInfo,
+  email: string,
+  paymentId: string,
+  sessionId: string,
+  claimToken: string,
+  ipCountry?: string,
 }) {
-  await likePlusGiftCartCollection.doc(paymentId).create({
+  const payload: any = {
     id: paymentId,
     email,
     period,
@@ -240,7 +252,9 @@ export async function createPlusGiftCart({
     sessionId,
     claimToken,
     timestamp: FieldValue.serverTimestamp(),
-  });
+  };
+  if (ipCountry) payload.ipCountry = ipCountry;
+  await likePlusGiftCartCollection.doc(paymentId).create(payload);
 }
 
 export async function claimPlusGiftCart({
@@ -447,6 +461,7 @@ export async function processPlusGiftStripePurchase(
     giftMessage = '',
     userAgent,
     clientIp,
+    ipCountry,
     referrer,
     fbClickId,
     fbp,
@@ -489,6 +504,7 @@ export async function processPlusGiftStripePurchase(
     paymentId,
     sessionId,
     claimToken,
+    ipCountry,
   });
 
   await sendPlusGiftPendingClaimEmail({

--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -439,6 +439,7 @@ export async function createNewPlusCheckoutSession(
     referrer,
     userAgent,
     clientIp,
+    ipCountry,
     utm,
   }: {
     from?: string,
@@ -452,6 +453,7 @@ export async function createNewPlusCheckoutSession(
     referrer?: string,
     userAgent?: string,
     clientIp?: string,
+    ipCountry?: string,
     utm?: {
       campaign?: string,
       source?: string,
@@ -531,6 +533,7 @@ export async function createNewPlusCheckoutSession(
   if (utm?.term) subscriptionMetadata.utmTerm = utm.term;
   if (userAgent) subscriptionMetadata.userAgent = userAgent;
   if (clientIp) subscriptionMetadata.clientIp = clientIp;
+  if (ipCountry) subscriptionMetadata.ipCountry = ipCountry;
   if (fbClickId) subscriptionMetadata.fbClickId = fbClickId;
   if (fbp) subscriptionMetadata.fbp = fbp.substring(0, 255);
   if (fbc) subscriptionMetadata.fbc = fbc.substring(0, 255);


### PR DESCRIPTION
Read `cf-ipcountry` (body-fallback) at Plus, Plus gift, book single, and book cart checkout routes. Forward as `ipCountry` into Stripe session/subscription metadata and persist on Firestore payment, cart, and plus-gift-cart documents.