### PR TITLE
✨ Forward browser PostHog distinct_id on checkout to stitch person graph

### DIFF
--- a/src/routes/likernft/book/purchase.ts
+++ b/src/routes/likernft/book/purchase.ts
@@ -133,6 +133,7 @@ router.post('/cart/new', jwtOptionalAuth('read:nftbook'), async (req, res, next)
       fbClickId,
       fbp,
       fbc,
+      posthogDistinctId,
       email,
       utmCampaign,
       utmSource,
@@ -256,6 +257,7 @@ router.post('/cart/new', jwtOptionalAuth('read:nftbook'), async (req, res, next)
         evmWallet: req.user?.evmWallet,
         gaClientId,
         gaSessionId,
+        posthogDistinctId,
       });
     }
   } catch (err) {
@@ -284,6 +286,7 @@ router.get(['/:classId/new', '/class/:classId/new'], jwtOptionalAuth('read:nftbo
       coupon,
       currency,
       fbclid: fbClickId = '',
+      posthog_distinct_id: posthogDistinctId = '',
       payment_method: paymentMethodQs,
       is_app: isApp,
     } = req.query;
@@ -399,6 +402,7 @@ router.get(['/:classId/new', '/class/:classId/new'], jwtOptionalAuth('read:nftbo
       evmWallet: req.user?.evmWallet,
       gaClientId: gaClientId as string,
       gaSessionId: gaSessionId as string,
+      posthogDistinctId: posthogDistinctId as string,
     });
   } catch (err) {
     if ((err as Error).message === 'OUT_OF_STOCK') {
@@ -427,6 +431,7 @@ router.post(['/:classId/new', '/class/:classId/new'], jwtOptionalAuth('read:nftb
       fbClickId,
       fbp,
       fbc,
+      posthogDistinctId,
       coupon,
       currency,
       email,
@@ -557,6 +562,7 @@ router.post(['/:classId/new', '/class/:classId/new'], jwtOptionalAuth('read:nftb
       evmWallet: req.user?.evmWallet,
       gaClientId,
       gaSessionId,
+      posthogDistinctId,
     });
   } catch (err) {
     next(err);

--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -29,6 +29,7 @@ router.post('/new', jwtAuth('write:plus'), async (req, res, next) => {
     fbClickId,
     fbp,
     fbc,
+    posthogDistinctId,
     referrer,
     utmCampaign,
     utmSource,
@@ -138,6 +139,7 @@ router.post('/new', jwtAuth('write:plus'), async (req, res, next) => {
       evmWallet: req.user?.evmWallet,
       gaClientId,
       gaSessionId,
+      posthogDistinctId,
     });
     publisher.publish(PUBSUB_TOPIC_MISC, req, {
       logType: 'PlusCheckoutSessionCreated',
@@ -182,6 +184,7 @@ router.post('/gift/new', jwtAuth('write:plus'), async (req, res, next) => {
     fbClickId,
     fbp,
     fbc,
+    posthogDistinctId,
     referrer,
     utmCampaign,
     utmSource,
@@ -272,6 +275,7 @@ router.post('/gift/new', jwtAuth('write:plus'), async (req, res, next) => {
       evmWallet: req.user?.evmWallet,
       gaClientId,
       gaSessionId,
+      posthogDistinctId,
     });
     publisher.publish(PUBSUB_TOPIC_MISC, req, {
       logType: 'PlusGiftCheckoutSessionCreated',

--- a/src/util/logServerEvents.ts
+++ b/src/util/logServerEvents.ts
@@ -23,6 +23,7 @@ export default async function logServerEvents(
     evmWallet?: string;
     gaClientId?: string;
     gaSessionId?: string;
+    posthogDistinctId?: string;
     customerType?: 'new' | 'returning';
     extraProperties?: Record<string, unknown>;
     setOnce?: Record<string, unknown>;

--- a/src/util/posthog.ts
+++ b/src/util/posthog.ts
@@ -38,6 +38,7 @@ export default function logPostHogEvents(event: ServerEventName, {
   predictedLTV,
   currency,
   paymentId,
+  posthogDistinctId,
   extraProperties,
   setOnce,
 }: {
@@ -48,6 +49,7 @@ export default function logPostHogEvents(event: ServerEventName, {
   predictedLTV?: number;
   currency?: string;
   paymentId?: string;
+  posthogDistinctId?: string;
   extraProperties?: Record<string, unknown>;
   setOnce?: Record<string, unknown>;
 }) {
@@ -65,6 +67,10 @@ export default function logPostHogEvents(event: ServerEventName, {
     return;
   }
   try {
+    // $anon_distinct_id triggers PostHog's implicit person-merge; skip when equal to avoid a no-op.
+    const anonDistinctId = posthogDistinctId && posthogDistinctId !== evmWallet
+      ? posthogDistinctId
+      : undefined;
     client.capture({
       distinctId: evmWallet,
       event: posthogEvent,
@@ -73,6 +79,7 @@ export default function logPostHogEvents(event: ServerEventName, {
         $set: email ? { email } : undefined,
         $set_once: setOnce && Object.keys(setOnce).length > 0 ? setOnce : undefined,
         $insert_id: paymentId ? `${posthogEvent}_${paymentId}` : undefined,
+        $anon_distinct_id: anonDistinctId,
         value,
         predicted_ltv: predictedLTV,
         currency,


### PR DESCRIPTION
Accept posthogDistinctId from checkout request bodies (Plus /new, Plus /gift/new, NFT book /cart/new, /:classId/new) and set $anon_distinct_id on InitiateCheckout captures. This triggers PostHog's implicit person-merge so events previously recorded under the browser's anonymous id get joined to the identified evmWallet person — closing funnel gaps when client-side identify races the server capture.

Requires: https://github.com/likecoin/3ook-com/pull/1004