### PR TITLE
🚸 Signal billing portal return so SPA can retry past_due invoices

### DIFF
--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -465,7 +465,7 @@ router.post('/portal', jwtAuth('write:plus'), async (req, res, next) => {
     }
     const session = await getStripeClient().billingPortal.sessions.create({
       customer: customerId,
-      return_url: `https://${BOOK3_HOSTNAME}/account`,
+      return_url: `https://${BOOK3_HOSTNAME}/account?action=billing-return`,
     });
 
     publisher.publish(PUBSUB_TOPIC_MISC, req, {


### PR DESCRIPTION
Append `action=billing-return` to the Stripe billing portal `return_url` so the 3ook.com /account page can detect the return trip, refresh the session, and call `/plus/retry` to pay the open invoice when the user landed in past_due. Stripe Smart Retries would eventually fire on its own schedule, but the explicit retry surfaces the reactivated state immediately after the user updates their payment method.