### PR TITLE
✨ Allow unlimited Arweave sponsor uploads for flagged accounts

### DIFF
--- a/src/routes/arweave/index.ts
+++ b/src/routes/arweave/index.ts
@@ -43,10 +43,10 @@ router.post(
     try {
       const { fileSize, ipfsHash } = req.body;
       if (!fileSize) throw new Error('MISSING_FILE_SIZE');
-      const {
-        arweaveId,
-        ETH,
-      } = await estimateUploadToArweaveV2(fileSize, ipfsHash);
+      const [{ arweaveId, ETH }, quota] = await Promise.all([
+        estimateUploadToArweaveV2(fileSize, ipfsHash),
+        req.user?.wallet ? getRemainingQuota(req.user.wallet) : Promise.resolve(null),
+      ]);
 
       publisher.publish(PUBSUB_TOPIC_MISC, req, {
         logType: 'arweaveEstimateV2',
@@ -61,16 +61,19 @@ router.post(
         evmAddress: string;
         remainingBytes?: number;
         remainingUploads?: number;
+        isUnlimited?: boolean;
       } = {
         arweaveId,
         ETH,
         memo: JSON.stringify({ ipfs: ipfsHash, fileSize }),
         evmAddress: ARWEAVE_EVM_TARGET_ADDRESS,
       };
-      if (req.user?.wallet) {
-        const quota = await getRemainingQuota(req.user.wallet);
-        result.remainingBytes = quota.remainingBytes;
-        result.remainingUploads = quota.remainingUploads;
+      if (quota) {
+        result.isUnlimited = quota.isUnlimited;
+        if (!quota.isUnlimited) {
+          result.remainingBytes = quota.remainingBytes;
+          result.remainingUploads = quota.remainingUploads;
+        }
       }
       res.json(result);
     } catch (error) {

--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -266,6 +266,7 @@ export interface NFTBookUserData {
   sponsoredUploadCount?: number;
   sponsoredUploadETH?: string;
   lastSponsoredUploadDate?: string;
+  isUnlimitedSponsoredUpload?: boolean;
   affiliateConfig?: AffiliateConfig;
   [key: string]: any;
 }

--- a/src/util/api/arweave/quota.ts
+++ b/src/util/api/arweave/quota.ts
@@ -5,12 +5,13 @@ import {
   ARWEAVE_SPONSORED_DAILY_UPLOAD_LIMIT,
   ARWEAVE_SPONSORED_DAILY_BYTES_LIMIT,
 } from '../../../../config/config';
+import type { NFTBookUserData } from '../../../types/book';
 
 function getTodayUTC(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
-function readTodayQuota(data: FirebaseFirestore.DocumentData | undefined, today: string) {
+function readTodayQuota(data: NFTBookUserData | undefined, today: string) {
   const isToday = data?.lastSponsoredUploadDate === today;
   return {
     currentBytes: isToday ? (data?.sponsoredUploadBytes || 0) : 0,
@@ -19,16 +20,26 @@ function readTodayQuota(data: FirebaseFirestore.DocumentData | undefined, today:
   };
 }
 
+function hasUnlimitedSponsoredUpload(data: NFTBookUserData | undefined): boolean {
+  return !!data?.isUnlimitedSponsoredUpload;
+}
+
 export async function getRemainingQuota(wallet: string): Promise<{
-  remainingBytes: number;
-  remainingUploads: number;
+  remainingBytes?: number;
+  remainingUploads?: number;
+  isUnlimited: boolean;
 }> {
   const doc = await likeNFTBookUserCollection.doc(wallet).get();
+  const data = doc.data();
+  if (hasUnlimitedSponsoredUpload(data)) {
+    return { isUnlimited: true };
+  }
   const today = getTodayUTC();
-  const { currentBytes, currentCount } = readTodayQuota(doc.data(), today);
+  const { currentBytes, currentCount } = readTodayQuota(data, today);
   return {
     remainingBytes: Math.max(0, ARWEAVE_SPONSORED_DAILY_BYTES_LIMIT - currentBytes),
     remainingUploads: Math.max(0, ARWEAVE_SPONSORED_DAILY_UPLOAD_LIMIT - currentCount),
+    isUnlimited: false,
   };
 }
 
@@ -48,13 +59,17 @@ export async function checkAndReserveQuota(
   const docRef = likeNFTBookUserCollection.doc(wallet);
   await db.runTransaction(async (t) => {
     const doc = await t.get(docRef);
-    const { currentBytes, currentCount, currentETH } = readTodayQuota(doc.data(), today);
+    const data = doc.data();
+    const isUnlimited = hasUnlimitedSponsoredUpload(data);
+    const { currentBytes, currentCount, currentETH } = readTodayQuota(data, today);
 
-    if (currentBytes + fileSize > ARWEAVE_SPONSORED_DAILY_BYTES_LIMIT) {
-      throw new ValidationError('DAILY_QUOTA_EXCEEDED', 403);
-    }
-    if (currentCount + 1 > ARWEAVE_SPONSORED_DAILY_UPLOAD_LIMIT) {
-      throw new ValidationError('DAILY_QUOTA_EXCEEDED', 403);
+    if (!isUnlimited) {
+      if (currentBytes + fileSize > ARWEAVE_SPONSORED_DAILY_BYTES_LIMIT) {
+        throw new ValidationError('DAILY_QUOTA_EXCEEDED', 403);
+      }
+      if (currentCount + 1 > ARWEAVE_SPONSORED_DAILY_UPLOAD_LIMIT) {
+        throw new ValidationError('DAILY_QUOTA_EXCEEDED', 403);
+      }
     }
 
     const newETH = new BigNumber(currentETH).plus(ethCostBN).toFixed();


### PR DESCRIPTION
Add isUnlimitedSponsoredUpload flag on the NFTBook user doc, set manually in Firestore, that bypasses the daily byte/count quota for special authors. Usage counters keep incrementing so analytics on VIP traffic stay intact. The /v2/estimate response surfaces an isUnlimited flag and omits the numeric remainings when unbounded.