### PR TITLE
[TAS-5743] ✨ Store buyerEmail on book purchase commissions

### DIFF
--- a/src/routes/likernft/book/user.ts
+++ b/src/routes/likernft/book/user.ts
@@ -370,7 +370,9 @@ router.get(
         const data = doc.data();
         data.id = doc.id;
         return data as BookPurchaseCommission;
-      }).map((data) => filterBookPurchaseCommission(data));
+      }).map((data) => filterBookPurchaseCommission(data, {
+        includeBuyerEmail: data.ownerWallet === wallet,
+      }));
       res.json({ commissions: list });
     } catch (err) {
       next(err);
@@ -393,7 +395,13 @@ router.get(
         .collection('commissions')
         .doc(id)
         .get();
-      res.json(filterBookPurchaseCommission(commissionDoc.data() as BookPurchaseCommission));
+      if (!commissionDoc.exists) {
+        throw new ValidationError('COMMISSION_NOT_FOUND', 404);
+      }
+      const commissionData = commissionDoc.data() as BookPurchaseCommission;
+      res.json(filterBookPurchaseCommission(commissionData, {
+        includeBuyerEmail: commissionData.ownerWallet === wallet,
+      }));
     } catch (err) {
       next(err);
     }

--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -81,6 +81,7 @@ export interface BookPurchaseCommission {
   amountTotal: number;
   amount: number;
   currency: string;
+  buyerEmail?: string;
   timestamp?: { toMillis: () => number };
 }
 

--- a/src/util/ValidationHelper.ts
+++ b/src/util/ValidationHelper.ts
@@ -381,8 +381,9 @@ export function filterBookPurchaseCommission({
   amountTotal,
   amount,
   currency,
+  buyerEmail,
   timestamp,
-}: BookPurchaseCommission): BookPurchaseCommissionFiltered {
+}: BookPurchaseCommission, { includeBuyerEmail = false } = {}): BookPurchaseCommissionFiltered {
   return {
     type,
     ownerWallet,
@@ -395,6 +396,7 @@ export function filterBookPurchaseCommission({
     amountTotal,
     amount,
     currency,
+    ...(includeBuyerEmail && buyerEmail ? { buyerEmail } : {}),
     timestamp: timestamp?.toMillis(),
   };
 }

--- a/src/util/api/likernft/book/purchase.ts
+++ b/src/util/api/likernft/book/purchase.ts
@@ -152,6 +152,7 @@ export async function handleStripeConnectedAccount({
             amountTotal,
             amount: channelCommission,
             currency,
+            ...(buyerEmail ? { buyerEmail } : {}),
             timestamp: FieldValue.serverTimestamp(),
           });
           const shouldSendNotificationEmailToChannel = !isOwner
@@ -246,6 +247,7 @@ export async function handleStripeConnectedAccount({
               amountTotal,
               amount: amountSplit,
               currency,
+              ...(buyerEmail ? { buyerEmail } : {}),
               timestamp: FieldValue.serverTimestamp(),
             });
             const likerUserInfo = await getUserWithCivicLikerPropertiesByWallet(wallet);
@@ -314,6 +316,7 @@ export async function handleStripeConnectedAccount({
           amountTotal,
           amount: likerLandArtFee,
           currency,
+          ...(buyerEmail ? { buyerEmail } : {}),
           timestamp: FieldValue.serverTimestamp(),
         });
       } catch (e) {


### PR DESCRIPTION
Persist the buyer's email on every commission doc at write time so it can be surfaced in the publish backend's sales report alongside the existing per-book purchase view.