### PR TITLE
🚸 Issue fresh Intercom token from /users/profile

### DIFF
--- a/src/routes/users/apiGetInfo.ts
+++ b/src/routes/users/apiGetInfo.ts
@@ -6,6 +6,7 @@ import {
 import {
   getUserWithCivicLikerProperties,
 } from '../../util/api/users/getPublicInfo';
+import { createIntercomTokenForUser } from '../../util/intercom';
 
 const router = Router();
 
@@ -19,7 +20,17 @@ router.get('/profile', jwtAuth('profile'), async (req, res, next) => {
     const payload = await getUserWithCivicLikerProperties(username);
     if (payload) {
       const scopes = (req.user.scope || []).concat(req.user.permissions || []);
-      res.json(filterUserDataScoped(payload, scopes));
+      const filteredPayload = filterUserDataScoped(payload, scopes);
+      // Rotate the Intercom JWT on every profile fetch so it never outlives
+      // its 1d lifetime in long-lived web sessions. Mint from the filtered
+      // payload so scope-gated fields (e.g. email) don't leak through the
+      // JWT's base64-readable claims to clients without that scope.
+      const intercomToken = createIntercomTokenForUser({
+        user: filteredPayload.user,
+        email: filteredPayload.email,
+        evmWallet: filteredPayload.evmWallet,
+      });
+      res.json({ ...filteredPayload, intercomToken });
     } else {
       res.sendStatus(404);
     }

--- a/src/routes/wallet/index.ts
+++ b/src/routes/wallet/index.ts
@@ -18,7 +18,7 @@ import publisher from '../../util/gcloudPub';
 import { PUBSUB_TOPIC_MISC } from '../../constant';
 import { checkAddressValid, checkCosmosAddressValid } from '../../util/ValidationHelper';
 import { verifyEmailByMagicDIDToken } from '../../util/magic';
-import { createIntercomToken } from '../../util/intercom';
+import { createIntercomTokenForUser } from '../../util/intercom';
 
 const router = Router();
 
@@ -80,10 +80,10 @@ router.post('/authorize', async (req, res, next) => {
     });
     let intercomToken: string | undefined;
     if (likerIdInfo) {
-      intercomToken = createIntercomToken({
-        user_id: likerIdInfo.user,
+      intercomToken = createIntercomTokenForUser({
+        user: likerIdInfo.user,
         email: likerIdInfo.email,
-        evm_wallet: payload.evmWallet,
+        evmWallet: payload.evmWallet,
       });
     }
 

--- a/src/util/intercom.ts
+++ b/src/util/intercom.ts
@@ -34,6 +34,24 @@ export function createIntercomToken(payload: JwtPayload): string | undefined {
   return jwt.sign(payload, INTERCOM_API_SECRET, { expiresIn: '1d' });
 }
 
+// Intercom Identity Verification expects snake_case payload keys; centralize
+// the camelCase → snake_case mapping so call sites can't drift.
+export function createIntercomTokenForUser({
+  user,
+  email,
+  evmWallet,
+}: {
+  user: string;
+  email?: string;
+  evmWallet?: string;
+}): string | undefined {
+  return createIntercomToken({
+    user_id: user,
+    email,
+    evm_wallet: evmWallet,
+  });
+}
+
 async function findIntercomLeadByEmail(
   email: string,
 ): Promise<Contact | null> {


### PR DESCRIPTION
Sessions are long-lived (30d wallet JWT) but the Intercom Identity Verification JWT is only 1d, so rotation has to happen mid-session. Mint a fresh token alongside the profile response and extract a createIntercomTokenForUser helper to centralize the snake_case payload mapping shared with /wallet/authorize.