### PR TITLE
🐛 Emit deterministic uuid on transactional events for cross-source dedup

### DIFF
--- a/src/util/posthog.ts
+++ b/src/util/posthog.ts
@@ -1,4 +1,5 @@
 import { PostHog } from 'posthog-node';
+import uuidv5 from 'uuid/v5';
 
 import {
   POSTHOG_API_KEY,
@@ -6,6 +7,25 @@ import {
 } from '../../config/config';
 import { SERVER_EVENT_MAP, buildItemId } from './analyticsEvents';
 import type { ServerEventName, AnalyticsItem } from './analyticsEvents';
+
+// Browser fires the same business events (purchase, start_trial, subscribe, begin_checkout)
+// from the corresponding success page in liker-land-v3. Both sides build the same URL
+// string and hash it under RFC 4122 NAMESPACE_URL to get a deterministic uuidv5, which is
+// passed as the event uuid. PostHog's ClickHouse dedup tuple (timestamp, distinct_id,
+// event, uuid) then collapses the pair into one row. The matching helper lives in
+// liker-land-v3/composables/use-logger.ts; the URL format below is the contract.
+//
+// The uuid is derived from the POST-MAPPING event name (`posthogEvent`, see capture call
+// below), NOT the internal `ServerEventName`. The browser passes the raw PostHog event
+// name (e.g. 'subscribe'), so we must match that side. Renaming a SERVER_EVENT_MAP value
+// without updating the browser would silently break dedup.
+const NAMESPACE_URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8'; // RFC 4122 appendix C
+
+// The host must be a fixed literal: substituting BOOK3_HOSTNAME or any other env-aware
+// hostname constant would flip between testnet/mainnet and silently break dedup.
+function derivePostHogEventUUID(eventName: string, transactionId: string): string {
+  return uuidv5(`https://3ook.com/posthog-dedup/${eventName}/${transactionId}`, NAMESPACE_URL);
+}
 
 let posthogClient: PostHog | null = null;
 
@@ -74,6 +94,9 @@ export default function logPostHogEvents(event: ServerEventName, {
     client.capture({
       distinctId: evmWallet,
       event: posthogEvent,
+      uuid: typeof paymentId === 'string' && paymentId
+        ? derivePostHogEventUUID(posthogEvent, paymentId)
+        : undefined,
       properties: {
         ...extraProperties,
         $set: email ? { email } : undefined,


### PR DESCRIPTION
Pair with liker-land-v3's matching capture: the browser fires the same purchase/start_trial/subscribe/begin_checkout events from success pages after a user action. Both sides now build the same URL (`https://3ook.com/posthog-dedup/${posthogEvent}/${paymentId}`) and hash it under RFC 4122 NAMESPACE_URL to get a deterministic uuidv5, which is passed as the event uuid. PostHog's ClickHouse dedup tuple (timestamp, distinct_id, event, uuid) then collapses the pair into a single row. `$insert_id` is kept alongside as the ingest-layer belt to the new uuid's ClickHouse-layer suspenders.

The browser keys on the post-mapping event name, so the URL here must also use `posthogEvent` (after SERVER_EVENT_MAP), not the internal ServerEventName. Renaming a SERVER_EVENT_MAP value without updating liker-land-v3 will silently break dedup.