### PR TITLE
✨ Allow affiliate opt-in to share Plus 20% discount on @likerId links

### DIFF
--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -426,9 +426,11 @@ router.get('/affiliate/:likerId', async (req, res, next) => {
       throw new ValidationError('Invalid likerId', 400);
     }
     const userInfo = await getBookUserInfoFromLikerId(normalizedLikerId);
-    const affiliateConfig = userInfo?.bookUserInfo?.affiliateConfig;
+    const bookUserInfo = userInfo?.bookUserInfo;
+    const affiliateConfig = bookUserInfo?.affiliateConfig;
+    const isPlusDiscountAllowed = !!bookUserInfo?.isPlusDiscountAllowed;
     if (!affiliateConfig?.active) {
-      res.json({ active: false });
+      res.json({ active: false, isPlusDiscountAllowed });
       return;
     }
     res.json({
@@ -437,6 +439,7 @@ router.get('/affiliate/:likerId', async (req, res, next) => {
       giftClassId: affiliateConfig.giftClassId,
       giftPriceIndex: affiliateConfig.giftPriceIndex || 0,
       giftOnTrial: !!affiliateConfig.giftOnTrial,
+      isPlusDiscountAllowed,
       customVoices: (affiliateConfig.customVoices || []).map((v) => ({
         id: v.id,
         name: v.name,

--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -269,6 +269,12 @@ export interface NFTBookUserData {
   lastSponsoredUploadDate?: string;
   isUnlimitedSponsoredUpload?: boolean;
   affiliateConfig?: AffiliateConfig;
+  /** When true, Plus members arriving via this user's `from=@likerId`
+   *  channel still receive the 20% Plus discount; the 30% channel share
+   *  absorbs the discount cost via the existing commission math in
+   *  `calculateItemPrices`. Lives at the user-doc root because channel
+   *  commission flows from `from` regardless of `affiliateConfig.active`. */
+  isPlusDiscountAllowed?: boolean;
   [key: string]: any;
 }
 

--- a/src/util/api/likernft/book/cart.ts
+++ b/src/util/api/likernft/book/cart.ts
@@ -52,7 +52,8 @@ import {
   sendPlusBookPromoCodeEmail,
 } from '../../../ses';
 import logServerEvents from '../../../logServerEvents';
-import { getBookUserInfoFromWallet } from './user';
+import { getBookUserInfoFromWallet, getBookUserInfoFromLikerId } from './user';
+import { normalizeLikerId } from '../../../ValidationHelper';
 import {
   SLACK_OUT_OF_STOCK_NOTIFICATION_THRESHOLD,
   LIKER_PLUS_20_COUPON_ID,
@@ -1535,16 +1536,43 @@ export async function handleNewCartStripeCheckout(inputItems: CartItem[], {
     customerId = bookUserInfo?.stripeCustomerId;
     customerEmail = isEmailVerified ? userEmail : email;
 
-    if (isLikerPlus && checkIsFromLikerLand(from) && !coupon) {
-      couponId = LIKER_PLUS_20_COUPON_ID;
-      items = items.map((item) => ({
-        ...item,
-        from: undefined,
-      }));
-      itemInfos = itemInfos.map((item) => ({
-        ...item,
-        from: undefined,
-      }));
+    if (isLikerPlus && !coupon) {
+      let shouldApplyPlusDiscount = false;
+      let shouldClearFrom = false;
+      if (checkIsFromLikerLand(from)) {
+        // Default Liker Land channel: no real affiliate to pay — apply the
+        // discount and clear `from` so commission stays at zero.
+        shouldApplyPlusDiscount = true;
+        shouldClearFrom = true;
+      } else if (from && from.startsWith('@')) {
+        // Affiliate link: only honor the Plus discount if the affiliate has
+        // opted in. Keep `from` so the 30% channel commission still flows,
+        // reduced by the discount via calculateItemPrices' existing math.
+        try {
+          const affiliateUserInfo = await getBookUserInfoFromLikerId(
+            normalizeLikerId(from),
+          );
+          if (affiliateUserInfo?.bookUserInfo?.isPlusDiscountAllowed) {
+            shouldApplyPlusDiscount = true;
+          }
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn('Failed to resolve affiliate Plus-discount flag:', err);
+        }
+      }
+      if (shouldApplyPlusDiscount) {
+        couponId = LIKER_PLUS_20_COUPON_ID;
+        if (shouldClearFrom) {
+          items = items.map((item) => ({
+            ...item,
+            from: undefined,
+          }));
+          itemInfos = itemInfos.map((item) => ({
+            ...item,
+            from: undefined,
+          }));
+        }
+      }
     }
   }
   const paymentId = uuidv4();


### PR DESCRIPTION
Plus members arriving via `?from=@likerId` previously lost their 20% discount so the affiliate could earn the 30% channel commission. With the new `isPlusDiscountAllowed` flag (stored at the `NFTBookUserData` root because channel commission flows from `from` regardless of `affiliateConfig.active`), opted-in affiliates now let the discount apply while keeping `from` set — `calculateItemPrices` already deducts the discount from the channel commission, so the affiliate's 30% share absorbs the cost automatically.

Default is false, so existing affiliate links keep current behavior. The flag is admin-set in Firestore for now (no self-serve endpoint yet).