### PR TITLE
[TAS-5745] ✨ Persist isPlusReadingEnabled on book listings

### DIFF
--- a/src/routes/likernft/book/store.ts
+++ b/src/routes/likernft/book/store.ts
@@ -489,6 +489,7 @@ router.post(['/:classId/new', '/class/:classId/new'], jwtAuth('write:nftbook'), 
       enableCustomMessagePage = false,
       tableOfContents,
       isAdultOnly = false,
+      isPlusReadingEnabled = false,
     } = req.body;
 
     let ownerWallet = '';
@@ -542,6 +543,7 @@ router.post(['/:classId/new', '/class/:classId/new'], jwtAuth('write:nftbook'), 
       hideAudio,
       hideUpsell,
       isAdultOnly,
+      isPlusReadingEnabled,
 
       // From ISCN content metadata
       inLanguage,
@@ -646,6 +648,7 @@ router.post(['/:classId/new', '/class/:classId/new'], jwtAuth('write:nftbook'), 
       hideUpsell,
       enableCustomMessagePage,
       isAdultOnly,
+      isPlusReadingEnabled,
       totalPrices: prices.length,
       autoDeliverTotalStock,
       manualDeliverTotalStock,
@@ -679,6 +682,7 @@ router.post(['/:classId/settings', '/class/:classId/settings'], jwtAuth('write:n
       enableCustomMessagePage,
       tableOfContents,
       isAdultOnly,
+      isPlusReadingEnabled,
     } = req.body;
     const bookInfo = await getNftBookInfo(classId);
     if (!bookInfo) throw new ValidationError('CLASS_ID_NOT_FOUND', 404);
@@ -698,6 +702,7 @@ router.post(['/:classId/settings', '/class/:classId/settings'], jwtAuth('write:n
       enableCustomMessagePage,
       tableOfContents,
       isAdultOnly,
+      isPlusReadingEnabled,
     });
 
     publisher.publish(PUBSUB_TOPIC_MISC, req, {
@@ -710,6 +715,7 @@ router.post(['/:classId/settings', '/class/:classId/settings'], jwtAuth('write:n
       hideUpsell,
       enableCustomMessagePage,
       isAdultOnly,
+      isPlusReadingEnabled,
       moderatorWalletCount: moderatorWallets ? moderatorWallets.length : 0,
       connectedWalletCount: connectedWallets ? connectedWallets.length : 0,
     });

--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -176,6 +176,7 @@ export interface NFTBookListingInfo {
   isApprovedForAds?: boolean;
   approvalStatus?: string;
   plusPromoEnabled?: boolean;
+  isPlusReadingEnabled?: boolean;
   successUrl?: string;
   cancelUrl?: string;
 }
@@ -228,6 +229,7 @@ export interface NFTBookListingInfoFiltered {
   isApprovedForAds: boolean;
   approvalStatus?: string;
   plusPromoEnabled?: boolean;
+  isPlusReadingEnabled?: boolean;
 }
 
 export interface AffiliateCustomVoice {

--- a/src/util/ValidationHelper.ts
+++ b/src/util/ValidationHelper.ts
@@ -628,6 +628,7 @@ export function filterNFTBookListingInfo(
     isApprovedForAds,
     approvalStatus,
     plusPromoEnabled,
+    isPlusReadingEnabled = false,
   } = bookInfo;
   const { stock, sold, prices } = filterNFTBookPricesInfo(inputPrices, isOwner);
   const id = inputId || classId;
@@ -675,6 +676,7 @@ export function filterNFTBookListingInfo(
     isApprovedForIndexing: isApprovedForIndexing !== undefined ? isApprovedForIndexing : true,
     isApprovedForAds: isApprovedForAds !== undefined ? isApprovedForAds : true,
     plusPromoEnabled,
+    isPlusReadingEnabled,
   };
   if (isOwner) {
     payload.sold = sold;

--- a/src/util/api/likernft/book/index.ts
+++ b/src/util/api/likernft/book/index.ts
@@ -267,6 +267,7 @@ export async function newNftBookInfo(
 
     image,
     isAdultOnly,
+    isPlusReadingEnabled,
   } = data;
   const previewContent = getPreviewContentFromHasPart(hasPart);
 
@@ -327,6 +328,7 @@ export async function newNftBookInfo(
   if (signedMessageText !== undefined) payload.signedMessageText = signedMessageText;
   if (tableOfContents) payload.tableOfContents = tableOfContents;
   if (isAdultOnly !== undefined) payload.isAdultOnly = isAdultOnly;
+  if (isPlusReadingEnabled !== undefined) payload.isPlusReadingEnabled = isPlusReadingEnabled;
   await likeNFTBookCollection.doc(classId).create(payload);
   return {
     isAutoApproved: isTrustedPublisher,
@@ -457,6 +459,7 @@ export async function updateNftBookInfo(classId: string, {
   signedMessageText,
   tableOfContents,
   isAdultOnly,
+  isPlusReadingEnabled,
 }: {
   prices?: NFTBookPrice[];
   moderatorWallets?: string[];
@@ -470,6 +473,7 @@ export async function updateNftBookInfo(classId: string, {
   signedMessageText?: string;
   tableOfContents?: string;
   isAdultOnly?: boolean;
+  isPlusReadingEnabled?: boolean;
 } = {}) {
   const timestamp = FieldValue.serverTimestamp();
   const payload: any = {
@@ -496,6 +500,7 @@ export async function updateNftBookInfo(classId: string, {
     payload.isAdultOnly = isAdultOnly;
     if (isAdultOnly) { payload.isApprovedForAds = false; }
   }
+  if (isPlusReadingEnabled !== undefined) { payload.isPlusReadingEnabled = isPlusReadingEnabled; }
   await likeNFTBookCollection.doc(classId).update(payload);
   await syncNFTBookInfoWithISCN(classId);
 }


### PR DESCRIPTION
Publishers opt their books into Plus all-you-can-read so subscribers get free reads and authors earn from reading-time rev share. Threaded through the listing type, filter, create/update helpers, and the POST /new and /settings routes; legacy listings without the field surface as false.