### PR TITLE
🐛 Tag book Purchase event with actual Stripe currency

### DIFF
--- a/src/util/api/likernft/book/cart.ts
+++ b/src/util/api/likernft/book/cart.ts
@@ -787,7 +787,7 @@ export async function processNFTBookCart(
       userAgent,
       clientIp,
       value: (amountTotal || 0) / 100,
-      currency: 'USD',
+      currency: (session?.currency || 'usd').toUpperCase(),
       paymentId,
       referrer,
       fbClickId,


### PR DESCRIPTION
The cart Purchase analytics event hardcoded currency:'USD' while value came from session.amount_total (the real settlement currency, often HKD), inflating/mislabeling revenue in PostHog/Meta. Use the session currency, matching the existing pattern in plus/gift.ts.