### PR TITLE
[TAS-5820] ✨ Let affiliates offer a gift book list for Plus subscribers to pick

### DIFF
--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -436,8 +436,10 @@ router.get('/affiliate/:likerId', async (req, res, next) => {
     res.json({
       active: true,
       affiliateClassIds: affiliateConfig.affiliateClassIds || [],
-      giftClassId: affiliateConfig.giftClassId,
-      giftPriceIndex: affiliateConfig.giftPriceIndex || 0,
+      giftBooks: (affiliateConfig.giftBooks || []).map((b) => ({
+        classId: b.classId,
+        priceIndex: b.priceIndex || 0,
+      })),
       giftOnTrial: !!affiliateConfig.giftOnTrial,
       isPlusDiscountAllowed,
       customVoices: (affiliateConfig.customVoices || []).map((v) => ({

--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -240,15 +240,20 @@ export interface AffiliateCustomVoice {
   providerVoiceId: string;
 }
 
+export interface AffiliateGiftBook {
+  classId: string;
+  priceIndex: number;
+}
+
 export interface AffiliateConfig {
   active: boolean;
   /** Book classes where this affiliate's custom voices can be used.
-   *  Must include `giftClassId` when set. */
+   *  Must include every `giftBooks[].classId`. */
   affiliateClassIds: string[];
-  /** The class currently being gifted at checkout; must be a member of
+  /** The list of books offered as a yearly-subscription gift; the subscriber
+   *  picks one at checkout. Each `classId` must be a member of
    *  `affiliateClassIds`. */
-  giftClassId?: string;
-  giftPriceIndex: number;
+  giftBooks?: AffiliateGiftBook[];
   giftOnTrial: boolean;
   customVoices: AffiliateCustomVoice[];
 }

--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -509,10 +509,23 @@ export async function createNewPlusCheckoutSession(
           : null;
         if (affiliateConfig) {
           subscriptionMetadata.affiliateFrom = from;
-          if (!giftClassId && affiliateConfig.giftClassId && period === 'yearly') {
-            resolvedGiftClassId = affiliateConfig.giftClassId;
-            resolvedGiftPriceIndex = String(affiliateConfig.giftPriceIndex || 0);
-            subscriptionMetadata.affiliateGiftOnTrial = affiliateConfig.giftOnTrial ? 'true' : 'false';
+          const giftBooks = affiliateConfig.giftBooks || [];
+          if (giftBooks.length && period === 'yearly') {
+            // No pick defaults to the first book so plain affiliate links still
+            // grant a gift. An explicit `giftClassId` outside the list stays
+            // untouched, keeping the non-affiliate gift flow (upsell
+            // "subscribe to get this book") working.
+            const chosen = giftClassId
+              ? giftBooks.find((b) => b.classId === giftClassId)
+              : giftBooks[0];
+            if (chosen) {
+              // priceIndex is from the affiliate config, never the client —
+              // the gift is free, so a client-supplied index is pure attack
+              // surface.
+              resolvedGiftClassId = chosen.classId;
+              resolvedGiftPriceIndex = String(chosen.priceIndex || 0);
+              subscriptionMetadata.affiliateGiftOnTrial = affiliateConfig.giftOnTrial ? 'true' : 'false';
+            }
           }
         }
       }


### PR DESCRIPTION
AffiliateConfig.giftClassId/giftPriceIndex become a giftBooks [{ classId, priceIndex }] list so a yearly subscriber can choose one book as their gift. /plus/affiliate/:likerId returns the list, and checkout resolves the subscriber's pick against it — defaulting to the first book for plain affiliate links and leaving an explicit out-of-list giftClassId untouched so the upsell self-gift flow keeps working. priceIndex is always taken from the affiliate config, never the client. No legacy fallback: existing single-value configs must be re-saved as giftBooks.