### PR TITLE
✨ Support per-currency book price overrides (HKD/TWD)

### DIFF
--- a/src/routes/likernft/book/store.ts
+++ b/src/routes/likernft/book/store.ts
@@ -35,7 +35,7 @@ import { getStripeClient } from '../../../util/stripe';
 import { filterNFTBookListingInfo, filterNFTBookPricesInfo } from '../../../util/ValidationHelper';
 import type { NFTBookListingInfo, NFTBookPrice } from '../../../types/book';
 import { uploadImageBufferToCache } from '../../../util/fileupload';
-import { convertUSDPriceToCurrency } from '../../../util/pricing';
+import { BOOK_PRICE_OVERRIDE_CURRENCIES, getStripeCurrencyOptionsFromNFTBookPrice } from '../../../util/pricing';
 import { normalizeClassIdParam } from '../../../middleware/likernft';
 
 const router = Router();
@@ -315,6 +315,14 @@ router.put(['/:classId/price/:priceIndex', '/class/:classId/price/:priceIndex'],
       ...oldPriceInfo,
       ...formatPriceInfo(price),
     };
+    // formatPriceInfo only sets priceInDecimalByCurrency when present, so the
+    // spread above would otherwise retain a stale override when the caller
+    // clears it. Reconcile against the validated value (undefined = cleared).
+    if (price.priceInDecimalByCurrency) {
+      newPriceInfo.priceInDecimalByCurrency = price.priceInDecimalByCurrency;
+    } else {
+      delete newPriceInfo.priceInDecimalByCurrency;
+    }
 
     if (oldPriceInfo.stripeProductId) {
       const stripe = getStripeClient();
@@ -325,19 +333,21 @@ router.put(['/:classId/price/:priceIndex', '/class/:classId/price/:priceIndex'],
         metadata,
       });
       if (oldPriceInfo.stripePriceId) {
-        if (oldPriceInfo.priceInDecimal !== newPriceInfo.priceInDecimal) {
+        const oldCurrencyOverride = oldPriceInfo.priceInDecimalByCurrency || {};
+        const newCurrencyOverride = newPriceInfo.priceInDecimalByCurrency || {};
+        const isCurrencyOverrideChanged = BOOK_PRICE_OVERRIDE_CURRENCIES.some(
+          (currency) => oldCurrencyOverride[currency] !== newCurrencyOverride[currency],
+        );
+        if (oldPriceInfo.priceInDecimal !== newPriceInfo.priceInDecimal
+          || isCurrencyOverrideChanged) {
           const newStripePrice = await stripe.prices.create({
             product: oldPriceInfo.stripeProductId,
             currency: 'usd',
             unit_amount: price.priceInDecimal,
-            currency_options: {
-              twd: {
-                unit_amount: convertUSDPriceToCurrency(price.priceInDecimal / 100, 'twd') * 100,
-              },
-              hkd: {
-                unit_amount: convertUSDPriceToCurrency(price.priceInDecimal / 100, 'hkd') * 100,
-              },
-            },
+            currency_options: getStripeCurrencyOptionsFromNFTBookPrice(
+              price.priceInDecimal,
+              newPriceInfo.priceInDecimalByCurrency,
+            ),
           });
           await stripe.products.update(
             oldPriceInfo.stripeProductId,

--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -89,10 +89,19 @@ export interface BookPurchaseCommissionFiltered extends Omit<BookPurchaseCommiss
   timestamp?: number;
 }
 
+// Per-currency price overrides, in that currency's minor units (e.g. cents),
+// matching the convention of `priceInDecimal`. A missing currency falls back
+// to the index-based ladder conversion.
+export interface BookPriceInDecimalByCurrency {
+  hkd?: number;
+  twd?: number;
+}
+
 export interface NFTBookPrice {
   name?: string | Record<string, string>;
   description?: string | Record<string, string>;
   priceInDecimal: number;
+  priceInDecimalByCurrency?: BookPriceInDecimalByCurrency;
   isAllowCustomPrice?: boolean;
   isTippingEnabled?: boolean;
   isUnlisted?: boolean;
@@ -109,6 +118,7 @@ export interface NFTBookPrice {
 export interface NFTBookPriceFiltered {
   index: number;
   price: number;
+  priceInDecimalByCurrency?: BookPriceInDecimalByCurrency;
   name?: string | Record<string, string>;
   description?: string | Record<string, string>;
   stock: number;

--- a/src/util/ValidationHelper.ts
+++ b/src/util/ValidationHelper.ts
@@ -538,6 +538,7 @@ export function filterNFTBookPricesInfo(
       name,
       description,
       priceInDecimal,
+      priceInDecimalByCurrency,
       isAllowCustomPrice,
       isTippingEnabled,
       isUnlisted,
@@ -563,6 +564,7 @@ export function filterNFTBookPricesInfo(
       isTippingEnabled: !priceInDecimal || isTippingEnabled,
       order: order ?? index,
     };
+    if (priceInDecimalByCurrency) payload.priceInDecimalByCurrency = priceInDecimalByCurrency;
     if (isOwner) {
       payload.sold = pSold;
       payload.stock = pStock;

--- a/src/util/api/likernft/book/cart.ts
+++ b/src/util/api/likernft/book/cart.ts
@@ -1214,6 +1214,7 @@ export async function formatCartItemsWithInfo(items: CartItem[]) {
       const priceData = prices[priceIndex];
       const {
         priceInDecimal: originalPriceInDecimal,
+        priceInDecimalByCurrency,
         stock,
         isAllowCustomPrice,
         name: priceNameObj,
@@ -1236,6 +1237,7 @@ export async function formatCartItemsWithInfo(items: CartItem[]) {
       info = {
         stock,
         isAllowCustomPrice,
+        priceInDecimalByCurrency,
         name,
         description,
         images,
@@ -1258,6 +1260,7 @@ export async function formatCartItemsWithInfo(items: CartItem[]) {
     } = info;
     const {
       isAllowCustomPrice,
+      priceInDecimalByCurrency,
       originalPriceInDecimal,
       stock,
       images,
@@ -1296,6 +1299,7 @@ export async function formatCartItemsWithInfo(items: CartItem[]) {
       ...item,
       priceName,
       priceInDecimal,
+      priceInDecimalByCurrency,
       customPriceDiffInDecimal,
       stock,
       isAllowCustomPrice,

--- a/src/util/api/likernft/book/index.ts
+++ b/src/util/api/likernft/book/index.ts
@@ -28,8 +28,8 @@ import { parseImageURLFromMetadata } from '../metadata';
 import { getBook3NFTClassPageURL } from '../../../liker-land';
 import { updateAirtablePublicationRecord } from '../../../airtable';
 import { checkIsTrustedPublisher } from './user';
-import type { NFTBookListingInfo, NFTBookPrice } from '../../../../types/book';
-import { convertUSDPriceToCurrency } from '../../../pricing';
+import type { BookPriceInDecimalByCurrency, NFTBookListingInfo, NFTBookPrice } from '../../../../types/book';
+import { BOOK_PRICE_OVERRIDE_CURRENCIES, getStripeCurrencyOptionsFromNFTBookPrice } from '../../../pricing';
 
 export function getAuthorNameFromMetadata(author: unknown): string {
   if (typeof author === 'string') {
@@ -164,6 +164,7 @@ export function formatPriceInfo(price: NFTBookPrice): NFTBookPrice {
     name: nameInput,
     description: descriptionInput,
     priceInDecimal,
+    priceInDecimalByCurrency,
     isAllowCustomPrice = false,
     stock,
     isAutoDeliver = false,
@@ -176,7 +177,7 @@ export function formatPriceInfo(price: NFTBookPrice): NFTBookPrice {
     if (nameInput) name[locale] = nameInput[locale];
     if (descriptionInput) description[locale] = descriptionInput[locale];
   });
-  return {
+  const formatted: NFTBookPrice = {
     name,
     description,
     priceInDecimal,
@@ -186,6 +187,8 @@ export function formatPriceInfo(price: NFTBookPrice): NFTBookPrice {
     isUnlisted,
     autoMemo,
   };
+  if (priceInDecimalByCurrency) formatted.priceInDecimalByCurrency = priceInDecimalByCurrency;
+  return formatted;
 }
 
 export async function createStripeProductFromNFTBookPrice(classId: string, priceIndex: number, {
@@ -212,14 +215,10 @@ export async function createStripeProductFromNFTBookPrice(classId: string, price
     default_price_data: {
       currency: 'usd',
       unit_amount: price.priceInDecimal,
-      currency_options: {
-        twd: {
-          unit_amount: convertUSDPriceToCurrency(price.priceInDecimal / 100, 'twd') * 100,
-        },
-        hkd: {
-          unit_amount: convertUSDPriceToCurrency(price.priceInDecimal / 100, 'hkd') * 100,
-        },
-      },
+      currency_options: getStripeCurrencyOptionsFromNFTBookPrice(
+        price.priceInDecimal,
+        price.priceInDecimalByCurrency,
+      ),
     },
     url: getBook3NFTClassPageURL({ classId, priceIndex }),
     metadata,
@@ -571,6 +570,7 @@ export function validatePrice(price: NFTBookPrice) {
     isAutoDeliver,
     isUnlisted,
     priceInDecimal,
+    priceInDecimalByCurrency: priceInDecimalByCurrencyInput,
   } = price;
   if (!(
     typeof priceInDecimal === 'number'
@@ -578,6 +578,22 @@ export function validatePrice(price: NFTBookPrice) {
     && (priceInDecimal === 0 || priceInDecimal >= MIN_BOOK_PRICE_DECIMAL)
   )) {
     throw new ValidationError('INVALID_PRICE');
+  }
+  let priceInDecimalByCurrency: BookPriceInDecimalByCurrency | undefined;
+  if (priceInDecimalByCurrencyInput !== undefined) {
+    if (typeof priceInDecimalByCurrencyInput !== 'object' || priceInDecimalByCurrencyInput === null) {
+      throw new ValidationError('INVALID_PRICE_CURRENCY_OVERRIDE');
+    }
+    const override: BookPriceInDecimalByCurrency = {};
+    BOOK_PRICE_OVERRIDE_CURRENCIES.forEach((currency) => {
+      const value = priceInDecimalByCurrencyInput[currency];
+      if (value === undefined) return;
+      if (!(typeof value === 'number' && Number.isInteger(value) && value >= 0)) {
+        throw new ValidationError('INVALID_PRICE_CURRENCY_OVERRIDE');
+      }
+      override[currency] = value;
+    });
+    if (Object.keys(override).length) priceInDecimalByCurrency = override;
   }
   if (!(typeof stock === 'number' && stock >= 0)) {
     throw new ValidationError('INVALID_PRICE_STOCK');
@@ -594,6 +610,7 @@ export function validatePrice(price: NFTBookPrice) {
     autoMemo,
     order,
     priceInDecimal,
+    priceInDecimalByCurrency,
     stock,
     name,
     description,

--- a/src/util/api/likernft/book/purchase.ts
+++ b/src/util/api/likernft/book/purchase.ts
@@ -39,7 +39,7 @@ import { CartItemWithInfo, TransactionFeeInfo } from './type';
 import {
   getClassCurrentTokenId, isEVMClassId, mintNFT, triggerNFTIndexerUpdate,
 } from '../../../evm/nft';
-import { convertUSDPriceToCurrency } from '../../../pricing';
+import { getCurrencyPriceInDecimal } from '../../../pricing';
 import { checkIsFromLikerLand, calculateItemPrices } from './price';
 
 // Re-export pure functions for backward compatibility
@@ -694,10 +694,11 @@ export async function formatStripeCheckoutSession({
             images: item.images,
             metadata: productMetadata,
           },
-          unit_amount: convertUSDPriceToCurrency(
-            item.originalPriceInDecimal / 100,
+          unit_amount: getCurrencyPriceInDecimal(
+            item.originalPriceInDecimal,
             currencyWithDefault,
-          ) * 100,
+            item.priceInDecimalByCurrency,
+          ),
         },
         adjustable_quantity: {
           enabled: false,
@@ -706,10 +707,10 @@ export async function formatStripeCheckoutSession({
       });
     }
     if (item.customPriceDiffInDecimal) {
-      const convertedPriceDiffInDecimal = convertUSDPriceToCurrency(
-        item.customPriceDiffInDecimal / 100,
+      const convertedPriceDiffInDecimal = getCurrencyPriceInDecimal(
+        item.customPriceDiffInDecimal,
         currencyWithDefault,
-      ) * 100;
+      );
       lineItems.push({
         price_data: {
           currency: currencyWithDefault,

--- a/src/util/api/likernft/book/type.ts
+++ b/src/util/api/likernft/book/type.ts
@@ -1,3 +1,5 @@
+import type { BookPriceInDecimalByCurrency } from '../../../../types/book';
+
 export type CartItem = {
   classId?: string
   priceIndex?: number
@@ -12,6 +14,7 @@ export type CartItemWithInfo = CartItem & {
   customPriceDiffInDecimal: number;
   stock: number;
   isAllowCustomPrice: boolean;
+  priceInDecimalByCurrency?: BookPriceInDecimalByCurrency;
   name: string,
   description: string,
   images: string[],

--- a/src/util/pricing.ts
+++ b/src/util/pricing.ts
@@ -1,5 +1,6 @@
 import { USD_PRICE_TIER_LIST, HKD_PRICE_TIER_LIST, TWD_PRICE_TIER_LIST } from '../constant/pricing';
 import type { SupportedPlusCurrency } from '../constant';
+import type { BookPriceInDecimalByCurrency } from '../types/book';
 
 const MAX_USD = USD_PRICE_TIER_LIST[USD_PRICE_TIER_LIST.length - 1]!;
 const MAX_HKD = HKD_PRICE_TIER_LIST[HKD_PRICE_TIER_LIST.length - 1]!;
@@ -28,6 +29,48 @@ export function convertUSDPriceToCurrency(price: number, currency: SupportedPlus
     default:
       return price;
   }
+}
+
+// Currencies whose book price can be overridden away from the ladder. USD is
+// excluded by design: it is the stored `priceInDecimal` and the commission base.
+export const BOOK_PRICE_OVERRIDE_CURRENCIES = ['hkd', 'twd'] as const;
+
+/**
+ * Resolves the charge amount (in minor units, e.g. cents) for a given currency.
+ *
+ * USD always uses the stored `usdPriceInDecimal` (the commission base). For
+ * HKD/TWD, an explicit per-book override on the price tier takes precedence
+ * over the index-based ladder conversion; this is how operations can offer a
+ * bespoke off-ladder TWD price without polluting the global price ladder.
+ */
+export function getCurrencyPriceInDecimal(
+  usdPriceInDecimal: number,
+  currency: SupportedPlusCurrency,
+  priceInDecimalByCurrency?: BookPriceInDecimalByCurrency,
+): number {
+  if (currency === 'usd') return usdPriceInDecimal;
+  const override = priceInDecimalByCurrency?.[currency];
+  if (typeof override === 'number' && override > 0) return override;
+  return convertUSDPriceToCurrency(usdPriceInDecimal / 100, currency) * 100;
+}
+
+/**
+ * Builds the Stripe `currency_options` block for a book price, honouring any
+ * per-currency override. Centralised so product creation, price updates and
+ * inline checkout line items stay consistent.
+ */
+export function getStripeCurrencyOptionsFromNFTBookPrice(
+  usdPriceInDecimal: number,
+  priceInDecimalByCurrency?: BookPriceInDecimalByCurrency,
+) {
+  return {
+    twd: {
+      unit_amount: getCurrencyPriceInDecimal(usdPriceInDecimal, 'twd', priceInDecimalByCurrency),
+    },
+    hkd: {
+      unit_amount: getCurrencyPriceInDecimal(usdPriceInDecimal, 'hkd', priceInDecimalByCurrency),
+    },
+  };
 }
 
 export function convertCurrencyToUSDPrice(price: number, currency: SupportedPlusCurrency): number {


### PR DESCRIPTION
Let operations offer a bespoke off-ladder HKD/TWD price for a specific book tier without inserting a rung into the shared price ladder (which would retroactively reprice every existing book, since the ladder index is the price identity).

The override lives on the price tier doc, so it stays invisible to the publisher dropdown and is set manually via PUT .../price/:priceIndex. USD remains the stored priceInDecimal and commission base; only the Stripe charge amount per currency changes. Centralised the override resolution and the Stripe currency_options block in one pricing helper so product creation, price updates and inline checkout stay consistent; clearing an override now also reverts the synced Stripe price.