### PR TITLE
[TAS-5899] 🐛 Reflect HKD/TWD price overrides in Airtable publication record

### DIFF
--- a/src/routes/likernft/book/store.ts
+++ b/src/routes/likernft/book/store.ts
@@ -41,7 +41,11 @@ import { getStripeClient } from '../../../util/stripe';
 import { filterNFTBookListingInfo, filterNFTBookPricesInfo } from '../../../util/ValidationHelper';
 import type { NFTBookListingInfo, NFTBookPrice } from '../../../types/book';
 import { uploadImageBufferToCache } from '../../../util/fileupload';
-import { BOOK_PRICE_OVERRIDE_CURRENCIES, getStripeCurrencyOptionsFromNFTBookPrice } from '../../../util/pricing';
+import {
+  BOOK_PRICE_OVERRIDE_CURRENCIES,
+  getBookPriceRangeByCurrency,
+  getStripeCurrencyOptionsFromNFTBookPrice,
+} from '../../../util/pricing';
 import { cacheBookFilesFromNFTClassMetadata } from '../../../util/api/likernft/book/cache';
 import { normalizeClassIdParam } from '../../../middleware/likernft';
 
@@ -619,6 +623,7 @@ router.post(['/:classId/new', '/class/:classId/new'], jwtAuth('write:nftbook'), 
         type: metadata?.data?.metadata?.nft_meta_collection_id,
         minPrice: prices.reduce((min, p) => Math.min(min, p.priceInDecimal), Infinity) / 100,
         maxPrice: prices.reduce((max, p) => Math.max(max, p.priceInDecimal), 0) / 100,
+        priceRangeByCurrency: getBookPriceRangeByCurrency(prices),
         imageURL: image,
         language: inLanguage,
         keywords,

--- a/src/util/airtable.ts
+++ b/src/util/airtable.ts
@@ -20,6 +20,7 @@ interface AirtablePublicationRecordParams {
   type?: string;
   minPrice?: number;
   maxPrice?: number;
+  priceRangeByCurrency?: Record<string, { min: number; max: number }>;
   imageURL?: string;
   author?: string;
   publisher?: string;
@@ -73,6 +74,7 @@ export async function createAirtablePublicationRecord({
   type,
   minPrice,
   maxPrice,
+  priceRangeByCurrency,
   imageURL,
   author,
   publisher,
@@ -106,6 +108,14 @@ export async function createAirtablePublicationRecord({
       'Max Price': maxPrice,
       'DRM-free': isDRMFree,
     };
+
+    if (priceRangeByCurrency) {
+      for (const [currency, range] of Object.entries(priceRangeByCurrency)) {
+        const code = currency.toUpperCase();
+        fields[`Min Price ${code}`] = range.min;
+        fields[`Max Price ${code}`] = range.max;
+      }
+    }
 
     if (author) fields.Author = author;
     if (publisher) fields.Publisher = publisher;
@@ -273,6 +283,7 @@ export async function updateAirtablePublicationRecord({
   type,
   minPrice,
   maxPrice,
+  priceRangeByCurrency,
   imageURL,
   author,
   publisher,
@@ -310,6 +321,13 @@ export async function updateAirtablePublicationRecord({
     }
     if (minPrice !== undefined) fields['Min Price'] = minPrice;
     if (maxPrice !== undefined) fields['Max Price'] = maxPrice;
+    if (priceRangeByCurrency) {
+      for (const [currency, range] of Object.entries(priceRangeByCurrency)) {
+        const code = currency.toUpperCase();
+        fields[`Min Price ${code}`] = range.min;
+        fields[`Max Price ${code}`] = range.max;
+      }
+    }
     if (isDRMFree !== undefined) fields['DRM-free'] = isDRMFree;
 
     if (author) fields.Author = author;

--- a/src/util/api/likernft/book/index.ts
+++ b/src/util/api/likernft/book/index.ts
@@ -28,7 +28,7 @@ import { updateAirtablePublicationRecord } from '../../../airtable';
 import { checkIsTrustedPublisher } from './user';
 import { cacheBookFilesFromNFTClassMetadata } from './cache';
 import type { NFTBookListingInfo, NFTBookPrice } from '../../../../types/book';
-import { getStripeCurrencyOptionsFromNFTBookPrice } from '../../../pricing';
+import { getBookPriceRangeByCurrency, getStripeCurrencyOptionsFromNFTBookPrice } from '../../../pricing';
 
 export function getAuthorNameFromMetadata(author: unknown): string {
   if (typeof author === 'string') {
@@ -421,6 +421,7 @@ export async function syncNFTBookInfoWithISCN(classId) {
     } = bookInfo;
     const minPrice = prices.reduce((min, p) => Math.min(min, p.priceInDecimal), Infinity) / 100;
     const maxPrice = prices.reduce((max, p) => Math.max(max, p.priceInDecimal), 0) / 100;
+    const priceRangeByCurrency = getBookPriceRangeByCurrency(prices);
     await updateAirtablePublicationRecord({
       id: classId,
       name,
@@ -430,6 +431,7 @@ export async function syncNFTBookInfoWithISCN(classId) {
       type: 'book',
       minPrice,
       maxPrice,
+      priceRangeByCurrency,
       imageURL: image,
       author: getAuthorNameFromMetadata(author),
       publisher,

--- a/src/util/pricing.ts
+++ b/src/util/pricing.ts
@@ -61,6 +61,30 @@ export function getStripeCurrencyOptionsFromNFTBookPrice(
   );
 }
 
+type OverrideCurrency = typeof BOOK_PRICE_OVERRIDE_CURRENCIES[number];
+
+type BookPriceLike = {
+  priceInDecimal: number;
+  priceInDecimalByCurrency?: BookPriceInDecimalByCurrency;
+};
+
+export function getBookPriceRangeByCurrency(
+  prices: BookPriceLike[],
+): Record<OverrideCurrency, { min: number; max: number }> {
+  const result = {} as Record<OverrideCurrency, { min: number; max: number }>;
+  for (const currency of BOOK_PRICE_OVERRIDE_CURRENCIES) {
+    const amounts = prices.map((p) => getCurrencyPriceInDecimal(
+      p.priceInDecimal,
+      currency,
+      p.priceInDecimalByCurrency,
+    ));
+    const min = amounts.reduce((acc, v) => Math.min(acc, v), Infinity) / 100;
+    const max = amounts.reduce((acc, v) => Math.max(acc, v), 0) / 100;
+    result[currency] = { min, max };
+  }
+  return result;
+}
+
 export function convertCurrencyToUSDPrice(price: number, currency: SupportedPlusCurrency): number {
   switch (currency) {
     case 'hkd': {


### PR DESCRIPTION
Min/Max Price in Airtable was computed purely from USD priceInDecimal, so a custom TWD/HKD override on a book tier never showed up. Emit per-currency "Min Price <CODE>" / "Max Price <CODE>" fields using the same override-aware resolver that drives Stripe currency_options.

The original USD columns stay untouched. Adding a new override currency to BOOK_PRICE_OVERRIDE_CURRENCIES now produces the matching Airtable fields automatically.