### PR TITLE
✨ Default new book listings to on-shelf but not promoted

### DIFF
--- a/src/util/api/likernft/book/index.ts
+++ b/src/util/api/likernft/book/index.ts
@@ -281,8 +281,6 @@ export async function newNftBookInfo(
     ...formatPriceInfo(p),
   }));
 
-  const isFree = newPrices.every((p) => p.priceInDecimal === 0);
-
   const isTrustedPublisher = await checkIsTrustedPublisher(ownerWallet);
 
   const timestamp = FieldValue.serverTimestamp();
@@ -293,7 +291,10 @@ export async function newNftBookInfo(
     ownerWallet,
     timestamp: timestamp as any,
     chain: isEVMClassId(classId) ? 'base' : 'like',
-    isApprovedForSale: isTrustedPublisher || isFree,
+    // Default new listings to on-shelf: sellable and indexed, but not promoted.
+    // Ads are auto-approved only for trusted publishers (never for adult content);
+    // everyone else stays `pending` until an admin grants ads via `/book approve`.
+    isApprovedForSale: true,
     isApprovedForIndexing: true,
     isApprovedForAds: (isAdultOnly ? false : isTrustedPublisher),
     approvalStatus: isTrustedPublisher ? 'approved' : 'pending',


### PR DESCRIPTION
New listings are now sellable and indexed by default; only ads/promotion stay gated. Non-trusted publishers' paid books were previously blocked from sale (isApprovedForSale was trusted-or-free only) until manually approved — they now go on-shelf immediately and remain `pending` for ads review until an admin grants them via `/book approve`. Trusted-publisher auto-approval (and the adult-content ads block) is unchanged.