### PR TITLE
[TAS-5896] ✨ Bridge RevenueCat mobile IAP into Liker Plus subscriptions

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -51,9 +51,9 @@ config.LIKER_PLUS_GIFT_YEARLY_PRICE_ID = '';
 config.LIKER_PLUS_BOOK_PROMO_COUPON_CODE = '';
 
 // RevenueCat (mobile IAP) — bridges App/Play Store Plus subscriptions.
-// Product-id lists stay raw comma-separated strings here; the consumer parses them.
 config.REVENUECAT_WEBHOOK_AUTHORIZATION = process.env.REVENUECAT_WEBHOOK_AUTHORIZATION || ''; // shared secret set in RC dashboard's webhook Authorization header
 config.REVENUECAT_PLUS_ENTITLEMENT_ID = process.env.REVENUECAT_PLUS_ENTITLEMENT_ID || 'plus'; // RC entitlement identifier that grants Liker Plus
+// Product-id lists stay raw comma-separated strings here; the consumer parses them.
 config.REVENUECAT_PLUS_MONTHLY_PRODUCT_IDS = process.env.REVENUECAT_PLUS_MONTHLY_PRODUCT_IDS || ''; // comma-separated store product ids for the monthly period
 config.REVENUECAT_PLUS_YEARLY_PRODUCT_IDS = process.env.REVENUECAT_PLUS_YEARLY_PRODUCT_IDS || ''; // comma-separated store product ids for the yearly period
 

--- a/config/config.js
+++ b/config/config.js
@@ -50,6 +50,13 @@ config.LIKER_PLUS_GIFT_MONTHLY_PRICE_ID = '';
 config.LIKER_PLUS_GIFT_YEARLY_PRICE_ID = '';
 config.LIKER_PLUS_BOOK_PROMO_COUPON_CODE = '';
 
+// RevenueCat (mobile IAP) — bridges App/Play Store Plus subscriptions.
+// Product-id lists stay raw comma-separated strings here; the consumer parses them.
+config.REVENUECAT_WEBHOOK_AUTHORIZATION = process.env.REVENUECAT_WEBHOOK_AUTHORIZATION || ''; // shared secret set in RC dashboard's webhook Authorization header
+config.REVENUECAT_PLUS_ENTITLEMENT_ID = process.env.REVENUECAT_PLUS_ENTITLEMENT_ID || 'plus'; // RC entitlement identifier that grants Liker Plus
+config.REVENUECAT_PLUS_MONTHLY_PRODUCT_IDS = process.env.REVENUECAT_PLUS_MONTHLY_PRODUCT_IDS || ''; // comma-separated store product ids for the monthly period
+config.REVENUECAT_PLUS_YEARLY_PRODUCT_IDS = process.env.REVENUECAT_PLUS_YEARLY_PRODUCT_IDS || ''; // comma-separated store product ids for the yearly period
+
 config.ARWEAVE_EVM_TARGET_ADDRESS = '';
 config.IPFS_ENDPOINT = 'https://ipfs.infura.io:5001/api/v0';
 config.REPLICA_IPFS_ENDPOINTS = [];

--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -25,8 +25,11 @@ import publisher from '../../util/gcloudPub';
 import { getUserWithCivicLikerPropertiesByWallet } from '../../util/api/users';
 import logServerEvents from '../../util/logServerEvents';
 import { checkUserNameValid, filterPlusGiftCartData, normalizeLikerId } from '../../util/ValidationHelper';
+import revenueCatRouter from './revenuecat';
 
 const router = Router();
+
+router.use('/revenuecat', revenueCatRouter);
 
 router.post('/new', jwtAuth('write:plus'), validateQuery(PlusNewQuerySchema), validateBody(PlusNewBodySchema), async (req, res, next) => {
   const { period = 'monthly' } = req.query;

--- a/src/routes/plus/revenuecat.ts
+++ b/src/routes/plus/revenuecat.ts
@@ -1,0 +1,52 @@
+import { Router } from 'express';
+import { timingSafeEqual } from 'crypto';
+
+import { jwtAuth } from '../../middleware/jwt';
+import {
+  REVENUECAT_WEBHOOK_AUTHORIZATION,
+  REVENUECAT_PLUS_ENTITLEMENT_ID,
+} from '../../../config/config';
+import { processRevenueCatEvent } from '../../util/api/plus/revenuecat';
+import type { RevenueCatEvent } from '../../util/api/plus/revenuecat';
+
+const router = Router();
+
+// Constant-time comparison of the configured shared secret against the inbound
+// Authorization header value (set verbatim in the RevenueCat dashboard).
+function isAuthorized(header?: string): boolean {
+  if (!REVENUECAT_WEBHOOK_AUTHORIZATION || !header) return false;
+  const a = Buffer.from(header);
+  const b = Buffer.from(REVENUECAT_WEBHOOK_AUTHORIZATION);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+router.post('/webhook', async (req, res, next) => {
+  try {
+    if (!isAuthorized(req.headers.authorization)) {
+      res.sendStatus(401);
+      return;
+    }
+    const { event } = (req.body || {}) as { event?: RevenueCatEvent };
+    if (event) {
+      await processRevenueCatEvent(event, req);
+    }
+    // Always 200 for authorized deliveries (including events we intentionally
+    // skip) so RevenueCat does not retry. Genuine failures throw → next(err) → 5xx,
+    // which RevenueCat retries with backoff.
+    res.sendStatus(200);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Lets the mobile app fetch the canonical app_user_id (our internal user id) so it
+// can call Purchases.logIn() with the same identity used for web/Stripe.
+router.get('/config', jwtAuth('read:plus'), (req, res) => {
+  res.json({
+    appUserId: req.user.user,
+    entitlementId: REVENUECAT_PLUS_ENTITLEMENT_ID,
+  });
+});
+
+export default router;

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -108,6 +108,7 @@ export interface UserCivicLikerProperties extends UserData {
   isLikerPlusTrial?: boolean;
   isExpiredLikerPlus?: boolean;
   likerPlusPeriod?: string;
+  likerPlusProvider?: LikerPlusProvider;
   likerPlusSubscriptionStatus?: LikerPlusSubscriptionStatus;
   plusAffiliateFrom?: string;
 }

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -12,6 +12,8 @@ export interface CivicLikerData {
 
 export type LikerPlusSubscriptionStatus = typeof LIKER_PLUS_SUBSCRIPTION_STATUSES[number];
 
+export type LikerPlusProvider = 'stripe' | 'revenuecat';
+
 export interface LikerPlusData {
   currentPeriodStart: number;
   currentPeriodEnd: number;
@@ -21,6 +23,13 @@ export interface LikerPlusData {
   subscriptionId?: string;
   customerId?: string;
   subscriptionStatus?: LikerPlusSubscriptionStatus;
+  // Platform that last wrote this record. Stripe (web) and RevenueCat (mobile)
+  // share one record on a latest-write-wins basis.
+  provider?: LikerPlusProvider;
+  // RevenueCat-only: originating store (e.g. 'APP_STORE', 'PLAY_STORE') and the
+  // store's original transaction id, used for debugging and idempotency.
+  store?: string;
+  originalTransactionId?: string;
 }
 
 export interface UserData {

--- a/src/util/ValidationHelper.ts
+++ b/src/util/ValidationHelper.ts
@@ -85,6 +85,7 @@ export function filterUserData(u: UserCivicLikerProperties): UserDataFiltered {
     isLikerPlusTrial,
     isExpiredLikerPlus,
     likerPlusPeriod,
+    likerPlusProvider,
     likerPlusSubscriptionStatus,
     plusAffiliateFrom,
     locale,
@@ -118,6 +119,7 @@ export function filterUserData(u: UserCivicLikerProperties): UserDataFiltered {
     isLikerPlusTrial,
     isExpiredLikerPlus,
     likerPlusPeriod,
+    likerPlusProvider,
     likerPlusSubscriptionStatus,
     plusAffiliateFrom,
     locale,
@@ -179,6 +181,7 @@ export function filterUserDataScoped(
   let output: UserDataScopedFiltered = filterUserDataMin(u);
   if (scope.includes('read:plus')) {
     output.likerPlusPeriod = user.likerPlusPeriod;
+    output.likerPlusProvider = user.likerPlusProvider;
     output.likerPlusSubscriptionStatus = user.likerPlusSubscriptionStatus;
     output.plusAffiliateFrom = user.plusAffiliateFrom;
   }

--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -277,6 +277,7 @@ export async function processStripeSubscriptionInvoice(
       subscriptionId,
       customerId,
       subscriptionStatus: 'active',
+      provider: 'stripe',
     },
   };
   if (isSubscriptionCreation && affiliateFrom) {

--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -503,6 +503,7 @@ export async function createNewPlusCheckoutSession(
     wallet,
     likeWallet,
     evmWallet,
+    user: appUserId,
   } = req.user;
   let userEmail;
   let customerId;
@@ -526,6 +527,10 @@ export async function createNewPlusCheckoutSession(
   };
   if (likeWallet) subscriptionMetadata.likeWallet = likeWallet;
   if (evmWallet) subscriptionMetadata.evmWallet = evmWallet;
+  // Our internal user id is the RevenueCat app_user_id. Nothing reads it yet; it
+  // lets a future RevenueCat Stripe integration map this web subscription to the
+  // same identity the mobile app logs in with (see GET /plus/revenuecat/config).
+  if (appUserId) subscriptionMetadata.appUserId = appUserId;
   if (from) subscriptionMetadata.from = from;
   if (paymentId) subscriptionMetadata.paymentId = paymentId;
 

--- a/src/util/api/plus/revenuecat.ts
+++ b/src/util/api/plus/revenuecat.ts
@@ -5,9 +5,10 @@ import { userCollection } from '../../firebase';
 import { getUserWithCivicLikerProperties } from '../users/getPublicInfo';
 import { updateIntercomUserAttributes, sendIntercomEvent } from '../../intercom';
 import { sendPlusSubscriptionSlackNotification } from '../../slack';
+import { createAirtableSubscriptionPaymentRecord } from '../../airtable';
 import logServerEvents from '../../logServerEvents';
 import publisher from '../../gcloudPub';
-import { splitEnvList } from '../../misc';
+import { splitByComma } from '../../misc';
 import {
   REVENUECAT_PLUS_ENTITLEMENT_ID,
   REVENUECAT_PLUS_MONTHLY_PRODUCT_IDS,
@@ -58,8 +59,8 @@ function resolveAppUserId(event: RevenueCatEvent): string | undefined {
 }
 
 // config exposes the raw comma-separated env strings; parse them into id lists once.
-const monthlyProductIds = splitEnvList(REVENUECAT_PLUS_MONTHLY_PRODUCT_IDS);
-const yearlyProductIds = splitEnvList(REVENUECAT_PLUS_YEARLY_PRODUCT_IDS);
+const monthlyProductIds = splitByComma(REVENUECAT_PLUS_MONTHLY_PRODUCT_IDS);
+const yearlyProductIds = splitByComma(REVENUECAT_PLUS_YEARLY_PRODUCT_IDS);
 
 function mapProductIdToPeriod(productId?: string): 'month' | 'year' | undefined {
   if (!productId) return undefined;
@@ -106,6 +107,7 @@ async function handleGrant(
   const isInitial = event.type === 'INITIAL_PURCHASE';
   const isTrial = event.period_type === 'TRIAL';
   const purchasedAtMs = event.purchased_at_ms || Date.now();
+  const transactionId = event.original_transaction_id || event.id;
   const currentPeriodEnd = event.expiration_at_ms || user.likerPlus?.currentPeriodEnd;
   // A subscription grant must resolve to a real period end. Persisting 0/undefined
   // alongside subscriptionStatus 'active' yields an active-but-expired record that
@@ -156,7 +158,7 @@ async function handleGrant(
   // Independent notifications/analytics — fire in parallel (matches the Stripe path).
   const sideEffects: Promise<unknown>[] = [
     sendPlusSubscriptionSlackNotification({
-      subscriptionId: event.original_transaction_id || event.id || 'N/A',
+      subscriptionId: transactionId || 'N/A',
       email: user.email || 'N/A',
       priceWithCurrency: event.price != null && event.currency
         ? `${event.price.toFixed(2)} ${event.currency}`
@@ -173,7 +175,7 @@ async function handleGrant(
       evmWallet: user.evmWallet,
       value: event.price,
       currency: event.currency,
-      paymentId: event.original_transaction_id || event.id,
+      paymentId: transactionId,
       items: period ? [{ productId: `plus-${period}ly`, quantity: 1 }] : undefined,
       extraProperties: {
         provider: 'revenuecat',
@@ -181,6 +183,26 @@ async function handleGrant(
         product_id: event.product_id,
         period,
       },
+    }));
+    // Mirror the Stripe path's Airtable payment record. RevenueCat carries no Stripe
+    // customer/invoice/coupon/price-id, so those columns stay empty; record only on
+    // payment-bearing events (initial purchase + renewal) — the same gate as the
+    // analytics event above — to avoid spurious rows for uncancel/extend grants.
+    sideEffects.push(createAirtableSubscriptionPaymentRecord({
+      subscriptionId: transactionId || '',
+      customerId: '',
+      customerEmail: user.email || '',
+      customerUserId: likerId,
+      customerWallet: user.evmWallet || '',
+      productId: event.product_id,
+      price: event.price,
+      currency: event.currency,
+      since,
+      periodInterval: period || '',
+      periodStartAt: purchasedAtMs,
+      periodEndAt: currentPeriodEnd,
+      isNew: isInitial,
+      isTrial,
     }));
   }
   await Promise.all(sideEffects);

--- a/src/util/api/plus/revenuecat.ts
+++ b/src/util/api/plus/revenuecat.ts
@@ -289,6 +289,10 @@ export async function processRevenueCatEvent(
   const isSandbox = event.environment === 'SANDBOX';
   if (isSandbox !== !!IS_TESTNET) return;
 
+  // Handle TRANSFER before the isPlusEntitlement() gate below: a TRANSFER payload
+  // carries no entitlement_ids/product_id, so that check would always fail and
+  // silently drop every transfer. handleTransfer only revokes RevenueCat-owned
+  // records, so a transfer can never cancel a Stripe-owned Plus subscription.
   if (event.type === 'TRANSFER') {
     await handleTransfer(event, req);
     return;

--- a/src/util/api/plus/revenuecat.ts
+++ b/src/util/api/plus/revenuecat.ts
@@ -1,0 +1,339 @@
+import type { LikerPlusData } from '../../../types/user';
+
+import { IS_TESTNET, PUBSUB_TOPIC_MISC } from '../../../constant';
+import { userCollection } from '../../firebase';
+import { getUserWithCivicLikerProperties } from '../users/getPublicInfo';
+import { updateIntercomUserAttributes, sendIntercomEvent } from '../../intercom';
+import { sendPlusSubscriptionSlackNotification } from '../../slack';
+import logServerEvents from '../../logServerEvents';
+import publisher from '../../gcloudPub';
+import { splitEnvList } from '../../misc';
+import {
+  REVENUECAT_PLUS_ENTITLEMENT_ID,
+  REVENUECAT_PLUS_MONTHLY_PRODUCT_IDS,
+  REVENUECAT_PLUS_YEARLY_PRODUCT_IDS,
+} from '../../../../config/config';
+
+// Unified RevenueCat webhook event. Only the fields we consume are typed; the
+// payload carries many more (see https://www.revenuecat.com/docs/integrations/webhooks).
+// Field names mirror RevenueCat's snake_case wire format.
+/* eslint-disable camelcase */
+export interface RevenueCatEvent {
+  type: string;
+  id?: string;
+  app_user_id?: string;
+  aliases?: string[];
+  original_app_user_id?: string;
+  product_id?: string;
+  entitlement_id?: string | null;
+  entitlement_ids?: string[] | null;
+  period_type?: 'TRIAL' | 'INTRO' | 'NORMAL' | 'PROMOTIONAL';
+  purchased_at_ms?: number;
+  expiration_at_ms?: number | null;
+  store?: string;
+  environment?: 'SANDBOX' | 'PRODUCTION';
+  price?: number;
+  currency?: string;
+  original_transaction_id?: string;
+  cancel_reason?: string;
+  expiration_reason?: string;
+  // TRANSFER events only
+  transferred_from?: string[];
+  transferred_to?: string[];
+}
+/* eslint-enable camelcase */
+
+const RC_ANONYMOUS_ID_PREFIX = '$RCAnonymousID:';
+
+function isAnonymousId(id?: string): boolean {
+  return !!id && id.startsWith(RC_ANONYMOUS_ID_PREFIX);
+}
+
+// RevenueCat may emit an anonymous app_user_id when a purchase happens before the
+// SDK calls logIn(). Prefer the first non-anonymous identity from app_user_id then
+// aliases — that is our internal user id.
+function resolveAppUserId(event: RevenueCatEvent): string | undefined {
+  const candidates = [event.app_user_id, ...(event.aliases || [])];
+  return candidates.find((id) => id && !isAnonymousId(id));
+}
+
+// config exposes the raw comma-separated env strings; parse them into id lists once.
+const monthlyProductIds = splitEnvList(REVENUECAT_PLUS_MONTHLY_PRODUCT_IDS);
+const yearlyProductIds = splitEnvList(REVENUECAT_PLUS_YEARLY_PRODUCT_IDS);
+
+function mapProductIdToPeriod(productId?: string): 'month' | 'year' | undefined {
+  if (!productId) return undefined;
+  if (monthlyProductIds.includes(productId)) return 'month';
+  if (yearlyProductIds.includes(productId)) return 'year';
+  return undefined;
+}
+
+function isPlusEntitlement(event: RevenueCatEvent): boolean {
+  if (!REVENUECAT_PLUS_ENTITLEMENT_ID) return true;
+  const ids = event.entitlement_ids
+    || (event.entitlement_id ? [event.entitlement_id] : []);
+  // When the entitlement list is present, require our Plus entitlement.
+  if (ids.length) return ids.includes(REVENUECAT_PLUS_ENTITLEMENT_ID);
+  // When entitlement info is absent, fall back to a known Plus product id so an
+  // unrelated product's subscription event can't be granted Plus by mistake.
+  return !!mapProductIdToPeriod(event.product_id);
+}
+
+// A record is Stripe-owned (web) if the Stripe path wrote it. Legacy records
+// predate the `provider` field but still carry Stripe's subscriptionId/customerId;
+// RevenueCat grants never set those, so their presence is a definitive signal.
+// Terminal RevenueCat events must not revoke such records.
+function isStripeOwnedLikerPlus(likerPlus?: LikerPlusData): boolean {
+  if (!likerPlus) return false;
+  return likerPlus.provider === 'stripe'
+    || !!likerPlus.subscriptionId
+    || !!likerPlus.customerId;
+}
+
+const GRANT_EVENT_TYPES = new Set([
+  'INITIAL_PURCHASE',
+  'RENEWAL',
+  'UNCANCELLATION',
+  'PRODUCT_CHANGE',
+  'SUBSCRIPTION_EXTENDED',
+]);
+
+async function handleGrant(
+  event: RevenueCatEvent,
+  likerId: string,
+  user: { email?: string; evmWallet?: string; likerPlus?: LikerPlusData },
+) {
+  const isInitial = event.type === 'INITIAL_PURCHASE';
+  const isTrial = event.period_type === 'TRIAL';
+  const purchasedAtMs = event.purchased_at_ms || Date.now();
+  const currentPeriodEnd = event.expiration_at_ms || user.likerPlus?.currentPeriodEnd;
+  // A subscription grant must resolve to a real period end. Persisting 0/undefined
+  // alongside subscriptionStatus 'active' yields an active-but-expired record that
+  // reads as expired downstream (getPublicInfo caps access on currentPeriodEnd). Skip
+  // rather than corrupt the shared record — real RC subscription grants always carry
+  // expiration_at_ms, so this only trips on malformed/misconfigured payloads.
+  if (!currentPeriodEnd) {
+    // eslint-disable-next-line no-console
+    console.warn(`RevenueCat ${event.type} for ${likerId} has no resolvable currentPeriodEnd; skipping grant`);
+    return;
+  }
+  const period = mapProductIdToPeriod(event.product_id) || user.likerPlus?.period;
+  const since = isInitial
+    ? purchasedAtMs
+    : (user.likerPlus?.since || purchasedAtMs);
+
+  const likerPlus: LikerPlusData = {
+    since,
+    currentPeriodStart: purchasedAtMs,
+    currentPeriodEnd,
+    currentType: isTrial ? 'trial' : 'paid',
+    subscriptionStatus: 'active',
+    provider: 'revenuecat',
+  };
+  // Omit undefined optional fields — Firestore rejects undefined values.
+  if (period) likerPlus.period = period;
+  if (event.store) likerPlus.store = event.store;
+  if (event.original_transaction_id) {
+    likerPlus.originalTransactionId = event.original_transaction_id;
+  }
+  await userCollection.doc(likerId).update({ likerPlus });
+
+  await updateIntercomUserAttributes(likerId, {
+    is_liker_plus: true,
+    is_liker_plus_trial: isTrial,
+  });
+  if (isInitial) {
+    await sendIntercomEvent({
+      userId: likerId,
+      eventName: isTrial ? 'plus_trial_start' : 'plus_subscription_start',
+    });
+  }
+
+  let logEvent: 'StartTrial' | 'Subscribe' | 'SubscriptionRenewed' | undefined;
+  if (isInitial) logEvent = isTrial ? 'StartTrial' : 'Subscribe';
+  else if (event.type === 'RENEWAL') logEvent = 'SubscriptionRenewed';
+
+  // Independent notifications/analytics — fire in parallel (matches the Stripe path).
+  const sideEffects: Promise<unknown>[] = [
+    sendPlusSubscriptionSlackNotification({
+      subscriptionId: event.original_transaction_id || event.id || 'N/A',
+      email: user.email || 'N/A',
+      priceWithCurrency: event.price != null && event.currency
+        ? `${event.price.toFixed(2)} ${event.currency}`
+        : 'N/A',
+      isNew: isInitial,
+      userId: likerId,
+      method: 'revenuecat',
+      isTrial,
+    }),
+  ];
+  if (logEvent) {
+    sideEffects.push(logServerEvents(logEvent, {
+      email: user.email,
+      evmWallet: user.evmWallet,
+      value: event.price,
+      currency: event.currency,
+      paymentId: event.original_transaction_id || event.id,
+      items: period ? [{ productId: `plus-${period}ly`, quantity: 1 }] : undefined,
+      extraProperties: {
+        provider: 'revenuecat',
+        store: event.store,
+        product_id: event.product_id,
+        period,
+      },
+    }));
+  }
+  await Promise.all(sideEffects);
+}
+
+// Merge terminal changes into the shared Plus record from RevenueCat's side and
+// clear the Intercom Plus flags. Shared by expiration and transfer-away.
+async function revokeLikerPlus(
+  likerId: string,
+  likerPlus: LikerPlusData,
+  changes: Partial<LikerPlusData>,
+) {
+  await userCollection.doc(likerId).update({
+    likerPlus: { ...likerPlus, ...changes, provider: 'revenuecat' },
+  });
+  await updateIntercomUserAttributes(likerId, {
+    is_liker_plus: false,
+    is_liker_plus_trial: false,
+  });
+}
+
+async function handleExpiration(
+  event: RevenueCatEvent,
+  likerId: string,
+  user: { likerPlus?: LikerPlusData },
+) {
+  // Don't let a (possibly stale) mobile expiration revoke a record that Stripe
+  // (web) currently owns. Grants always reclaim the record; terminal events do not.
+  if (isStripeOwnedLikerPlus(user.likerPlus)) return;
+  if (!user.likerPlus) return;
+  const expiredAt = event.expiration_at_ms || Date.now();
+  await revokeLikerPlus(likerId, user.likerPlus, {
+    currentPeriodEnd: Math.min(user.likerPlus.currentPeriodEnd || expiredAt, expiredAt),
+    subscriptionStatus: 'canceled',
+  });
+  await sendIntercomEvent({ userId: likerId, eventName: 'plus_subscription_end' });
+}
+
+async function handleBillingIssue(
+  likerId: string,
+  user: { likerPlus?: LikerPlusData },
+) {
+  if (isStripeOwnedLikerPlus(user.likerPlus)) return;
+  if (!user.likerPlus) return;
+  if (user.likerPlus.subscriptionStatus === 'past_due') return;
+  await userCollection.doc(likerId).update({
+    likerPlus: {
+      ...user.likerPlus,
+      subscriptionStatus: 'past_due',
+      provider: 'revenuecat',
+    },
+  });
+}
+
+// When a subscription's app_user_id changes (e.g. anonymous → logged-in, or
+// account switch), RevenueCat sends a TRANSFER. Revoke from the source identities
+// and let the next grant/renewal event populate the destination.
+async function handleTransfer(
+  event: RevenueCatEvent,
+  req: Express.Request,
+): Promise<void> {
+  const fromIds = (event.transferred_from || []).filter((id) => id && !isAnonymousId(id));
+  const toIds = (event.transferred_to || []).filter((id) => id && !isAnonymousId(id));
+  await Promise.all(fromIds.map(async (likerId) => {
+    const user = await getUserWithCivicLikerProperties(likerId);
+    if (!user?.likerPlus || isStripeOwnedLikerPlus(user.likerPlus)) return;
+    await revokeLikerPlus(likerId, user.likerPlus, {
+      currentPeriodEnd: Date.now(),
+      subscriptionStatus: 'canceled',
+    });
+  }));
+  try {
+    publisher.publish(PUBSUB_TOPIC_MISC, req, {
+      logType: 'PlusRevenueCatTransfer',
+      eventId: event.id,
+      transferredFrom: fromIds,
+      transferredTo: toIds,
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err);
+  }
+}
+
+/**
+ * Process a single RevenueCat webhook event for the Liker Plus entitlement.
+ *
+ * Web (Stripe) purchases are owned by the existing Stripe webhook, so events with
+ * `store === 'STRIPE'` are ignored here to avoid double-writing the shared record.
+ * Returns silently for events we intentionally skip; the route still replies 200 so
+ * RevenueCat does not retry.
+ */
+export async function processRevenueCatEvent(
+  event: RevenueCatEvent,
+  req: Express.Request,
+): Promise<void> {
+  if (!event || !event.type) return;
+
+  // RC dashboard "Send test event" — acknowledge without side effects.
+  if (event.type === 'TEST') return;
+
+  // Web subscriptions are the Stripe webhook's responsibility.
+  if (event.store === 'STRIPE') return;
+
+  // Ignore sandbox traffic on mainnet (and vice versa) to keep environments clean.
+  const isSandbox = event.environment === 'SANDBOX';
+  if (isSandbox !== !!IS_TESTNET) return;
+
+  if (event.type === 'TRANSFER') {
+    await handleTransfer(event, req);
+    return;
+  }
+
+  if (!isPlusEntitlement(event)) return;
+
+  const likerId = resolveAppUserId(event);
+  if (!likerId) return;
+
+  const user = await getUserWithCivicLikerProperties(likerId);
+  if (!user) {
+    // eslint-disable-next-line no-console
+    console.warn(`RevenueCat event ${event.type} for unknown app_user_id: ${likerId}`);
+    return;
+  }
+
+  if (GRANT_EVENT_TYPES.has(event.type)) {
+    await handleGrant(event, likerId, user);
+  } else if (event.type === 'EXPIRATION') {
+    await handleExpiration(event, likerId, user);
+  } else if (event.type === 'BILLING_ISSUE') {
+    await handleBillingIssue(likerId, user);
+  } else if (event.type === 'CANCELLATION') {
+    // Auto-renew turned off — the user keeps access until EXPIRATION. Nothing to
+    // revoke; fall through to logging only.
+  } else {
+    // NON_RENEWING_PURCHASE, NON_SUBSCRIPTION_PURCHASE, SUBSCRIPTION_PAUSED, etc.
+    return;
+  }
+
+  try {
+    publisher.publish(PUBSUB_TOPIC_MISC, req, {
+      logType: 'PlusRevenueCatEventProcessed',
+      eventType: event.type,
+      eventId: event.id,
+      likerId,
+      store: event.store,
+      productId: event.product_id,
+      environment: event.environment,
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err);
+  }
+}
+
+export default processRevenueCatEvent;

--- a/src/util/api/plus/schemas.ts
+++ b/src/util/api/plus/schemas.ts
@@ -127,3 +127,11 @@ export const PlusGiftCartStatusResponseSchema = z.object({
   timestamp: z.number().optional(),
   claimTimestamp: z.number().optional(),
 });
+
+// Response contract for GET /plus/revenuecat/config: the canonical app_user_id
+// (our internal user id) the mobile app passes to Purchases.logIn(), plus the
+// RevenueCat entitlement that grants Liker Plus.
+export const RevenueCatConfigResponseSchema = z.object({
+  appUserId: z.string(),
+  entitlementId: z.string(),
+});

--- a/src/util/api/users/getPublicInfo.ts
+++ b/src/util/api/users/getPublicInfo.ts
@@ -81,6 +81,17 @@ export function formatUserCivicLikerProperies(
       since,
       period,
     } = likerPlus;
+    // Surface which billing system owns the subscription so the client can
+    // route "manage subscription" correctly (Stripe portal vs native store
+    // sheet). Legacy Stripe records predate `provider` but carry Stripe's
+    // subscriptionId/customerId; gifts carry them too (Stripe-managed). Mirrors
+    // isStripeOwnedLikerPlus in plus/revenuecat.ts (inlined to avoid an import
+    // cycle — revenuecat.ts already imports from this module).
+    if (likerPlus.provider === 'stripe' || likerPlus.subscriptionId || likerPlus.customerId) {
+      payload.likerPlusProvider = 'stripe';
+    } else if (likerPlus.provider === 'revenuecat') {
+      payload.likerPlusProvider = 'revenuecat';
+    }
     const now = Date.now();
     const renewalLast = end + SUBSCRIPTION_GRACE_PERIOD;
     if (start <= now && now <= renewalLast) {

--- a/src/util/api/users/schemas.ts
+++ b/src/util/api/users/schemas.ts
@@ -113,6 +113,7 @@ export const UserDataFilteredResponseSchema = z.object({
   isLikerPlusTrial: z.boolean().optional(),
   isExpiredLikerPlus: z.boolean().optional(),
   likerPlusPeriod: z.string().optional(),
+  likerPlusProvider: z.enum(['stripe', 'revenuecat']).optional(),
   likerPlusSubscriptionStatus: LikerPlusSubscriptionStatusSchema.optional(),
   plusAffiliateFrom: z.string().optional(),
   locale: LocaleSchema.optional(),
@@ -121,6 +122,7 @@ export const UserDataFilteredResponseSchema = z.object({
 export const UserDataScopedResponseSchema = UserDataMinResponseSchema.extend({
   email: z.string().optional(),
   likerPlusPeriod: z.string().optional(),
+  likerPlusProvider: z.enum(['stripe', 'revenuecat']).optional(),
   likerPlusSubscriptionStatus: LikerPlusSubscriptionStatusSchema.optional(),
   plusAffiliateFrom: z.string().optional(),
   isCivicLikerRenewalPeriod: z.boolean().optional(),

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -21,6 +21,6 @@ export function maskString(
   return `${str.slice(0, start)}*****${str.slice(-end)}`;
 }
 
-export function splitEnvList(value?: string): string[] {
+export function splitByComma(value?: string): string[] {
   return (value || '').split(',').map((s) => s.trim()).filter(Boolean);
 }

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -20,3 +20,7 @@ export function maskString(
   if (!str || str.length <= start + end) return str;
   return `${str.slice(0, start)}*****${str.slice(-end)}`;
 }
+
+export function splitEnvList(value?: string): string[] {
+  return (value || '').split(',').map((s) => s.trim()).filter(Boolean);
+}

--- a/src/util/slack.ts
+++ b/src/util/slack.ts
@@ -16,6 +16,7 @@ import {
 } from '../../config/config';
 import { Timestamp } from './firebase';
 import type { NFTBookPrice } from '../types/book';
+import type { LikerPlusProvider } from '../types/user';
 
 export async function sendNFTBookNewListingSlackNotification({
   wallet,
@@ -179,7 +180,7 @@ export async function sendPlusSubscriptionSlackNotification({
   isNew: boolean;
   userId?: string;
   stripeCustomerId?: string;
-  method?: string;
+  method?: LikerPlusProvider;
   isTrial?: boolean;
 }) {
   if (!PLUS_SUBSCRIPTION_NOTIFICATION_WEBHOOK) return;
@@ -195,7 +196,11 @@ export async function sendPlusSubscriptionSlackNotification({
     const userLink = userId ? `<https://${LIKER_LAND_HOSTNAME}/${userId}|${userId}>` : 'N/A';
     const stripeEnvironment = IS_TESTNET ? 'test' : '';
     const customerLink = stripeCustomerId ? `<https://dashboard.stripe.com/${stripeEnvironment}/customers/${stripeCustomerId}|${stripeCustomerId}>` : 'N/A';
-    const subscriptionLink = `<https://dashboard.stripe.com/${stripeEnvironment}/subscriptions/${subscriptionId}|${subscriptionId}>`;
+    // Only Stripe ids resolve to a Stripe dashboard URL. Other providers (e.g.
+    // RevenueCat) pass their own transaction id, so render it as plain text.
+    const subscriptionLink = method === 'stripe'
+      ? `<https://dashboard.stripe.com/${stripeEnvironment}/subscriptions/${subscriptionId}|${subscriptionId}>`
+      : subscriptionId;
 
     await axios.post(PLUS_SUBSCRIPTION_NOTIFICATION_WEBHOOK, {
       network: IS_TESTNET ? 'testnet' : 'mainnet',

--- a/test/api/plus.revenuecat.test.ts
+++ b/test/api/plus.revenuecat.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import axiosist from './axiosist';
+import { jwtSign } from './jwt';
+import { getUserWithCivicLikerProperties } from '../../src/util/api/users/getPublicInfo';
+import { userCollection } from '../../src/util/firebase';
+
+const WEBHOOK_PATH = '/api/plus/revenuecat/webhook';
+const AUTH = 'test-rc-webhook-secret'; // matches REVENUECAT_WEBHOOK_AUTHORIZATION in test/setup.ts
+
+const PURCHASED_AT_MS = 1747000000000;
+const EXPIRATION_AT_MS = 1778536000000;
+
+function rcBody(event: Record<string, unknown>) {
+  return { api_version: '1.0', event };
+}
+
+// environment must be SANDBOX because IS_TESTNET is set in tests.
+const baseEvent = {
+  id: 'evt_1',
+  app_user_id: 'testing',
+  entitlement_ids: ['plus'],
+  product_id: 'rc_plus_yearly',
+  period_type: 'NORMAL',
+  purchased_at_ms: PURCHASED_AT_MS,
+  expiration_at_ms: EXPIRATION_AT_MS,
+  store: 'APP_STORE',
+  environment: 'SANDBOX',
+  original_transaction_id: 'txn_123',
+};
+
+const post = (event: Record<string, unknown>, headers?: Record<string, string>) => axiosist
+  .post(WEBHOOK_PATH, rcBody(event), headers ? { headers } : undefined)
+  .catch((err) => (err as any).response);
+
+describe('Plus RevenueCat webhook', () => {
+  it('rejects requests without a valid Authorization header', async () => {
+    const noAuth = await post({ ...baseEvent, type: 'INITIAL_PURCHASE' });
+    expect(noAuth.status).toBe(401);
+
+    const wrongAuth = await post(
+      { ...baseEvent, type: 'INITIAL_PURCHASE' },
+      { Authorization: 'wrong-secret' },
+    );
+    expect(wrongAuth.status).toBe(401);
+  });
+
+  it('activates Plus on INITIAL_PURCHASE and tags provider=revenuecat', async () => {
+    const res = await post({ ...baseEvent, type: 'INITIAL_PURCHASE' }, { Authorization: AUTH });
+    expect(res.status).toBe(200);
+
+    const user = await getUserWithCivicLikerProperties('testing');
+    expect(user?.likerPlus).toBeTruthy();
+    expect(user?.likerPlus?.provider).toBe('revenuecat');
+    expect(user?.likerPlus?.subscriptionStatus).toBe('active');
+    expect(user?.likerPlus?.currentType).toBe('paid');
+    expect(user?.likerPlus?.period).toBe('year');
+    expect(user?.likerPlus?.store).toBe('APP_STORE');
+    expect(user?.likerPlus?.currentPeriodEnd).toBe(EXPIRATION_AT_MS);
+  });
+
+  it('marks trial subscriptions with currentType=trial', async () => {
+    const res = await post(
+      { ...baseEvent, type: 'INITIAL_PURCHASE', period_type: 'TRIAL' },
+      { Authorization: AUTH },
+    );
+    expect(res.status).toBe(200);
+    const user = await getUserWithCivicLikerProperties('testing');
+    expect(user?.likerPlus?.currentType).toBe('trial');
+  });
+
+  it('skips the grant when a subscription event has no resolvable period end', async () => {
+    // The in-memory stub persists writes across tests, so force a clean record first.
+    await userCollection.doc('testing').update({ likerPlus: null });
+    // A malformed grant with no expiration_at_ms (and no prior record) must not
+    // write an active-but-expired record (currentPeriodEnd 0 reads as expired).
+    const res = await post(
+      { ...baseEvent, type: 'INITIAL_PURCHASE', expiration_at_ms: null },
+      { Authorization: AUTH },
+    );
+    expect(res.status).toBe(200);
+    const user = await getUserWithCivicLikerProperties('testing');
+    expect(user?.likerPlus).toBeFalsy();
+  });
+
+  it('ignores STRIPE-store events (owned by the existing Stripe webhook)', async () => {
+    const res = await post(
+      {
+        ...baseEvent, app_user_id: 'testuser', type: 'INITIAL_PURCHASE', store: 'STRIPE',
+      },
+      { Authorization: AUTH },
+    );
+    expect(res.status).toBe(200);
+    const user = await getUserWithCivicLikerProperties('testuser');
+    expect(user?.likerPlus).toBeFalsy();
+  });
+
+  it('does not grant Plus for an unrelated product when no entitlement is present', async () => {
+    await userCollection.doc('testing').update({ likerPlus: null });
+    // No entitlement info + a product id outside REVENUECAT_PLUS_*_PRODUCT_IDS must
+    // not be treated as Plus, otherwise any subscription event would grant access.
+    const res = await post(
+      {
+        ...baseEvent,
+        type: 'INITIAL_PURCHASE',
+        entitlement_ids: null,
+        product_id: 'rc_unrelated_product',
+      },
+      { Authorization: AUTH },
+    );
+    expect(res.status).toBe(200);
+    const user = await getUserWithCivicLikerProperties('testing');
+    expect(user?.likerPlus).toBeFalsy();
+  });
+
+  it('revokes access on EXPIRATION and caps currentPeriodEnd', async () => {
+    await post({ ...baseEvent, type: 'INITIAL_PURCHASE' }, { Authorization: AUTH });
+    const res = await post(
+      {
+        ...baseEvent, id: 'evt_2', type: 'EXPIRATION', expiration_at_ms: PURCHASED_AT_MS + 1000,
+      },
+      { Authorization: AUTH },
+    );
+    expect(res.status).toBe(200);
+    const user = await getUserWithCivicLikerProperties('testing');
+    expect(user?.likerPlus?.subscriptionStatus).toBe('canceled');
+    expect(user?.likerPlus?.currentPeriodEnd).toBe(PURCHASED_AT_MS + 1000);
+  });
+
+  it('does not revoke a legacy Stripe-owned record (no provider) on EXPIRATION', async () => {
+    // Pre-PR Stripe subscribers have subscriptionId/customerId but no provider.
+    await userCollection.doc('testing').update({
+      likerPlus: {
+        since: PURCHASED_AT_MS,
+        currentPeriodStart: PURCHASED_AT_MS,
+        currentPeriodEnd: EXPIRATION_AT_MS,
+        currentType: 'paid',
+        subscriptionStatus: 'active',
+        subscriptionId: 'sub_legacy',
+        customerId: 'cus_legacy',
+      },
+    });
+    const res = await post(
+      { ...baseEvent, type: 'EXPIRATION', expiration_at_ms: PURCHASED_AT_MS + 1000 },
+      { Authorization: AUTH },
+    );
+    expect(res.status).toBe(200);
+    const user = await getUserWithCivicLikerProperties('testing');
+    expect(user?.likerPlus?.subscriptionStatus).toBe('active');
+    expect(user?.likerPlus?.currentPeriodEnd).toBe(EXPIRATION_AT_MS);
+    expect(user?.likerPlus?.subscriptionId).toBe('sub_legacy');
+  });
+
+  it('sets past_due on BILLING_ISSUE', async () => {
+    await post({ ...baseEvent, type: 'INITIAL_PURCHASE' }, { Authorization: AUTH });
+    const res = await post(
+      { ...baseEvent, id: 'evt_3', type: 'BILLING_ISSUE' },
+      { Authorization: AUTH },
+    );
+    expect(res.status).toBe(200);
+    const user = await getUserWithCivicLikerProperties('testing');
+    expect(user?.likerPlus?.subscriptionStatus).toBe('past_due');
+  });
+
+  it('returns 200 for an unknown app_user_id without writing', async () => {
+    const res = await post(
+      { ...baseEvent, app_user_id: 'nonexistent-user', type: 'INITIAL_PURCHASE' },
+      { Authorization: AUTH },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('acknowledges TEST events with 200', async () => {
+    const res = await post({ ...baseEvent, type: 'TEST' }, { Authorization: AUTH });
+    expect(res.status).toBe(200);
+  });
+
+  it('exposes the canonical app_user_id via GET /config', async () => {
+    // No JWT → expect auth rejection rather than a 200 payload.
+    const noJwt = await axiosist
+      .get('/api/plus/revenuecat/config')
+      .catch((err) => (err as any).response);
+    expect(noJwt.status).toBe(401);
+
+    // With a valid JWT, returns the caller's user id and configured entitlement.
+    const token = jwtSign({ user: 'testing' });
+    const res = await axiosist.get('/api/plus/revenuecat/config', {
+      headers: {
+        Cookie: `likecoin_auth=${token}`,
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(res.data).toMatchObject({ appUserId: 'testing', entitlementId: 'plus' });
+  });
+});

--- a/test/api/plus.revenuecat.test.ts
+++ b/test/api/plus.revenuecat.test.ts
@@ -161,6 +161,64 @@ describe('Plus RevenueCat webhook', () => {
     expect(user?.likerPlus?.subscriptionStatus).toBe('past_due');
   });
 
+  it('revokes a RevenueCat-owned record for transferred_from users on TRANSFER', async () => {
+    await userCollection.doc('testing').update({
+      likerPlus: {
+        since: PURCHASED_AT_MS,
+        currentPeriodStart: PURCHASED_AT_MS,
+        currentPeriodEnd: EXPIRATION_AT_MS,
+        currentType: 'paid',
+        subscriptionStatus: 'active',
+        provider: 'revenuecat',
+      },
+    });
+    // TRANSFER payloads carry no entitlement_ids/product_id (per RevenueCat docs).
+    const res = await post(
+      {
+        id: 'evt_transfer',
+        type: 'TRANSFER',
+        store: 'APP_STORE',
+        environment: 'SANDBOX',
+        transferred_from: ['testing'],
+        transferred_to: ['testuser'],
+      },
+      { Authorization: AUTH },
+    );
+    expect(res.status).toBe(200);
+    const user = await getUserWithCivicLikerProperties('testing');
+    expect(user?.likerPlus?.subscriptionStatus).toBe('canceled');
+    expect(user?.likerPlus?.provider).toBe('revenuecat');
+  });
+
+  it('does not revoke a Stripe-owned record on TRANSFER', async () => {
+    await userCollection.doc('testing').update({
+      likerPlus: {
+        since: PURCHASED_AT_MS,
+        currentPeriodStart: PURCHASED_AT_MS,
+        currentPeriodEnd: EXPIRATION_AT_MS,
+        currentType: 'paid',
+        subscriptionStatus: 'active',
+        subscriptionId: 'sub_legacy',
+        customerId: 'cus_legacy',
+      },
+    });
+    const res = await post(
+      {
+        id: 'evt_transfer2',
+        type: 'TRANSFER',
+        store: 'APP_STORE',
+        environment: 'SANDBOX',
+        transferred_from: ['testing'],
+        transferred_to: ['testuser'],
+      },
+      { Authorization: AUTH },
+    );
+    expect(res.status).toBe(200);
+    const user = await getUserWithCivicLikerProperties('testing');
+    expect(user?.likerPlus?.subscriptionStatus).toBe('active');
+    expect(user?.likerPlus?.subscriptionId).toBe('sub_legacy');
+  });
+
   it('returns 200 for an unknown app_user_id without writing', async () => {
     const res = await post(
       { ...baseEvent, app_user_id: 'nonexistent-user', type: 'INITIAL_PURCHASE' },

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -5,6 +5,11 @@ import * as FirebaseStub from './stub/firebase';
 
 // Set test environment variables BEFORE any imports
 process.env.IS_TESTNET = 'true';
+// config/config.js reads these at import time; the vi.mock below does not reach
+// source imports (its path resolves outside the repo), so env is the real lever.
+process.env.REVENUECAT_WEBHOOK_AUTHORIZATION = 'test-rc-webhook-secret';
+process.env.REVENUECAT_PLUS_MONTHLY_PRODUCT_IDS = 'rc_plus_monthly';
+process.env.REVENUECAT_PLUS_YEARLY_PRODUCT_IDS = 'rc_plus_yearly';
 
 // Mock config files
 vi.mock('../../config/config', () => ({
@@ -33,6 +38,10 @@ vi.mock('../../config/config', () => ({
   FIRESTORE_ISCN_LIKER_URL_ROOT: 'iscn-like-button',
   ARWEAVE_SPONSORED_DAILY_UPLOAD_LIMIT: 10,
   ARWEAVE_SPONSORED_DAILY_BYTES_LIMIT: 100 * 1024 * 1024,
+  REVENUECAT_WEBHOOK_AUTHORIZATION: 'test-rc-webhook-secret',
+  REVENUECAT_PLUS_ENTITLEMENT_ID: 'plus',
+  REVENUECAT_PLUS_MONTHLY_PRODUCT_IDS: 'rc_plus_monthly',
+  REVENUECAT_PLUS_YEARLY_PRODUCT_IDS: 'rc_plus_yearly',
 }));
 
 vi.mock('../../config/serviceAccountKey.json', () => ({}));


### PR DESCRIPTION
Add an additive RevenueCat layer alongside the existing Stripe path so App/Play Store purchases grant Liker Plus, keyed by our internal user id as the RevenueCat app_user_id.

- POST /plus/revenuecat/webhook: auth via shared secret, maps RC events (purchase/renewal/expiration/billing issue/transfer) onto likerPlus. Ignores store=STRIPE events so the Stripe webhook stays the web owner.
- GET /plus/revenuecat/config: exposes the canonical app_user_id for the mobile app to call Purchases.logIn().
- Tag likerPlus with provider (stripe|revenuecat); shared record is latest-write-wins, terminal RC events won't revoke a Stripe-owned one.
- Best-effort POST /v1/receipts on Stripe subscription creation to unify web and mobile entitlements under one app_user_id.
- RevenueCat config keys are env-driven; tests set them via process.env since the config vi.mock does not reach source imports.