### PR TITLE
✨ Validate path params and query strings with zod schemas

### DIFF
--- a/src/routes/arweave/index.ts
+++ b/src/routes/arweave/index.ts
@@ -23,9 +23,10 @@ import {
   ArweaveEstimateBodySchema,
   ArweaveRegisterBodySchema,
   ArweaveSignPaymentBodySchema,
+  ArweaveTxHashParamsSchema,
 } from '../../util/api/arweave/schemas';
 import { jwtAuth, jwtOptionalAuth } from '../../middleware/jwt';
-import { validateBody } from '../../middleware/validate';
+import { validateBody, validateParams } from '../../middleware/validate';
 import { ValidationError } from '../../util/ValidationError';
 
 const router = Router();
@@ -247,6 +248,7 @@ router.post(
 router.get(
   '/v2/link/:txHash',
   jwtOptionalAuth('read:iscn'),
+  validateParams(ArweaveTxHashParamsSchema),
   async (req, res, next) => {
     try {
       const { txHash } = req.params;
@@ -289,6 +291,7 @@ router.get(
 router.post(
   '/v2/access_token/:txHash',
   jwtAuth('write:iscn'),
+  validateParams(ArweaveTxHashParamsSchema),
   async (req, res, next) => {
     try {
       const { txHash } = req.params;

--- a/src/routes/likerland/nft/metadata.ts
+++ b/src/routes/likerland/nft/metadata.ts
@@ -14,6 +14,8 @@ import {
   getTokenAccountsByBookNFT,
 } from '../../../util/evm/nft';
 import type { NFTBookListingInfoFiltered } from '../../../types/book';
+import { validateQuery } from '../../../middleware/validate';
+import { NFTAggregatedMetadataQuerySchema } from '../../../util/api/likerland/schemas';
 
 const axios = Axios.create({
   timeout: 60000,
@@ -150,7 +152,7 @@ async function getNFTClassBookstoreInfo(classId) {
   }
 }
 
-router.get('/metadata', async (req, res, next) => {
+router.get('/metadata', validateQuery(NFTAggregatedMetadataQuerySchema), async (req, res, next) => {
   try {
     const { class_id: rawClassId, data: inputSelected } = req.query;
     const classId = typeof rawClassId === 'string' ? rawClassId.toLowerCase() : rawClassId;

--- a/src/routes/likernft/book/purchase.ts
+++ b/src/routes/likernft/book/purchase.ts
@@ -41,7 +41,7 @@ import { isValidLikeAddress } from '../../../util/cosmos';
 import { claimFreeBooks, getFreeBooksForUser } from '../../../util/api/likernft/book/free';
 import { fetchUserInfoByEmail } from '../../../util/api/users';
 import { normalizeClassIdParam } from '../../../middleware/likernft';
-import { validateBody } from '../../../middleware/validate';
+import { validateBody, validateParams } from '../../../middleware/validate';
 import {
   BookCartClaimBodySchema,
   BookCartNewBodySchema,
@@ -49,6 +49,9 @@ import {
   BookMessageBodySchema,
   BookPurchaseNewBodySchema,
   NFTBookSentBodySchema,
+  BookCartIdParamsSchema,
+  BookClassIdParamsSchema,
+  BookClassIdPaymentIdParamsSchema,
 } from '../../../util/api/likernft/book/schemas';
 
 const router = Router();
@@ -58,6 +61,7 @@ router.param('classId', normalizeClassIdParam);
 router.get(
   '/cart/:cartId/status',
   jwtOptionalAuth('read:nftbook'),
+  validateParams(BookCartIdParamsSchema),
   async (req, res, next) => {
     try {
       const { cartId } = req.params;
@@ -83,6 +87,7 @@ router.get(
 
 router.post(
   '/cart/:cartId/claim',
+  validateParams(BookCartIdParamsSchema),
   validateBody(BookCartClaimBodySchema),
   async (req, res, next) => {
     try {
@@ -260,7 +265,7 @@ router.post('/cart/new', jwtOptionalAuth('read:nftbook'), validateBody(BookCartN
   }
 });
 
-router.get(['/:classId/new', '/class/:classId/new'], jwtOptionalAuth('read:nftbook'), async (req, res, next) => {
+router.get(['/:classId/new', '/class/:classId/new'], jwtOptionalAuth('read:nftbook'), validateParams(BookClassIdParamsSchema), async (req, res, next) => {
   const { classId } = req.params;
   try {
     const {
@@ -410,7 +415,7 @@ router.get(['/:classId/new', '/class/:classId/new'], jwtOptionalAuth('read:nftbo
   }
 });
 
-router.post(['/:classId/new', '/class/:classId/new'], jwtOptionalAuth('read:nftbook'), validateBody(BookPurchaseNewBodySchema), async (req, res, next) => {
+router.post(['/:classId/new', '/class/:classId/new'], jwtOptionalAuth('read:nftbook'), validateParams(BookClassIdParamsSchema), validateBody(BookPurchaseNewBodySchema), async (req, res, next) => {
   try {
     const { classId } = req.params;
     const {
@@ -555,6 +560,7 @@ router.post(['/:classId/new', '/class/:classId/new'], jwtOptionalAuth('read:nftb
 router.get(
   ['/:classId/status/:paymentId', '/class/:classId/status/:paymentId'],
   jwtOptionalAuth('read:nftbook'),
+  validateParams(BookClassIdPaymentIdParamsSchema),
   async (req, res, next) => {
     try {
       const { classId, paymentId } = req.params;
@@ -623,6 +629,7 @@ router.post('/free', jwtAuth('write:nftbook'), validateBody(BookFreeClaimBodySch
 
 router.post(
   ['/:classId/claim/:paymentId', '/class/:classId/claim/:paymentId'],
+  validateParams(BookClassIdPaymentIdParamsSchema),
   async (req, res, next) => {
     try {
       const { classId, paymentId } = req.params;
@@ -660,6 +667,7 @@ router.post(
 
 router.post(
   '/class/:classId/message/:paymentId',
+  validateParams(BookClassIdPaymentIdParamsSchema),
   validateBody(BookMessageBodySchema),
   async (req, res, next) => {
     try {
@@ -688,6 +696,7 @@ router.post(
 router.post(
   ['/:classId/sent/:paymentId', '/class/:classId/sent/:paymentId'],
   jwtAuth('write:nftbook'),
+  validateParams(BookClassIdPaymentIdParamsSchema),
   validateBody(NFTBookSentBodySchema),
   async (req, res, next) => {
     try {
@@ -804,6 +813,7 @@ router.post(
 router.post(
   ['/:classId/status/:paymentId/remind', '/class/:classId/status/:paymentId/remind'],
   jwtAuth('write:nftbook'),
+  validateParams(BookClassIdPaymentIdParamsSchema),
   async (req, res, next) => {
     try {
       const { classId, paymentId } = req.params;
@@ -912,6 +922,7 @@ router.post(
 router.get(
   ['/:classId/orders', '/class/:classId/orders'],
   jwtAuth('read:nftbook'),
+  validateParams(BookClassIdParamsSchema),
   async (req, res, next) => {
     try {
       const { classId } = req.params;
@@ -941,6 +952,7 @@ router.get(
 
 router.get(
   ['/:classId/messages', '/class/:classId/messages'],
+  validateParams(BookClassIdParamsSchema),
   async (req, res, next) => {
     try {
       const { classId } = req.params;

--- a/src/routes/likernft/book/store.ts
+++ b/src/routes/likernft/book/store.ts
@@ -19,8 +19,11 @@ import {
   NewListingBodySchema,
   PriceMutationBodySchema,
   PriceReorderBodySchema,
+  BookClassIdParamsSchema,
+  BookClassIdPriceIndexParamsSchema,
+  BookSearchQuerySchema,
 } from '../../../util/api/likernft/book/schemas';
-import { validateBody } from '../../../middleware/validate';
+import { validateBody, validateParams, validateQuery } from '../../../middleware/validate';
 import {
   getNFTClassDataById as getEVMNFTClassDataById,
   getNFTClassOwner as getEVMNFTClassOwner,
@@ -66,7 +69,7 @@ const pngUpload = multer({
   },
 });
 
-router.get('/search', async (req, res, next) => {
+router.get('/search', validateQuery(BookSearchQuerySchema), async (req, res, next) => {
   try {
     const {
       q,
@@ -173,7 +176,7 @@ router.get('/list/moderated', jwtAuth('read:nftbook'), async (req, res, next) =>
   }
 });
 
-router.get(['/:classId', '/class/:classId'], jwtOptionalAuth('read:nftbook'), async (req, res, next) => {
+router.get(['/:classId', '/class/:classId'], jwtOptionalAuth('read:nftbook'), validateParams(BookClassIdParamsSchema), async (req, res, next) => {
   try {
     const { classId } = req.params;
     let bookInfo;
@@ -198,7 +201,7 @@ router.get(['/:classId', '/class/:classId'], jwtOptionalAuth('read:nftbook'), as
   }
 });
 
-router.get(['/:classId/price/:priceIndex', '/class/:classId/price/:priceIndex'], jwtOptionalAuth('read:nftbook'), async (req, res, next) => {
+router.get(['/:classId/price/:priceIndex', '/class/:classId/price/:priceIndex'], jwtOptionalAuth('read:nftbook'), validateParams(BookClassIdPriceIndexParamsSchema), async (req, res, next) => {
   try {
     const { classId, priceIndex: priceIndexString } = req.params;
     const priceIndex = Number(priceIndexString);
@@ -224,7 +227,7 @@ router.get(['/:classId/price/:priceIndex', '/class/:classId/price/:priceIndex'],
   }
 });
 
-router.post(['/:classId/price/:priceIndex', '/class/:classId/price/:priceIndex'], jwtAuth('write:nftbook'), validateBody(PriceMutationBodySchema), async (req, res, next) => {
+router.post(['/:classId/price/:priceIndex', '/class/:classId/price/:priceIndex'], jwtAuth('write:nftbook'), validateParams(BookClassIdPriceIndexParamsSchema), validateBody(PriceMutationBodySchema), async (req, res, next) => {
   try {
     const { classId, priceIndex: priceIndexString } = req.params;
     const priceIndex = Number(priceIndexString);
@@ -290,7 +293,7 @@ router.post(['/:classId/price/:priceIndex', '/class/:classId/price/:priceIndex']
   }
 });
 
-router.put(['/:classId/price/:priceIndex', '/class/:classId/price/:priceIndex'], jwtAuth('write:nftbook'), validateBody(PriceMutationBodySchema), async (req, res, next) => {
+router.put(['/:classId/price/:priceIndex', '/class/:classId/price/:priceIndex'], jwtAuth('write:nftbook'), validateParams(BookClassIdPriceIndexParamsSchema), validateBody(PriceMutationBodySchema), async (req, res, next) => {
   try {
     const { classId, priceIndex: priceIndexString } = req.params;
     const { price } = req.body;
@@ -392,7 +395,7 @@ router.put(['/:classId/price/:priceIndex', '/class/:classId/price/:priceIndex'],
   }
 });
 
-router.put(['/:classId/price/:priceIndex/order', '/class/:classId/price/:priceIndex/order'], jwtAuth('write:nftbook'), validateBody(PriceReorderBodySchema), async (req, res, next) => {
+router.put(['/:classId/price/:priceIndex/order', '/class/:classId/price/:priceIndex/order'], jwtAuth('write:nftbook'), validateParams(BookClassIdPriceIndexParamsSchema), validateBody(PriceReorderBodySchema), async (req, res, next) => {
   try {
     const { classId } = req.params;
     const bookInfo = await getNftBookInfo(classId);
@@ -447,7 +450,7 @@ router.put(['/:classId/price/:priceIndex/order', '/class/:classId/price/:priceIn
   }
 });
 
-router.post('/class/:classId/refresh', jwtAuth('write:nftbook'), async (req, res, next) => {
+router.post('/class/:classId/refresh', jwtAuth('write:nftbook'), validateParams(BookClassIdParamsSchema), async (req, res, next) => {
   try {
     const { classId } = req.params;
     const bookInfo = await getNftBookInfo(classId);
@@ -471,7 +474,7 @@ router.post('/class/:classId/refresh', jwtAuth('write:nftbook'), async (req, res
   }
 });
 
-router.post(['/:classId/new', '/class/:classId/new'], jwtAuth('write:nftbook'), validateBody(NewListingBodySchema), async (req, res, next) => {
+router.post(['/:classId/new', '/class/:classId/new'], jwtAuth('write:nftbook'), validateParams(BookClassIdParamsSchema), validateBody(NewListingBodySchema), async (req, res, next) => {
   try {
     const { classId } = req.params;
     const {
@@ -676,7 +679,7 @@ router.post(['/:classId/new', '/class/:classId/new'], jwtAuth('write:nftbook'), 
   }
 });
 
-router.post(['/:classId/settings', '/class/:classId/settings'], jwtAuth('write:nftbook'), validateBody(ListingSettingsBodySchema), async (req, res, next) => {
+router.post(['/:classId/settings', '/class/:classId/settings'], jwtAuth('write:nftbook'), validateParams(BookClassIdParamsSchema), validateBody(ListingSettingsBodySchema), async (req, res, next) => {
   try {
     const { classId } = req.params;
     const {
@@ -741,6 +744,7 @@ router.post(['/:classId/settings', '/class/:classId/settings'], jwtAuth('write:n
 router.post(
   '/:classId/image/upload',
   jwtAuth('write:nftbook'),
+  validateParams(BookClassIdParamsSchema),
   pngUpload.fields([
     { name: 'signImage', maxCount: 1 },
     { name: 'memoImage', maxCount: 1 },

--- a/src/routes/likernft/book/user.ts
+++ b/src/routes/likernft/book/user.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { ValidationError } from '../../../util/ValidationError';
 import { jwtAuth, jwtOptionalAuth } from '../../../middleware/jwt';
-import { validateBody } from '../../../middleware/validate';
+import { validateBody, validateParams } from '../../../middleware/validate';
 import { FieldValue, likeNFTBookUserCollection } from '../../../util/firebase';
 import { getStripeClient } from '../../../util/stripe';
 import { BOOK3_HOSTNAME, NFT_BOOKSTORE_HOSTNAME, PUBSUB_TOPIC_MISC } from '../../../constant';
@@ -11,6 +11,7 @@ import { getUserWithCivicLikerPropertiesByWallet } from '../../../util/api/users
 import { getBookUserInfoFromWallet } from '../../../util/api/likernft/book/user';
 import {
   StripeConnectNewBodySchema,
+  BookIdParamsSchema,
   type StripeConnectSite,
 } from '../../../util/api/likernft/book/schemas';
 import type { BookPurchaseCommission } from '../../../types/book';
@@ -288,7 +289,7 @@ router.get(
   },
 );
 
-router.get('/payouts/:id', jwtAuth('read:nftbook'), async (req, res, next) => {
+router.get('/payouts/:id', jwtAuth('read:nftbook'), validateParams(BookIdParamsSchema), async (req, res, next) => {
   try {
     const { wallet } = req.user;
     const { id } = req.params;
@@ -386,6 +387,7 @@ router.get(
 router.get(
   '/commissions/:id',
   jwtAuth('read:nftbook'),
+  validateParams(BookIdParamsSchema),
   async (req, res, next) => {
     try {
       const { wallet } = req.user;

--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -1,10 +1,14 @@
 import { Router } from 'express';
 import { jwtAuth, jwtOptionalAuth } from '../../middleware/jwt';
-import { validateBody } from '../../middleware/validate';
+import { validateBody, validateParams, validateQuery } from '../../middleware/validate';
 import { ValidationError } from '../../util/ValidationError';
 import {
+  PlusAffiliateParamsSchema,
+  PlusCartIdParamsSchema,
   PlusGiftNewBodySchema,
+  PlusGiftNewQuerySchema,
   PlusNewBodySchema,
+  PlusNewQuerySchema,
   PlusPriceBodySchema,
 } from '../../util/api/plus/schemas';
 import { getBookUserInfoFromWallet, getBookUserInfoFromLikerId } from '../../util/api/likernft/book/user';
@@ -24,8 +28,8 @@ import { checkUserNameValid, filterPlusGiftCartData, normalizeLikerId } from '..
 
 const router = Router();
 
-router.post('/new', jwtAuth('write:plus'), validateBody(PlusNewBodySchema), async (req, res, next) => {
-  let { period = 'monthly' } = req.query;
+router.post('/new', jwtAuth('write:plus'), validateQuery(PlusNewQuerySchema), validateBody(PlusNewBodySchema), async (req, res, next) => {
+  const { period = 'monthly' } = req.query;
   const { from, currency } = req.query;
   const {
     gaClientId,
@@ -51,10 +55,6 @@ router.post('/new', jwtAuth('write:plus'), validateBody(PlusNewBodySchema), asyn
     uiMode,
   } = req.body;
   try {
-    // Ensure period is either 'monthly' or 'yearly'
-    if (period !== 'monthly' && period !== 'yearly') {
-      period = 'monthly'; // Default to monthly if invalid
-    }
     if (period !== 'yearly' && giftClassId) {
       throw new ValidationError('Gift subscriptions are only available for yearly plans.', 400);
     }
@@ -170,8 +170,8 @@ router.post('/new', jwtAuth('write:plus'), validateBody(PlusNewBodySchema), asyn
   }
 });
 
-router.post('/gift/new', jwtAuth('write:plus'), validateBody(PlusGiftNewBodySchema), async (req, res, next) => {
-  let { period = 'yearly' } = req.query;
+router.post('/gift/new', jwtAuth('write:plus'), validateQuery(PlusGiftNewQuerySchema), validateBody(PlusGiftNewBodySchema), async (req, res, next) => {
+  const { period = 'yearly' } = req.query;
   const { from, currency } = req.query;
   const {
     gaClientId,
@@ -193,9 +193,6 @@ router.post('/gift/new', jwtAuth('write:plus'), validateBody(PlusGiftNewBodySche
     isApp,
   } = req.body;
   try {
-    if (period !== 'monthly' && period !== 'yearly') {
-      period = 'yearly'; // Default to yearly if invalid
-    }
     if (currency !== undefined
       && !SUPPORTED_PLUS_CURRENCIES.includes(currency as SupportedPlusCurrency)) {
       throw new ValidationError('UNSUPPORTED_CURRENCY', 400);
@@ -294,7 +291,7 @@ router.post('/gift/new', jwtAuth('write:plus'), validateBody(PlusGiftNewBodySche
   }
 });
 
-router.post('/gift/:cartId/claim', jwtAuth('write:plus'), async (req, res, next) => {
+router.post('/gift/:cartId/claim', jwtAuth('write:plus'), validateParams(PlusCartIdParamsSchema), async (req, res, next) => {
   const { cartId } = req.params;
   const { token } = req.query;
   try {
@@ -353,7 +350,7 @@ router.post('/price', jwtAuth('write:plus'), validateBody(PlusPriceBodySchema), 
   }
 });
 
-router.get('/gift/:cartId/status', jwtOptionalAuth('read:plus'), async (req, res, next) => {
+router.get('/gift/:cartId/status', jwtOptionalAuth('read:plus'), validateParams(PlusCartIdParamsSchema), async (req, res, next) => {
   try {
     const { cartId } = req.params;
     const { token } = req.query;
@@ -405,7 +402,7 @@ router.get('/gift', jwtAuth('read:plus'), async (req, res, next) => {
   }
 });
 
-router.get('/affiliate/:likerId', async (req, res, next) => {
+router.get('/affiliate/:likerId', validateParams(PlusAffiliateParamsSchema), async (req, res, next) => {
   try {
     const { likerId } = req.params;
     const normalizedLikerId = normalizeLikerId(likerId);

--- a/src/routes/users/apiRegister.ts
+++ b/src/routes/users/apiRegister.ts
@@ -19,8 +19,8 @@ import {
   handleTransferPlatformDelegatedUser,
 } from '../../util/api/users/platforms';
 import { createAuthCoreUserAndWallet } from '../../util/api/users/authcore';
-import { UsersNewCheckBodySchema } from '../../util/api/users/schemas';
-import { validateBody } from '../../middleware/validate';
+import { UsersNewCheckBodySchema, UsersPlatformParamsSchema } from '../../util/api/users/schemas';
+import { validateBody, validateParams } from '../../middleware/validate';
 import { fetchMattersUser } from '../../util/oauth/matters';
 import { checkUserNameValid } from '../../util/ValidationHelper';
 import { ValidationError } from '../../util/ValidationError';
@@ -73,7 +73,7 @@ router.post('/new/check', validateBody(UsersNewCheckBodySchema), async (req, res
   }
 });
 
-router.post('/new/:platform', getOAuthClientInfo(), async (req, res, next) => {
+router.post('/new/:platform', getOAuthClientInfo(), validateParams(UsersPlatformParamsSchema), async (req, res, next) => {
   const {
     platform,
   } = req.params;
@@ -210,7 +210,7 @@ router.post('/new/:platform', getOAuthClientInfo(), async (req, res, next) => {
   }
 });
 
-router.post('/edit/:platform', getOAuthClientInfo(), async (req, res, next) => {
+router.post('/edit/:platform', getOAuthClientInfo(), validateParams(UsersPlatformParamsSchema), async (req, res, next) => {
   const { platform } = req.params;
   if (req.auth.platform !== platform) {
     throw new ValidationError('AUTH_PLATFORM_NOT_MATCH');

--- a/src/routes/users/delete.ts
+++ b/src/routes/users/delete.ts
@@ -1,18 +1,18 @@
 import { Router } from 'express';
 import { jwtAuth } from '../../middleware/jwt';
-import { validateBody } from '../../middleware/validate';
+import { validateBody, validateParams } from '../../middleware/validate';
 import { getAuthCoreUser } from '../../util/authcore';
 import {
   getUserWithCivicLikerProperties,
 } from '../../util/api/users/getPublicInfo';
 import { checkCosmosSignPayload, checkEVMSignPayload } from '../../util/api/users';
 import { deleteAllUserData } from '../../util/api/users/delete';
-import { UsersDeleteBodySchema } from '../../util/api/users/schemas';
+import { UsersDeleteBodySchema, UsersIdParamsSchema } from '../../util/api/users/schemas';
 import { ValidationError } from '../../util/ValidationError';
 
 const router = Router();
 
-router.post('/delete/:id', jwtAuth('write'), validateBody(UsersDeleteBodySchema), async (req, res, next) => {
+router.post('/delete/:id', jwtAuth('write'), validateParams(UsersIdParamsSchema), validateBody(UsersDeleteBodySchema), async (req, res, next) => {
   try {
     const { id } = req.params;
     const { user } = req.user;

--- a/src/routes/users/getInfo.ts
+++ b/src/routes/users/getInfo.ts
@@ -3,6 +3,8 @@ import {
   userCollection as dbRef,
 } from '../../util/firebase';
 import { jwtAuth } from '../../middleware/jwt';
+import { validateParams } from '../../middleware/validate';
+import { UsersIdParamsSchema } from '../../util/api/users/schemas';
 import {
   filterUserData,
 } from '../../util/ValidationHelper';
@@ -45,7 +47,7 @@ router.get('/self', jwtAuth('read'), async (req, res, next) => {
   }
 });
 
-router.get('/id/:id', jwtAuth('read'), async (req, res, next) => {
+router.get('/id/:id', jwtAuth('read'), validateParams(UsersIdParamsSchema), async (req, res, next) => {
   try {
     const username = req.params.id;
     if (req.user.user !== username) {

--- a/src/routes/users/getPublicInfo.ts
+++ b/src/routes/users/getPublicInfo.ts
@@ -11,10 +11,12 @@ import {
   getUserWithCivicLikerPropertiesByWallet,
 } from '../../util/api/users/getPublicInfo';
 import { ONE_DAY_IN_S, AVATAR_DEFAULT_PATH, DEFAULT_AVATAR_SIZE } from '../../constant';
+import { validateParams } from '../../middleware/validate';
+import { UsersAddrParamsSchema, UsersIdParamsSchema } from '../../util/api/users/schemas';
 
 const router = Router();
 
-router.get('/id/:id/min', async (req, res, next) => {
+router.get('/id/:id/min', validateParams(UsersIdParamsSchema), async (req, res, next) => {
   try {
     const { id } = req.params;
     const { type = '' } = req.query;
@@ -34,7 +36,7 @@ router.get('/id/:id/min', async (req, res, next) => {
   }
 });
 
-router.get('/id/:id/avatar', async (req, res, next) => {
+router.get('/id/:id/avatar', validateParams(UsersIdParamsSchema), async (req, res, next) => {
   try {
     const { id } = req.params;
     const { size: inputSizeStr = DEFAULT_AVATAR_SIZE } = req.query;
@@ -85,7 +87,7 @@ router.get('/id/:id/avatar', async (req, res, next) => {
   }
 });
 
-router.get('/addr/:addr/min', async (req, res, next) => {
+router.get('/addr/:addr/min', validateParams(UsersAddrParamsSchema), async (req, res, next) => {
   try {
     const { addr } = req.params;
     const { type } = req.query;

--- a/src/routes/wallet/index.ts
+++ b/src/routes/wallet/index.ts
@@ -17,8 +17,9 @@ import {
 import {
   WalletAuthorizeBodySchema,
   WalletEvmMigrateEmailMagicBodySchema,
+  WalletLikeWalletParamsSchema,
 } from '../../util/api/wallet/schemas';
-import { validateBody } from '../../middleware/validate';
+import { validateBody, validateParams } from '../../middleware/validate';
 import publisher from '../../util/gcloudPub';
 import { PUBSUB_TOPIC_MISC } from '../../constant';
 import { checkAddressValid, checkCosmosAddressValid } from '../../util/ValidationHelper';
@@ -131,7 +132,7 @@ router.post('/evm/migrate/book', async (req, res, next) => {
   }
 });
 
-router.get('/evm/migrate/user/addr/:likeWallet', async (req, res, next) => {
+router.get('/evm/migrate/user/addr/:likeWallet', validateParams(WalletLikeWalletParamsSchema), async (req, res, next) => {
   try {
     const { likeWallet } = req.params;
     if (!likeWallet || !checkCosmosAddressValid(likeWallet, 'like')) {

--- a/src/util/api/arweave/schemas.ts
+++ b/src/util/api/arweave/schemas.ts
@@ -21,6 +21,10 @@ export const ArweaveRegisterBodySchema = z.object({
   isRequireAuth: z.boolean().optional(),
 });
 
+export const ArweaveTxHashParamsSchema = z.object({
+  txHash: z.string().min(1),
+});
+
 export const ArweaveEstimateResponseSchema = z.object({
   arweaveId: z.string().optional(),
   ETH: z.string(),

--- a/src/util/api/likerland/schemas.ts
+++ b/src/util/api/likerland/schemas.ts
@@ -8,3 +8,8 @@ export const NFTAggregatedMetadataResponseSchema = z.object({
   ownerInfo: z.array(z.string()).nullable().optional(),
   bookstoreInfo: NFTBookListingInfoFilteredSchema.nullable().optional(),
 });
+
+export const NFTAggregatedMetadataQuerySchema = z.object({
+  class_id: z.string().optional(),
+  data: z.union([z.string(), z.array(z.string())]).optional(),
+}).passthrough();

--- a/src/util/api/likernft/book/schemas.ts
+++ b/src/util/api/likernft/book/schemas.ts
@@ -151,6 +151,33 @@ export const BookFreeClaimBodySchema = z.object({
   classId: z.string().min(1),
 });
 
+export const BookClassIdParamsSchema = z.object({
+  classId: z.string().min(1),
+});
+
+export const BookClassIdPriceIndexParamsSchema = z.object({
+  classId: z.string().min(1),
+  priceIndex: z.coerce.number().int().min(0),
+});
+
+export const BookClassIdPaymentIdParamsSchema = z.object({
+  classId: z.string().min(1),
+  paymentId: z.string().min(1),
+});
+
+export const BookCartIdParamsSchema = z.object({
+  cartId: z.string().min(1),
+});
+
+export const BookIdParamsSchema = z.object({
+  id: z.string().min(1),
+});
+
+export const BookSearchQuerySchema = z.object({
+  q: z.string().optional(),
+  fields: z.union([z.string(), z.array(z.string())]).optional(),
+}).passthrough();
+
 export const ClassIdResponseSchema = z.object({
   classId: z.string(),
 });

--- a/src/util/api/plus/schemas.ts
+++ b/src/util/api/plus/schemas.ts
@@ -39,6 +39,28 @@ export const PlusGiftNewBodySchema = TrackingFieldsSchema.extend({
   giftInfo: BookGiftInfoBodySchema,
 });
 
+export const PlusCartIdParamsSchema = z.object({
+  cartId: z.string().min(1),
+});
+
+export const PlusAffiliateParamsSchema = z.object({
+  likerId: z.string().min(1),
+});
+
+// `.catch()` keeps the endpoints' historically lenient behaviour: a missing or
+// invalid `period` falls back to the default instead of returning 400.
+export const PlusNewQuerySchema = z.object({
+  period: z.enum(['monthly', 'yearly']).default('monthly').catch('monthly'),
+  from: z.string().optional(),
+  currency: z.string().optional(),
+}).passthrough();
+
+export const PlusGiftNewQuerySchema = z.object({
+  period: z.enum(['monthly', 'yearly']).default('yearly').catch('yearly'),
+  from: z.string().optional(),
+  currency: z.string().optional(),
+}).passthrough();
+
 export const PlusCheckoutResponseSchema = StripeCheckoutResponseSchema.extend({
   sessionId: z.string(),
   clientSecret: z.string().nullable().optional(),

--- a/src/util/api/users/schemas.ts
+++ b/src/util/api/users/schemas.ts
@@ -42,6 +42,18 @@ export const UsersUpdateAvatarBodySchema = z.object({
   avatarSHA256: z.string().optional(),
 });
 
+export const UsersIdParamsSchema = z.object({
+  id: z.string().min(1),
+});
+
+export const UsersAddrParamsSchema = z.object({
+  addr: z.string().min(1),
+});
+
+export const UsersPlatformParamsSchema = z.object({
+  platform: z.string().min(1),
+});
+
 export const UsersPreferencesResponseSchema = z.object({
   locale: z.string().optional(),
   creatorPitch: z.string(),

--- a/src/util/api/wallet/schemas.ts
+++ b/src/util/api/wallet/schemas.ts
@@ -19,6 +19,10 @@ export const WalletEvmMigrateEmailMagicBodySchema = z.object({
   message: z.string().min(1),
 });
 
+export const WalletLikeWalletParamsSchema = z.object({
+  likeWallet: z.string().min(1),
+});
+
 export const WalletAuthorizeResponseSchema = z.object({
   jwtid: z.string(),
   token: z.string(),


### PR DESCRIPTION
Extend zod validation from request bodies to path params and query strings across the arweave, likerland, likernft/book, plus, users and wallet surfaces. Adds validateParams to every route with a path param, and validateQuery where it tightens input the handler did not already guard.

Query schemas use .passthrough() and keep handler-guarded fields optional so existing error responses are preserved; priceIndex path segments are coerced to non-negative integers.