### PR TITLE
🐛 Let sandbox IAP grant overwrite an expired non-sandbox record

### DIFF
--- a/src/util/api/plus/revenuecat.ts
+++ b/src/util/api/plus/revenuecat.ts
@@ -1,6 +1,6 @@
 import type { LikerPlusData } from '../../../types/user';
 
-import { IS_TESTNET, PUBSUB_TOPIC_MISC } from '../../../constant';
+import { IS_TESTNET, PUBSUB_TOPIC_MISC, SUBSCRIPTION_GRACE_PERIOD } from '../../../constant';
 import { userCollection } from '../../firebase';
 import { getUserWithCivicLikerProperties } from '../users/getPublicInfo';
 import { updateIntercomUserAttributes, sendIntercomEvent } from '../../intercom';
@@ -102,16 +102,20 @@ function isQuarantinedSandbox(isSandbox: boolean): boolean {
   return isSandbox && !IS_TESTNET;
 }
 
-// Prevent SANDBOX events on prod from mutating a non-sandbox record. Without
-// this, an App Store reviewer (or anyone with a sandbox account) who collides
-// on app_user_id with an existing paid user could clobber their real sub.
-// Testnet has no production records to protect, so the guard is a no-op there.
-// Mirrors the shape of isStripeOwnedLikerPlus — terminal events only revoke
-// records owned by the same environment.
+// Prevent SANDBOX events on prod from mutating a non-sandbox record with live
+// access. Without this, an App Store reviewer (or anyone with a sandbox account)
+// who collides on app_user_id with an existing paid user could clobber their
+// real sub. Testnet has no production records to protect, so the guard is a
+// no-op there. Mirrors the shape of isStripeOwnedLikerPlus — terminal events
+// only revoke records owned by the same environment.
+// Expired non-sandbox records are not protected — there is no live access to
+// clobber. Expiry matches getPublicInfo's boundary (currentPeriodEnd + grace).
 function isSandboxLockedOut(isSandbox: boolean, likerPlus?: LikerPlusData): boolean {
   if (!isSandbox || IS_TESTNET) return false;
   if (!likerPlus) return false;
-  return likerPlus.environment !== 'SANDBOX';
+  if (likerPlus.environment === 'SANDBOX') return false;
+  const accessUntil = (likerPlus.currentPeriodEnd || 0) + SUBSCRIPTION_GRACE_PERIOD;
+  return accessUntil > Date.now();
 }
 
 const GRANT_EVENT_TYPES = new Set([


### PR DESCRIPTION
The isSandboxLockedOut guard from 5afbc547 was too strict: any non- sandbox record blocked sandbox grants, so a TestFlight tester or App Store reviewer whose only prior Plus was an expired Stripe sub could not resubscribe via mobile IAP — the INITIAL_PURCHASE webhook was silently dropped and Restore Purchases re-fired the same locked-out event. Permit the grant when the existing record's access window has already passed (currentPeriodEnd + SUBSCRIPTION_GRACE_PERIOD <= now); active non-sandbox records remain protected, and the resulting record is still tagged environment='SANDBOX' and quarantined from Slack / Airtable / Intercom / analytics by isQuarantinedSandbox.