### PR TITLE
✨ Serve Meta product catalog feed as CSV via ?format=csv

### DIFF
--- a/src/routes/likernft/book/store.ts
+++ b/src/routes/likernft/book/store.ts
@@ -50,7 +50,7 @@ import {
   getStripeCurrencyOptionsFromNFTBookPrice,
 } from '../../../util/pricing';
 import { cacheBookFilesFromNFTClassMetadata } from '../../../util/api/likernft/book/cache';
-import { getMetaProductCatalogItems } from '../../../util/api/likernft/book/metaCatalog';
+import { getMetaProductCatalogItems, formatMetaProductCatalogCSV } from '../../../util/api/likernft/book/metaCatalog';
 import { normalizeClassIdParam } from '../../../middleware/likernft';
 
 const router = Router();
@@ -94,6 +94,12 @@ router.get('/catalog/meta', async (req, res, next) => {
   try {
     const items = await getMetaProductCatalogItems();
     res.set('Cache-Control', `public, max-age=${ONE_HOUR_IN_S}, s-maxage=${ONE_HOUR_IN_S}, stale-while-revalidate=${ONE_DAY_IN_S}, stale-if-error=${ONE_DAY_IN_S}`);
+    if (req.query.format === 'csv') {
+      res.type('text/csv; charset=utf-8');
+      res.set('Content-Disposition', 'attachment; filename="meta-catalog.csv"');
+      res.send(formatMetaProductCatalogCSV(items));
+      return;
+    }
     res.json({ items });
   } catch (err) {
     next(err);

--- a/src/util/api/likernft/book/metaCatalog.ts
+++ b/src/util/api/likernft/book/metaCatalog.ts
@@ -16,6 +16,10 @@ const META_CATALOG_LOCALE = 'en';
 // use-structured-data.ts.
 const META_CATALOG_FALLBACK_BRAND = '3ook.com';
 const META_CATALOG_GOOGLE_PRODUCT_CATEGORY = 'Media > Books > E-Books';
+// `fb_product_category` uses Meta's own product taxonomy (distinct from Google's
+// taxonomy above) and is a required column in Meta's official catalog CSV
+// template. Books map to "Media > Books".
+const META_CATALOG_FB_PRODUCT_CATEGORY = 'Media > Books';
 // Meta limits a single catalog feed to 200k products; books listings are
 // nowhere near that today, but cap defensively to keep the response bounded.
 const META_CATALOG_MAX_BOOKS = 5000;
@@ -33,9 +37,34 @@ export interface MetaCatalogItem {
   brand: string;
   item_group_id: string;
   google_product_category: string;
+  fb_product_category: string;
   gtin?: string;
   custom_label_0?: string;
 }
+/* eslint-enable camelcase */
+
+// Column order follows Meta's official catalog CSV template (Commerce Manager →
+// Data sources → "Use template"). We emit only the columns we populate; Meta
+// treats absent optional columns as empty. `custom_label_0` is a standard Meta
+// feed column used for product-set filtering even though it is not pre-printed
+// in the downloadable template.
+/* eslint-disable camelcase -- Meta product catalog field names must be snake_case per spec */
+const META_CATALOG_CSV_COLUMNS: Array<keyof MetaCatalogItem> = [
+  'id',
+  'title',
+  'description',
+  'availability',
+  'condition',
+  'price',
+  'link',
+  'image_link',
+  'brand',
+  'google_product_category',
+  'fb_product_category',
+  'item_group_id',
+  'gtin',
+  'custom_label_0',
+];
 /* eslint-enable camelcase */
 
 function formatPrice(price: NFTBookPrice): string {
@@ -82,6 +111,7 @@ function buildItem(
     brand,
     item_group_id: classId,
     google_product_category: META_CATALOG_GOOGLE_PRODUCT_CATEGORY,
+    fb_product_category: META_CATALOG_FB_PRODUCT_CATEGORY,
   };
   // Mirrors `product:custom_label_0` in liker-land-v3 (owner wallet address).
   if (book.ownerWallet) item.custom_label_0 = book.ownerWallet;
@@ -118,4 +148,26 @@ export async function getMetaProductCatalogItems(): Promise<MetaCatalogItem[]> {
     });
   });
   return items;
+}
+
+// Defang spreadsheet formula injection (CWE-1236): publisher-supplied fields
+// (title/description/brand) could start with a formula trigger. Meta ingests
+// the value as-is, but an admin opening the downloaded feed in Excel/Sheets
+// would otherwise evaluate it. Prefix a single quote per OWASP, before the
+// RFC 4180 quoting below so quoted cells are defanged too.
+// RFC 4180: wrap a field in double quotes when it contains a comma, quote, or
+// line break, and escape embedded quotes by doubling them. Book descriptions
+// routinely contain all three, so this keeps columns from shifting.
+function escapeCSVField(value: string | undefined): string {
+  if (!value) return '';
+  const defanged = /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+  return /[",\r\n]/.test(defanged) ? `"${defanged.replace(/"/g, '""')}"` : defanged;
+}
+
+export function formatMetaProductCatalogCSV(items: MetaCatalogItem[]): string {
+  const header = META_CATALOG_CSV_COLUMNS.join(',');
+  const rows = items.map((item) => META_CATALOG_CSV_COLUMNS
+    .map((col) => escapeCSVField(item[col]))
+    .join(','));
+  return `${header}\n${rows.join('\n')}`;
 }

--- a/test/unit/meta-catalog.test.ts
+++ b/test/unit/meta-catalog.test.ts
@@ -1,7 +1,8 @@
 import {
   describe, it, expect, beforeEach, vi,
 } from 'vitest';
-import { getMetaProductCatalogItems } from '../../src/util/api/likernft/book/metaCatalog';
+import { getMetaProductCatalogItems, formatMetaProductCatalogCSV } from '../../src/util/api/likernft/book/metaCatalog';
+import type { MetaCatalogItem } from '../../src/util/api/likernft/book/metaCatalog';
 import { listLatestNFTBookInfo } from '../../src/util/api/likernft/book/index';
 import type { NFTBookListingInfo } from '../../src/types/book';
 
@@ -70,6 +71,7 @@ describe('getMetaProductCatalogItems', () => {
     expect(item.brand).toBe('Penguin');
     expect(item.item_group_id).toBe('class-a');
     expect(item.google_product_category).toBe('Media > Books > E-Books');
+    expect(item.fb_product_category).toBe('Media > Books');
     // hyphenated ISBN-13 normalized to a 13-digit GTIN
     expect(item.gtin).toBe('9783161484100');
     expect(item.custom_label_0).toBe('0xabc');
@@ -156,5 +158,72 @@ describe('getMetaProductCatalogItems', () => {
         id: 'noimage', classId: 'noimage', name: 'No Image', prices: [{ priceInDecimal: 1000 }], // missing image → dropped
       },
     ], ['mixed-0']);
+  });
+});
+
+describe('formatMetaProductCatalogCSV', () => {
+  const baseItem: MetaCatalogItem = {
+    id: 'class-a-0',
+    title: 'The Great Book',
+    description: 'Full description',
+    availability: 'in stock',
+    condition: 'new',
+    price: '15.00 USD',
+    link: 'https://3ook.com/store/class-a?priceIndex=0',
+    image_link: 'https://img.example/a.jpg',
+    brand: 'Penguin',
+    item_group_id: 'class-a',
+    google_product_category: 'Media > Books > E-Books',
+    fb_product_category: 'Media > Books',
+    gtin: '9783161484100',
+    custom_label_0: '0xabc',
+  };
+
+  it('emits the template header in column order', () => {
+    const [header] = formatMetaProductCatalogCSV([]).split('\n');
+    expect(header).toBe(
+      'id,title,description,availability,condition,price,link,image_link,brand,'
+      + 'google_product_category,fb_product_category,item_group_id,gtin,custom_label_0',
+    );
+  });
+
+  it('serializes an item into a row matching the header order', () => {
+    const [, row] = formatMetaProductCatalogCSV([baseItem]).split('\n');
+    expect(row).toBe(
+      'class-a-0,The Great Book,Full description,in stock,new,15.00 USD,'
+      + 'https://3ook.com/store/class-a?priceIndex=0,https://img.example/a.jpg,Penguin,'
+      + 'Media > Books > E-Books,Media > Books,class-a,9783161484100,0xabc',
+    );
+  });
+
+  it('quotes and escapes fields containing commas, quotes, and newlines', () => {
+    const csv = formatMetaProductCatalogCSV([{
+      ...baseItem,
+      title: 'Book, "Special" Edition',
+      description: 'Line one\nLine two',
+    }]);
+    // Don't split on '\n' here: the escaped description legitimately contains one.
+    expect(csv).toContain('class-a-0,"Book, ""Special"" Edition","Line one\nLine two",');
+  });
+
+  it('defangs spreadsheet formula injection in publisher-supplied fields', () => {
+    const csv = formatMetaProductCatalogCSV([{
+      ...baseItem,
+      title: '=HYPERLINK("http://evil")',
+      brand: '@SUM(A1)',
+    }]);
+    // Leading formula triggers get a single-quote prefix; the '=' value also
+    // contains a comma/quote so it is additionally RFC 4180 quoted.
+    expect(csv).toContain('"\'=HYPERLINK(""http://evil"")"');
+    expect(csv).toContain(",'@SUM(A1),");
+  });
+
+  it('leaves optional columns blank when absent', () => {
+    const withoutOptional: MetaCatalogItem = { ...baseItem };
+    delete withoutOptional.gtin;
+    delete withoutOptional.custom_label_0;
+    const [, row] = formatMetaProductCatalogCSV([withoutOptional]).split('\n');
+    // trailing gtin and custom_label_0 columns are empty
+    expect(row.endsWith('class-a,,')).toBe(true);
   });
 });


### PR DESCRIPTION
Meta's scheduled data feed ingests CSV/XML, not the JSON envelope the endpoint returned. Add a ?format=csv branch that emits the catalog in Meta's official template column order with RFC 4180 escaping, plus the required fb_product_category field.