### PR TITLE
✨ Add zod request validation + response schemas across API surfaces

### DIFF
--- a/src/routes/email/index.ts
+++ b/src/routes/email/index.ts
@@ -11,12 +11,18 @@ import {
 import publisher from '../../util/gcloudPub';
 import { sendVerificationEmail } from '../../util/sendgrid';
 import { ValidationError } from '../../util/ValidationError';
+import { validateParams, validateBody } from '../../middleware/validate';
+import {
+  EmailVerifyUserParamsSchema,
+  EmailVerifyUserBodySchema,
+  EmailVerifyParamsSchema,
+} from '../../util/api/email/schemas';
 
 const THIRTY_S_IN_MS = 30000;
 
 const router = Router();
 
-router.post('/verify/user/:id/', async (req, res, next) => {
+router.post('/verify/user/:id/', validateParams(EmailVerifyUserParamsSchema), validateBody(EmailVerifyUserBodySchema), async (req, res, next) => {
   try {
     const username = req.params.id;
     const { ref } = req.body;
@@ -70,7 +76,7 @@ router.post('/verify/user/:id/', async (req, res, next) => {
   }
 });
 
-router.post('/verify/:uuid', async (req, res, next) => {
+router.post('/verify/:uuid', validateParams(EmailVerifyParamsSchema), async (req, res, next) => {
   try {
     const verificationUUID = req.params.uuid;
     const query = await dbRef.where('verificationUUID', '==', verificationUUID).get();

--- a/src/routes/likernft/book/store.ts
+++ b/src/routes/likernft/book/store.ts
@@ -25,6 +25,7 @@ import {
   BookClassIdPriceIndexParamsSchema,
   BookSearchQuerySchema,
   BookListQuerySchema,
+  BookCatalogMetaQuerySchema,
   type BookListQuery,
 } from '../../../util/api/likernft/book/schemas';
 import { validateBody, validateParams, validateQuery } from '../../../middleware/validate';
@@ -94,7 +95,7 @@ router.get('/search', validateQuery(BookSearchQuerySchema), async (req, res, nex
   }
 });
 
-router.get('/catalog/meta', async (req, res, next) => {
+router.get('/catalog/meta', validateQuery(BookCatalogMetaQuerySchema), async (req, res, next) => {
   try {
     const items = await getMetaProductCatalogItems();
     res.set('Cache-Control', `public, max-age=${ONE_HOUR_IN_S}, s-maxage=${ONE_HOUR_IN_S}, stale-while-revalidate=${ONE_DAY_IN_S}, stale-if-error=${ONE_DAY_IN_S}`);
@@ -179,7 +180,7 @@ router.get('/list/moderated', jwtAuth('read:nftbook'), async (req, res, next) =>
           ownerWallet,
         } = b;
         const { stock, sold, prices } = filterNFTBookPricesInfo(docPrices, true);
-        const result: Record<string, unknown> = {
+        return {
           classId: id,
           prices,
           pendingNFTCount,
@@ -187,7 +188,6 @@ router.get('/list/moderated', jwtAuth('read:nftbook'), async (req, res, next) =>
           sold,
           ownerWallet,
         };
-        return result;
       });
     res.json({ list });
   } catch (err) {

--- a/src/routes/likernft/book/user.ts
+++ b/src/routes/likernft/book/user.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { ValidationError } from '../../../util/ValidationError';
 import { jwtAuth, jwtOptionalAuth } from '../../../middleware/jwt';
-import { validateBody, validateParams } from '../../../middleware/validate';
+import { validateBody, validateParams, validateQuery } from '../../../middleware/validate';
 import { FieldValue, likeNFTBookUserCollection } from '../../../util/firebase';
 import { getStripeClient } from '../../../util/stripe';
 import { BOOK3_HOSTNAME, NFT_BOOKSTORE_HOSTNAME, PUBSUB_TOPIC_MISC } from '../../../constant';
@@ -12,6 +12,7 @@ import { getBookUserInfoFromWallet } from '../../../util/api/likernft/book/user'
 import {
   StripeConnectNewBodySchema,
   BookIdParamsSchema,
+  BookConnectStatusQuerySchema,
   type StripeConnectSite,
 } from '../../../util/api/likernft/book/schemas';
 import type { BookPurchaseCommission } from '../../../types/book';
@@ -62,6 +63,7 @@ router.get(
 router.get(
   '/connect/status',
   jwtOptionalAuth('read:nftbook'),
+  validateQuery(BookConnectStatusQuerySchema),
   async (req, res, next) => {
     try {
       const { wallet } = req.query;

--- a/src/routes/likernft/history.ts
+++ b/src/routes/likernft/history.ts
@@ -3,6 +3,11 @@ import axios from 'axios';
 import { ValidationError } from '../../util/ValidationError';
 import { getISCNDocByClassId } from '../../util/api/likernft';
 import { fetchISCNPrefixAndClassId } from '../../middleware/likernft';
+import { validateQuery } from '../../middleware/validate';
+import {
+  LikernftClassQuerySchema,
+  LikernftHistoryQuerySchema,
+} from '../../util/api/likernft/schemas';
 import { COSMOS_LCD_INDEXER_ENDPOINT } from '../../../config/config';
 import { ONE_DAY_IN_S } from '../../constant';
 
@@ -10,6 +15,7 @@ const router = Router();
 
 router.get(
   '/history',
+  validateQuery(LikernftHistoryQuerySchema),
   fetchISCNPrefixAndClassId,
   async (req, res, next) => {
     try {
@@ -40,6 +46,7 @@ router.get(
 
 router.get(
   '/events',
+  validateQuery(LikernftClassQuerySchema),
   fetchISCNPrefixAndClassId,
   async (_, res, next) => {
     try {

--- a/src/routes/likernft/metadata.ts
+++ b/src/routes/likernft/metadata.ts
@@ -15,6 +15,12 @@ import {
 } from '../../util/api/likernft/metadata';
 import { getNFTClassDataById, getNFTISCNData } from '../../util/cosmos/nft';
 import { fetchISCNPrefixAndClassId, normalizeClassIdParam } from '../../middleware/likernft';
+import { validateParams, validateQuery } from '../../middleware/validate';
+import {
+  LikernftClassQuerySchema,
+  LikernftClassIdParamsSchema,
+  LikernftImageQuerySchema,
+} from '../../util/api/likernft/schemas';
 import { ValidationError } from '../../util/ValidationError';
 import { sleep } from '../../util/misc';
 import { BOOK_MODEL_GLTF, CLASS_ID_PLACEHOLDER, IMAGE_URI_PLACEHOLDER } from '../../constant/model';
@@ -25,6 +31,7 @@ router.param('classId', normalizeClassIdParam);
 
 router.get(
   '/metadata',
+  validateQuery(LikernftClassQuerySchema),
   fetchISCNPrefixAndClassId,
   async (_, res, next) => {
     try {
@@ -50,6 +57,8 @@ router.get(
 
 router.get(
   ['/image/class_:classId', '/image/class_:classId.png', '/metadata/image/class_:classId', '/metadata/image/class_:classId.png'],
+  validateParams(LikernftClassIdParamsSchema),
+  validateQuery(LikernftImageQuerySchema),
   async (req, res, next) => {
     try {
       const { classId } = req.params;
@@ -110,6 +119,7 @@ router.get(
 
 router.get(
   ['/model/class_:classId.gltf', '/metadata/model/class_:classId.gltf'],
+  validateParams(LikernftClassIdParamsSchema),
   async (req, res, next) => {
     try {
       const { classId } = req.params;

--- a/src/routes/likernft/mint.ts
+++ b/src/routes/likernft/mint.ts
@@ -3,11 +3,14 @@ import { Router } from 'express';
 import { filterLikeNFTISCNData } from '../../util/ValidationHelper';
 import { getISCNDocByClassId } from '../../util/api/likernft';
 import { fetchISCNPrefixAndClassId } from '../../middleware/likernft';
+import { validateQuery } from '../../middleware/validate';
+import { LikernftClassQuerySchema } from '../../util/api/likernft/schemas';
 
 const router = Router();
 
 router.get(
   '/mint',
+  validateQuery(LikernftClassQuerySchema),
   fetchISCNPrefixAndClassId,
   async (_, res, next) => {
     try {

--- a/src/routes/likernft/user.ts
+++ b/src/routes/likernft/user.ts
@@ -3,11 +3,14 @@ import { isValidLikeAddress } from '../../util/cosmos';
 import { getUserStat } from '../../util/api/likernft/user';
 import { ValidationError } from '../../util/ValidationError';
 import { ONE_DAY_IN_S } from '../../constant';
+import { validateParams } from '../../middleware/validate';
+import { LikernftUserStatsParamsSchema } from '../../util/api/likernft/schemas';
 
 const router = Router();
 
 router.get(
   '/user/:wallet/stats',
+  validateParams(LikernftUserStatsParamsSchema),
   async (req, res, next) => {
     try {
       const { wallet } = req.params;

--- a/src/routes/misc/price.ts
+++ b/src/routes/misc/price.ts
@@ -6,12 +6,14 @@ import {
 import { ValidationError } from '../../util/ValidationError';
 import { getLIKEPrice } from '../../util/api/likernft/likePrice';
 import { ONE_DAY_IN_S } from '../../constant';
+import { validateQuery } from '../../middleware/validate';
+import { MiscPriceQuerySchema } from '../../util/api/misc/schemas';
 
 const router = Router();
 
 const CACHE_IN_S = CMC_API_CACHE_S || 300; // Rate limit: 333 per day ~ 1 per 259s
 
-router.get('/price', async (req, res) => {
+router.get('/price', validateQuery(MiscPriceQuerySchema), async (req, res) => {
   const { currency = 'usd' } = req.query;
   if (currency !== 'usd') {
     throw new ValidationError('Unsupported currency.');

--- a/src/routes/misc/totalSupply.ts
+++ b/src/routes/misc/totalSupply.ts
@@ -10,6 +10,8 @@ import { LIKE_COIN_ABI as LIKE_COIN_V1_ABI, LIKE_COIN_ADDRESS as LIKE_COIN_V1_AD
 import { LIKE_COIN_V3_ABI, LIKE_COIN_V3_ADDRESS } from '../../constant/contract/likecoinV3';
 import { getCosmosTotalSupply, getCosmosAccountLIKE } from '../../util/cosmos';
 import { getEVMClient } from '../../util/evm/client';
+import { validateQuery } from '../../middleware/validate';
+import { MiscSupplyQuerySchema } from '../../util/api/misc/schemas';
 
 const router = Router();
 
@@ -36,7 +38,7 @@ const evmPublicClient = createPublicClient({
   transport: http(),
 });
 
-router.get('/totalsupply/erc20', async (req, res, next) => {
+router.get('/totalsupply/erc20', validateQuery(MiscSupplyQuerySchema), async (req, res, next) => {
   try {
     let rawSupply = new BigNumber(await readContract(evmPublicClient, {
       address: LIKE_COIN_V1_ADDRESS,
@@ -55,7 +57,7 @@ router.get('/totalsupply/erc20', async (req, res, next) => {
   }
 });
 
-router.get('/circulating/erc20', async (req, res, next) => {
+router.get('/circulating/erc20', validateQuery(MiscSupplyQuerySchema), async (req, res, next) => {
   try {
     const rawSupply = await readContract(evmPublicClient, {
       address: LIKE_COIN_V1_ADDRESS,
@@ -86,7 +88,7 @@ router.get('/circulating/erc20', async (req, res, next) => {
   }
 });
 
-router.get('/totalsupply/v3', async (req, res, next) => {
+router.get('/totalsupply/v3', validateQuery(MiscSupplyQuerySchema), async (req, res, next) => {
   try {
     const evmClient = getEVMClient();
     let rawSupply = new BigNumber(await readContract(evmClient, {
@@ -106,7 +108,7 @@ router.get('/totalsupply/v3', async (req, res, next) => {
   }
 });
 
-router.get('/circulating/v3', async (req, res, next) => {
+router.get('/circulating/v3', validateQuery(MiscSupplyQuerySchema), async (req, res, next) => {
   try {
     const evmClient = getEVMClient();
     const rawSupply = await readContract(evmClient, {
@@ -138,7 +140,7 @@ router.get('/circulating/v3', async (req, res, next) => {
   }
 });
 
-router.get(['/totalsupply', '/totalsupply/likecoinchain'], async (req, res, next) => {
+router.get(['/totalsupply', '/totalsupply/likecoinchain'], validateQuery(MiscSupplyQuerySchema), async (req, res, next) => {
   try {
     let rawSupply = new BigNumber(await getCosmosTotalSupply());
     if (req.query.raw === '1') {
@@ -152,7 +154,7 @@ router.get(['/totalsupply', '/totalsupply/likecoinchain'], async (req, res, next
   }
 });
 
-router.get(['/circulating', '/circulating/likecoinchain'], async (req, res, next) => {
+router.get(['/circulating', '/circulating/likecoinchain'], validateQuery(MiscSupplyQuerySchema), async (req, res, next) => {
   try {
     const rawSupply = await getCosmosTotalSupply();
     const amounts = await Promise.all(v2reservedCosmosWallets

--- a/src/routes/oembed/index.ts
+++ b/src/routes/oembed/index.ts
@@ -9,6 +9,8 @@ import {
 import {
   userCollection as dbRef,
 } from '../../util/firebase';
+import { validateQuery } from '../../middleware/validate';
+import { OembedQuerySchema } from '../../util/api/oembed/schemas';
 
 const allowedSubdomains = ['www.', 'rinkeby.', 'button.', 'button.rinkeby.', 'widget.'];
 const domainRegexp = /^((?:[a-z0-9]+\.)+)?like\.co$/;
@@ -188,7 +190,7 @@ function parseURL(url) {
   }
 }
 
-router.get('/', async (req, res, next) => {
+router.get('/', validateQuery(OembedQuerySchema), async (req, res, next) => {
   try {
     const { url, format = 'json' } = req.query;
     if (!url) {

--- a/src/routes/tx/history.ts
+++ b/src/routes/tx/history.ts
@@ -9,6 +9,12 @@ import {
 } from '../../util/firebase';
 import { filterMultipleTxData } from '../../util/api/tx';
 import { jwtAuth } from '../../middleware/jwt';
+import { validateParams, validateQuery } from '../../middleware/validate';
+import {
+  TxHistoryUserParamsSchema,
+  TxHistoryAddrParamsSchema,
+  TxHistoryQuerySchema,
+} from '../../util/api/tx/schemas';
 import { ValidationError } from '../../util/ValidationError';
 import {
   filterTxData,
@@ -17,7 +23,7 @@ import {
 
 const router = Router();
 
-router.get('/history/user/:id', jwtAuth('read'), async (req, res, next) => {
+router.get('/history/user/:id', jwtAuth('read'), validateParams(TxHistoryUserParamsSchema), validateQuery(TxHistoryQuerySchema), async (req, res, next) => {
   try {
     const { id } = req.params;
     if (req.user.user !== id) {
@@ -68,7 +74,7 @@ router.get('/history/user/:id', jwtAuth('read'), async (req, res, next) => {
   }
 });
 
-router.get('/history/addr/:addr', jwtAuth('read'), async (req, res, next) => {
+router.get('/history/addr/:addr', jwtAuth('read'), validateParams(TxHistoryAddrParamsSchema), validateQuery(TxHistoryQuerySchema), async (req, res, next) => {
   try {
     const { addr } = req.params;
 

--- a/src/routes/tx/tx.ts
+++ b/src/routes/tx/tx.ts
@@ -4,6 +4,12 @@ import { txCollection as txLogRef, userCollection } from '../../util/firebase';
 import { filterMultipleTxData } from '../../util/api/tx';
 import { filterTxData } from '../../util/ValidationHelper';
 import { jwtOptionalAuth } from '../../middleware/jwt';
+import { validateParams, validateQuery, validateBody } from '../../middleware/validate';
+import {
+  TxIdParamsSchema,
+  TxIdQuerySchema,
+  TxMetadataBodySchema,
+} from '../../util/api/tx/schemas';
 import {
   TX_METADATA_TYPES,
   TX_METADATA_TIME,
@@ -13,7 +19,7 @@ import { RPC_TX_UPDATE_COOKIE_KEY } from '../../constant';
 
 const router = Router();
 
-router.get('/id/:id', async (req, res, next) => {
+router.get('/id/:id', validateParams(TxIdParamsSchema), validateQuery(TxIdQuerySchema), async (req, res, next) => {
   try {
     const { id: txHash } = req.params;
     const { address } = req.query;
@@ -36,7 +42,7 @@ router.get('/id/:id', async (req, res, next) => {
   }
 });
 
-router.post('/id/:id/metadata', jwtOptionalAuth('write'), async (req, res, next) => {
+router.post('/id/:id/metadata', jwtOptionalAuth('write'), validateParams(TxIdParamsSchema), validateBody(TxMetadataBodySchema), async (req, res, next) => {
   try {
     const { id: txHash } = req.params;
     const { user } = (req.user || {});

--- a/src/routes/users/apiRegister.ts
+++ b/src/routes/users/apiRegister.ts
@@ -19,7 +19,12 @@ import {
   handleTransferPlatformDelegatedUser,
 } from '../../util/api/users/platforms';
 import { createAuthCoreUserAndWallet } from '../../util/api/users/authcore';
-import { UsersNewCheckBodySchema, UsersPlatformParamsSchema } from '../../util/api/users/schemas';
+import {
+  UsersNewCheckBodySchema,
+  UsersPlatformParamsSchema,
+  UsersNewPlatformBodySchema,
+  UsersEditPlatformBodySchema,
+} from '../../util/api/users/schemas';
 import { validateBody, validateParams } from '../../middleware/validate';
 import { fetchMattersUser } from '../../util/oauth/matters';
 import { checkUserNameValid } from '../../util/ValidationHelper';
@@ -73,7 +78,7 @@ router.post('/new/check', validateBody(UsersNewCheckBodySchema), async (req, res
   }
 });
 
-router.post('/new/:platform', getOAuthClientInfo(), validateParams(UsersPlatformParamsSchema), async (req, res, next) => {
+router.post('/new/:platform', getOAuthClientInfo(), validateParams(UsersPlatformParamsSchema), validateBody(UsersNewPlatformBodySchema), async (req, res, next) => {
   const {
     platform,
   } = req.params;
@@ -210,7 +215,7 @@ router.post('/new/:platform', getOAuthClientInfo(), validateParams(UsersPlatform
   }
 });
 
-router.post('/edit/:platform', getOAuthClientInfo(), validateParams(UsersPlatformParamsSchema), async (req, res, next) => {
+router.post('/edit/:platform', getOAuthClientInfo(), validateParams(UsersPlatformParamsSchema), validateBody(UsersEditPlatformBodySchema), async (req, res, next) => {
   const { platform } = req.params;
   if (req.auth.platform !== platform) {
     throw new ValidationError('AUTH_PLATFORM_NOT_MATCH');

--- a/src/routes/users/registerLogin.ts
+++ b/src/routes/users/registerLogin.ts
@@ -33,6 +33,9 @@ import { validateBody } from '../../middleware/validate';
 import {
   UsersUpdateAvatarBodySchema,
   UsersUpdateBodySchema,
+  UsersRegisterBodySchema,
+  UsersLoginBodySchema,
+  UsersSyncAuthcoreBodySchema,
 } from '../../util/api/users/schemas';
 import { authCoreJwtSignToken, authCoreJwtVerify } from '../../util/jwt';
 import publisher from '../../util/gcloudPub';
@@ -90,6 +93,7 @@ router.post(
   '/new',
   formdataParserForApp,
   apiLimiter,
+  validateBody(UsersRegisterBodySchema),
   async (req, res, next) => {
     const {
       platform,
@@ -440,7 +444,7 @@ router.post(
   },
 );
 
-router.post('/sync/authcore', jwtAuth('write'), async (req, res, next) => {
+router.post('/sync/authcore', jwtAuth('write'), validateBody(UsersSyncAuthcoreBodySchema), async (req, res, next) => {
   try {
     const { user } = req.user;
     const {
@@ -484,7 +488,7 @@ router.post('/sync/authcore', jwtAuth('write'), async (req, res, next) => {
   }
 });
 
-router.post('/login', async (req, res, next) => {
+router.post('/login', validateBody(UsersLoginBodySchema), async (req, res, next) => {
   try {
     let user;
     let wallet;

--- a/src/routes/wallet/index.ts
+++ b/src/routes/wallet/index.ts
@@ -17,6 +17,8 @@ import {
 import {
   WalletAuthorizeBodySchema,
   WalletEvmMigrateEmailMagicBodySchema,
+  WalletEvmMigrateBookBodySchema,
+  WalletEvmMigrateBodySchema,
   WalletLikeWalletParamsSchema,
 } from '../../util/api/wallet/schemas';
 import { validateBody, validateParams } from '../../middleware/validate';
@@ -99,7 +101,7 @@ router.post('/authorize', validateBody(WalletAuthorizeBodySchema), async (req, r
   }
 });
 
-router.post('/evm/migrate/book', async (req, res, next) => {
+router.post('/evm/migrate/book', validateBody(WalletEvmMigrateBookBodySchema), async (req, res, next) => {
   try {
     const {
       like_class_id: likeClassId,
@@ -237,7 +239,7 @@ router.post('/evm/migrate/email/magic', validateBody(WalletEvmMigrateEmailMagicB
   }
 });
 
-router.post(['/evm/migrate/user', '/evm/migrate/all'], async (req, res, next) => {
+router.post(['/evm/migrate/user', '/evm/migrate/all'], validateBody(WalletEvmMigrateBodySchema), async (req, res, next) => {
   try {
     const {
       cosmos_address: likeWallet,

--- a/src/util/api/email/schemas.ts
+++ b/src/util/api/email/schemas.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const EmailVerifyUserParamsSchema = z.object({
+  id: z.string().min(1),
+});
+
+// Only `ref` is read by the handler; .passthrough() keeps body intact.
+export const EmailVerifyUserBodySchema = z.object({
+  ref: z.string().optional(),
+}).passthrough();
+
+export const EmailVerifyParamsSchema = z.object({
+  uuid: z.string().min(1),
+});
+
+export const EmailVerifyResponseSchema = z.object({
+  referrer: z.boolean(),
+  wallet: z.string().optional(),
+});

--- a/src/util/api/likernft/book/schemas.ts
+++ b/src/util/api/likernft/book/schemas.ts
@@ -193,6 +193,14 @@ export const BookListQuerySchema = BookListPaginationQuerySchema.extend({
 });
 export type BookListQuery = z.infer<typeof BookListQuerySchema>;
 
+export const BookCatalogMetaQuerySchema = z.object({
+  format: z.string().optional(),
+}).passthrough();
+
+export const BookConnectStatusQuerySchema = z.object({
+  wallet: z.string().optional(),
+}).passthrough();
+
 export const ClassIdResponseSchema = z.object({
   classId: z.string(),
 });

--- a/src/util/api/likernft/schemas.ts
+++ b/src/util/api/likernft/schemas.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+// class_id / iscn_id are resolved by the fetchISCNPrefixAndClassId middleware,
+// which throws MISSING_ISCN_OR_CLASS_ID itself; keep them optional and use
+// .passthrough() so the middleware still sees them after req.query reassignment.
+export const LikernftClassQuerySchema = z.object({
+  class_id: z.string().optional(),
+  iscn_id: z.string().optional(),
+}).passthrough();
+
+export const LikernftHistoryQuerySchema = z.object({
+  class_id: z.string().optional(),
+  iscn_id: z.string().optional(),
+  nft_id: z.string().optional(),
+  tx_hash: z.string().optional(),
+}).passthrough();
+
+export const LikernftClassIdParamsSchema = z.object({
+  classId: z.string().min(1),
+});
+
+// size is parsed + clamped in-handler; keep permissive.
+export const LikernftImageQuerySchema = z.object({
+  size: z.string().optional(),
+}).passthrough();
+
+export const LikernftUserStatsParamsSchema = z.object({
+  wallet: z.string().min(1),
+});

--- a/src/util/api/misc/schemas.ts
+++ b/src/util/api/misc/schemas.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+// Query schemas use .passthrough() so the validate middleware's req.query
+// reassignment does not strip params; fields stay .optional() because the
+// handlers already guard them (currency throws UNSUPPORTED_CURRENCY, raw is
+// only compared against '1').
+
+export const MiscPriceQuerySchema = z.object({
+  currency: z.string().optional(),
+}).passthrough();
+
+export const MiscSupplyQuerySchema = z.object({
+  raw: z.string().optional(),
+}).passthrough();
+
+export const MiscPriceResponseSchema = z.object({
+  price: z.number(),
+});

--- a/src/util/api/oembed/schemas.ts
+++ b/src/util/api/oembed/schemas.ts
@@ -1,0 +1,10 @@
+/* eslint-disable import/prefer-default-export */
+import { z } from 'zod';
+
+// Fields stay .optional() because the handler throws specific errors
+// (missing url, invalid domain/subdomain, invalid format) and defaults
+// format to 'json'. .passthrough() preserves the query on reassignment.
+export const OembedQuerySchema = z.object({
+  url: z.string().optional(),
+  format: z.string().optional(),
+}).passthrough();

--- a/src/util/api/tx/schemas.ts
+++ b/src/util/api/tx/schemas.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+// Params schemas list every route :param. Query schemas use .passthrough()
+// and keep fields .optional() because the handlers already coerce ts/count
+// with Number()+NaN-fallback and validate addr via checkAddressValid.
+
+export const TxHistoryUserParamsSchema = z.object({
+  id: z.string().min(1),
+});
+
+export const TxHistoryAddrParamsSchema = z.object({
+  addr: z.string().min(1),
+});
+
+export const TxHistoryQuerySchema = z.object({
+  ts: z.union([z.string(), z.number()]).optional(),
+  count: z.union([z.string(), z.number()]).optional(),
+}).passthrough();
+
+export const TxIdParamsSchema = z.object({
+  id: z.string().min(1),
+});
+
+export const TxIdQuerySchema = z.object({
+  address: z.string().optional(),
+}).passthrough();
+
+// metadata is validated in-handler against TX_METADATA_TYPES; keep permissive.
+export const TxMetadataBodySchema = z.object({
+  metadata: z.record(z.string(), z.unknown()).optional(),
+}).passthrough();

--- a/src/util/api/users/schemas.ts
+++ b/src/util/api/users/schemas.ts
@@ -54,6 +54,47 @@ export const UsersPlatformParamsSchema = z.object({
   platform: z.string().min(1),
 });
 
+// Platform register/edit bodies are validated extensively in-handler and vary
+// per platform; keep permissive + .passthrough() so behaviour is unchanged.
+export const UsersNewPlatformBodySchema = z.object({
+  user: z.string().optional(),
+  displayName: z.string().optional(),
+  email: z.string().optional(),
+  locale: z.string().optional(),
+  isEmailEnabled: z.union([z.boolean(), z.string()]).optional(),
+  sourceURL: z.string().optional(),
+  token: z.string().optional(),
+}).passthrough();
+
+export const UsersEditPlatformBodySchema = z.object({
+  payload: z.record(z.string(), z.unknown()).optional(),
+  action: z.string().optional(),
+  user: z.string().optional(),
+}).passthrough();
+
+// /new reads many platform-specific body fields and forwards the whole body
+// (`payload = req.body`); .passthrough() is required so nothing is stripped.
+export const UsersRegisterBodySchema = z.object({
+  platform: z.string().optional(),
+  appReferrer: z.string().optional(),
+  user: z.string().optional(),
+  displayName: z.string().optional(),
+  description: z.string().optional(),
+  locale: z.string().optional(),
+  email: z.string().optional(),
+}).passthrough();
+
+export const UsersLoginBodySchema = z.object({
+  platform: z.string().optional(),
+  appReferrer: z.string().optional(),
+  sourceURL: z.string().optional(),
+  utmSource: z.string().optional(),
+}).passthrough();
+
+export const UsersSyncAuthcoreBodySchema = z.object({
+  authCoreAccessToken: z.string().optional(),
+}).passthrough();
+
 export const UsersPreferencesResponseSchema = z.object({
   locale: z.string().optional(),
   creatorPitch: z.string(),
@@ -63,6 +104,12 @@ export const UsersPreferencesResponseSchema = z.object({
 export const UsersUpdateAvatarResponseSchema = z.object({
   avatar: z.string().url(),
 });
+
+export const UsersPlatformAuthResponseSchema = z.object({
+  accessToken: z.string().optional(),
+  refreshToken: z.string().optional(),
+  scope: z.union([z.string(), z.array(z.string())]).optional(),
+}).passthrough();
 
 export const UserDataMinResponseSchema = z.object({
   user: z.string(),
@@ -134,5 +181,6 @@ export const UserDataScopedResponseSchema = UserDataMinResponseSchema.extend({
 });
 
 export const UserProfileResponseSchema = UserDataScopedResponseSchema.extend({
-  intercomToken: z.string(),
+  // createIntercomTokenForUser returns undefined when Intercom is unconfigured.
+  intercomToken: z.string().optional(),
 });

--- a/src/util/api/wallet/schemas.ts
+++ b/src/util/api/wallet/schemas.ts
@@ -19,6 +19,21 @@ export const WalletEvmMigrateEmailMagicBodySchema = z.object({
   message: z.string().min(1),
 });
 
+// snake_case body fields kept .optional() + .passthrough(): the handlers throw
+// their own INVALID_PAYLOAD when a field is missing.
+export const WalletEvmMigrateBookBodySchema = z.object({
+  like_class_id: z.string().optional(),
+  evm_class_id: z.string().optional(),
+}).passthrough();
+
+export const WalletEvmMigrateBodySchema = z.object({
+  cosmos_address: z.string().optional(),
+  cosmos_signature: z.string().optional(),
+  cosmos_public_key: z.string().optional(),
+  cosmos_signature_content: z.string().optional(),
+  signMethod: z.string().optional(),
+}).passthrough();
+
 export const WalletLikeWalletParamsSchema = z.object({
   likeWallet: z.string().min(1),
 });
@@ -34,10 +49,12 @@ export const WalletEvmMigrateResponseSchema = z.object({
   isMigratedBookOwner: z.boolean(),
   isMigratedLikerId: z.boolean(),
   isMigratedLikerLand: z.boolean(),
-  migratedLikerId: z.string().optional(),
-  migratedLikerLandUser: z.string().optional(),
-  migrateBookUserError: z.string().optional(),
-  migrateBookOwnerError: z.string().optional(),
-  migrateLikerIdError: z.string().optional(),
-  migrateLikerLandError: z.string().optional(),
+  // migrateLikeWalletToEVMWallet returns null (not undefined) for absent values,
+  // and the liker-land error is an untyped axios response body.
+  migratedLikerId: z.string().nullable(),
+  migratedLikerLandUser: z.string().nullable(),
+  migrateBookUserError: z.string().nullable(),
+  migrateBookOwnerError: z.string().nullable(),
+  migrateLikerIdError: z.string().nullable(),
+  migrateLikerLandError: z.unknown().nullable(),
 });


### PR DESCRIPTION
Wire validateBody/validateQuery/validateParams onto misc, tx, email, oembed, likernft (non-book + book list/catalog/connect), users (register/login/edit), and wallet migrate endpoints, with new per-surface schemas.ts files. Declare response schemas (kept inferred-only for now) and refine existing ones (nullable/optional fixes) to match real handler output.