### PR TITLE
[TAS-5919] ✨ Auto-link Magic email logins to legacy likeWallet accounts

### DIFF
--- a/src/constant/index.ts
+++ b/src/constant/index.ts
@@ -49,6 +49,29 @@ export const KNOWN_EMAIL_HOSTS = [
   'icloud.com',
 ];
 
+// Gmail-family domains ignore dots in the local part, so dots are stripped when
+// normalizing. Other providers treat dots as significant and must keep them.
+export const NORMALIZABLE_EMAIL_HOSTS = ['gmail.com', 'googlemail.com'];
+
+// Providers where "+tag" subaddressing routes to the base mailbox. The +tag is
+// dropped when normalizing, and normalizedEmail is trusted for account matching
+// on these domains. Excludes providers without it (e.g. Yahoo uses hyphens).
+export const PLUS_ADDRESSING_EMAIL_HOSTS = [
+  'gmail.com',
+  'googlemail.com',
+  'outlook.com',
+  'hotmail.com',
+  'live.com',
+  'msn.com',
+  'proton.me',
+  'protonmail.com',
+  'pm.me',
+  'icloud.com',
+  'me.com',
+  'mac.com',
+  'fastmail.com',
+];
+
 export const SUPPORTED_AVATAR_TYPE = new Set([
   'jpg',
   'png',

--- a/src/routes/wallet/index.ts
+++ b/src/routes/wallet/index.ts
@@ -183,6 +183,12 @@ router.post('/evm/migrate/email/magic', validateBody(WalletEvmMigrateEmailMagicB
       if (!userInfo) {
         throw new ValidationError('USER_NOT_FOUND');
       }
+      // Only auto-link when the existing account's email is itself verified;
+      // combined with the fresh Magic-verified email this proves both sides
+      // control the inbox before importing the EVM wallet.
+      if (!userInfo.isEmailVerified) {
+        throw new ValidationError('EXISTING_EMAIL_NOT_VERIFIED');
+      }
       const { likeWallet, evmWallet: docEvmWallet } = userInfo;
       if (docEvmWallet && docEvmWallet !== evmWallet) {
         throw new ValidationError('EVM_WALLET_MISMATCH');

--- a/src/util/api/users/index.ts
+++ b/src/util/api/users/index.ts
@@ -8,6 +8,8 @@ import {
   BUTTON_COOKIE_OPTION,
   KNOWN_EMAIL_HOSTS,
   KICKBOX_DISPOSIBLE_API,
+  NORMALIZABLE_EMAIL_HOSTS,
+  PLUS_ADDRESSING_EMAIL_HOSTS,
   W3C_EMAIL_REGEX,
 } from '../../../constant';
 import {
@@ -182,12 +184,45 @@ export function checkEVMSignPayload({
   return actualPayload;
 }
 
+function getEmailDomain(email: string): string | undefined {
+  return email ? email.split('@')[1]?.toLowerCase() : undefined;
+}
+
+// Domain-aware canonical email. Always lowercases and drops the "+tag" suffix.
+// Dots are stripped only for Gmail-family domains (which ignore them); every
+// other provider treats dots as significant, so they are kept.
+export function getNormalizedEmail(email: string): string | undefined {
+  if (!email || !W3C_EMAIL_REGEX.test(email)) return undefined;
+  const [rawUser, rawDomain] = email.split('@');
+  if (!rawDomain) return undefined;
+  const domain = rawDomain.toLowerCase();
+  const [withoutTag] = rawUser.split('+');
+  const isGmailFamily = NORMALIZABLE_EMAIL_HOSTS.includes(domain);
+  const localPart = isGmailFamily ? withoutTag.split('.').join('') : withoutTag;
+  return `${localPart.toLowerCase()}@${domain}`;
+}
+
+// Returns normalizedEmail only for providers where it reliably maps to a single
+// inbox (Gmail-family and plus-addressing hosts), so it is safe for account
+// matching. Other domains fall back to exact-email matching only.
+export function getMatchableNormalizedEmail(email: string): string | undefined {
+  const domain = getEmailDomain(email);
+  if (!domain || !PLUS_ADDRESSING_EMAIL_HOSTS.includes(domain)) return undefined;
+  return getNormalizedEmail(email);
+}
+
 export async function findLikerByEmail(email: string): Promise<{
   user: string,
   [key: string]: unknown
 } | undefined> {
   if (!email) return undefined;
-  const snapshot = await dbRef.where('email', '==', email).limit(1).get();
+  let snapshot = await dbRef.where('email', '==', email).limit(1).get();
+  if (!snapshot.docs.length) {
+    const normalizedEmail = getMatchableNormalizedEmail(email);
+    if (normalizedEmail) {
+      snapshot = await dbRef.where('normalizedEmail', '==', normalizedEmail).limit(1).get();
+    }
+  }
   if (!snapshot.docs.length) return undefined;
   const [doc] = snapshot.docs;
   return { user: doc.id, ...doc.data() };
@@ -202,27 +237,35 @@ export async function userOrWalletByEmailQuery({
   evmWallet?: string,
   likeWallet?: string,
 }, email: string, isEmailVerified = false): Promise<boolean> {
-  return dbRef.where('email', '==', email).get().then((snapshot) => {
-    snapshot.forEach((doc) => {
-      const docUser = doc.id;
-      const docData = doc.data();
-      if (
-        (user && user !== docUser)
-        || (evmWallet && evmWallet !== docData.evmWallet)
-        || (likeWallet && likeWallet !== docData.likeWallet)
-      ) {
-        let payload: any = null;
-        if (isEmailVerified) {
-          payload = {
-            evmWallet: maskString(docData.evmWallet),
-            likeWallet: maskString(docData.likeWallet, { start: 11 }),
-          };
-        }
-        throw new ValidationError('EMAIL_ALREADY_USED', 400, payload);
-      }
-    });
-    return true;
+  const normalizedEmail = getMatchableNormalizedEmail(email);
+  const queries = [dbRef.where('email', '==', email).get()];
+  if (normalizedEmail) {
+    queries.push(dbRef.where('normalizedEmail', '==', normalizedEmail).get());
+  }
+  const snapshots = await Promise.all(queries);
+  const docsById = new Map<string, any>();
+  snapshots.forEach((snapshot) => {
+    snapshot.docs.forEach((doc) => docsById.set(doc.id, doc));
   });
+  docsById.forEach((doc) => {
+    const docUser = doc.id;
+    const docData = doc.data();
+    if (
+      (user && user !== docUser)
+      || (evmWallet && evmWallet !== docData.evmWallet)
+      || (likeWallet && likeWallet !== docData.likeWallet)
+    ) {
+      let payload: any = null;
+      if (isEmailVerified) {
+        payload = {
+          evmWallet: maskString(docData.evmWallet),
+          likeWallet: maskString(docData.likeWallet, { start: 11 }),
+        };
+      }
+      throw new ValidationError('EMAIL_ALREADY_USED', 400, payload);
+    }
+  });
+  return true;
 }
 
 export function queryNormalizedEmailExists(user, email) {
@@ -241,7 +284,6 @@ export async function normalizeUserEmail(user, email) {
   let isEmailBlacklisted;
   const BLACK_LIST_DOMAIN = disposableDomains;
   const parts = email.split('@');
-  let emailUser = parts[0];
   const domain = parts[1];
   if (!domain) return {};
   if (BLACK_LIST_DOMAIN.includes(domain)) {
@@ -281,11 +323,7 @@ export async function normalizeUserEmail(user, email) {
   /* we handle special char for all domain
     the processed string is only stored as normalizedEmail
     for anti spam/analysis purpose, not for actual sending */
-  // handlt dot for all domain
-  emailUser = emailUser.split('.').join('');
-  // handlt plus for all domain
-  [emailUser] = emailUser.split('+');
-  normalizedEmail = `${emailUser.toLowerCase()}@${domain.toLowerCase()}`;
+  normalizedEmail = getNormalizedEmail(email) || normalizedEmail;
   let isEmailDuplicated;
   if (user) {
     isEmailDuplicated = await queryNormalizedEmailExists(user, normalizedEmail);

--- a/test/data/user.json
+++ b/test/data/user.json
@@ -143,6 +143,29 @@
             "referrals": [
             ]
           }
+        },
+        {
+          "id": "testgmaillegacy",
+          "displayName": "testgmaillegacy",
+          "email": "John.Doe+book@gmail.com",
+          "normalizedEmail": "johndoe@gmail.com",
+          "likeWallet": "like1gmaillegacy00000000000000000000000000",
+          "isEmailVerified": true
+        },
+        {
+          "id": "testgmailunverified",
+          "displayName": "testgmailunverified",
+          "email": "Jane.Roe@gmail.com",
+          "normalizedEmail": "janeroe@gmail.com",
+          "likeWallet": "like1gmailunverified000000000000000000000000"
+        },
+        {
+          "id": "testprotonlegacy",
+          "displayName": "testprotonlegacy",
+          "email": "John.Roe+news@proton.me",
+          "normalizedEmail": "john.roe@proton.me",
+          "likeWallet": "like1protonlegacy0000000000000000000000000",
+          "isEmailVerified": true
         }
     ]
 }

--- a/test/unit/email-normalization.test.ts
+++ b/test/unit/email-normalization.test.ts
@@ -1,0 +1,139 @@
+import {
+  describe, it, expect,
+} from 'vitest';
+import { ValidationError } from '../../src/util/ValidationError';
+import {
+  getNormalizedEmail,
+  getMatchableNormalizedEmail,
+  findLikerByEmail,
+  userOrWalletByEmailQuery,
+} from '../../src/util/api/users/index';
+
+// Note: Firebase is already mocked in test/setup.ts with FirebaseStub, seeded
+// from test/data/user.json (see testgmaillegacy / testprotonlegacy).
+
+describe('getNormalizedEmail', () => {
+  it('strips dots and plus-tags for Gmail-family domains', () => {
+    expect(getNormalizedEmail('John.Doe+book@Gmail.com')).toBe('johndoe@gmail.com');
+  });
+
+  it('strips the +tag but keeps dots for plus-addressing providers', () => {
+    expect(getNormalizedEmail('John.Roe+news@Proton.me')).toBe('john.roe@proton.me');
+    expect(getNormalizedEmail('A.B+tag@Outlook.com')).toBe('a.b@outlook.com');
+  });
+
+  it('lowercases the local part and domain', () => {
+    expect(getNormalizedEmail('USER@Example.COM')).toBe('user@example.com');
+  });
+
+  it('keeps dots for non-Gmail domains to avoid inbox collisions', () => {
+    // a.b@example.com and ab@example.com are different inboxes on a generic
+    // provider, so dots must survive normalization.
+    expect(getNormalizedEmail('a.b+tag@example.com')).toBe('a.b@example.com');
+  });
+
+  it('returns undefined for falsy or malformed input', () => {
+    expect(getNormalizedEmail('')).toBeUndefined();
+    expect(getNormalizedEmail('no-at-sign')).toBeUndefined();
+    expect(getNormalizedEmail('@gmail.com')).toBeUndefined();
+    expect(getNormalizedEmail('a@b@c')).toBeUndefined();
+  });
+});
+
+describe('getMatchableNormalizedEmail', () => {
+  it('returns normalizedEmail for Gmail-family and plus-addressing providers', () => {
+    expect(getMatchableNormalizedEmail('John.Doe+x@gmail.com')).toBe('johndoe@gmail.com');
+    expect(getMatchableNormalizedEmail('john+tag@proton.me')).toBe('john@proton.me');
+    expect(getMatchableNormalizedEmail('a.b+x@outlook.com')).toBe('a.b@outlook.com');
+  });
+
+  it('returns undefined for providers where matching is unsafe', () => {
+    // Yahoo uses hyphen disposable addresses, not plus subaddressing.
+    expect(getMatchableNormalizedEmail('user@yahoo.com')).toBeUndefined();
+    expect(getMatchableNormalizedEmail('user@likecoin.store')).toBeUndefined();
+  });
+
+  it('returns undefined for falsy input', () => {
+    expect(getMatchableNormalizedEmail('')).toBeUndefined();
+  });
+});
+
+describe('findLikerByEmail', () => {
+  it('finds an account by exact email', async () => {
+    const user = await findLikerByEmail('testing@likecoin.store');
+    expect(user?.user).toBe('testing');
+  });
+
+  it('matches a Gmail account by normalizedEmail', async () => {
+    // Stored email is "John.Doe+book@gmail.com"; a different but
+    // normalized-equivalent address must still resolve the account.
+    const user = await findLikerByEmail('johndoe@gmail.com');
+    expect(user?.user).toBe('testgmaillegacy');
+    expect(user?.likeWallet).toBe('like1gmaillegacy00000000000000000000000000');
+    expect(user?.evmWallet).toBeUndefined();
+  });
+
+  it('matches a plus-addressing account by normalizedEmail, keeping dots', async () => {
+    // Stored email is "John.Roe+news@proton.me"; the same inbox without the tag
+    // (and with different case) must still resolve via normalizedEmail.
+    const user = await findLikerByEmail('john.roe@proton.me');
+    expect(user?.user).toBe('testprotonlegacy');
+    const tagged = await findLikerByEmail('John.Roe+promo@proton.me');
+    expect(tagged?.user).toBe('testprotonlegacy');
+  });
+
+  it('keeps dots significant for plus-addressing providers', async () => {
+    // proton treats dots as significant, so the dotless variant is a different
+    // inbox and must NOT match.
+    const user = await findLikerByEmail('johnroe@proton.me');
+    expect(user).toBeUndefined();
+  });
+
+  it('returns undefined when nothing matches', async () => {
+    const user = await findLikerByEmail('nobody@gmail.com');
+    expect(user).toBeUndefined();
+  });
+});
+
+describe('userOrWalletByEmailQuery', () => {
+  it('passes when no account uses the email', async () => {
+    await expect(
+      userOrWalletByEmailQuery({ evmWallet: '0xNEW' }, 'free-email@gmail.com', true),
+    ).resolves.toBe(true);
+  });
+
+  it('throws EMAIL_ALREADY_USED for a normalized Proton match', async () => {
+    await expect(
+      userOrWalletByEmailQuery({ evmWallet: '0xNEW' }, 'John.Roe+promo@proton.me', true),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it('throws EMAIL_ALREADY_USED for a normalized Gmail match', async () => {
+    // Incoming Magic login with a fresh EVM wallet hits a legacy likeWallet-only
+    // account via normalized email — the conflict must be surfaced so the client
+    // can trigger the auto-link migration.
+    await expect(
+      userOrWalletByEmailQuery({ evmWallet: '0xNEW' }, 'johndoe@gmail.com', true),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it('exposes a masked payload only when the email is verified', async () => {
+    try {
+      await userOrWalletByEmailQuery({ evmWallet: '0xNEW' }, 'johndoe@gmail.com', true);
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      const { payload } = err as ValidationError;
+      expect(payload.evmWallet).toBeUndefined();
+      expect(typeof payload.likeWallet).toBe('string');
+    }
+
+    try {
+      await userOrWalletByEmailQuery({ evmWallet: '0xNEW' }, 'johndoe@gmail.com', false);
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      expect((err as ValidationError).payload).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
When a Magic email login resolves to an existing account that only has a likeWallet (v2) and no evmWallet (v3), match it by email so the new EVM wallet can be imported instead of blocking the user or creating a duplicate.

- Make normalizedEmail domain-aware: always drop the +tag, strip dots only for Gmail-family domains (which ignore them) and keep them for plus- addressing providers like Outlook/Proton where dots are significant.
- Match accounts on this single normalizedEmail field, gated to providers where it reliably maps to one inbox, so distinct mailboxes never merge.
- Gate the /wallet/evm/migrate/email/magic auto-link on the existing account's email being verified, since both sides then prove inbox control.