### PR TITLE
🐛 Report correct currency for RevenueCat subscription payments

### DIFF
--- a/src/util/api/plus/revenuecat.ts
+++ b/src/util/api/plus/revenuecat.ts
@@ -34,6 +34,7 @@ export interface RevenueCatEvent {
   store?: string;
   environment?: 'SANDBOX' | 'PRODUCTION';
   price?: number;
+  price_in_purchased_currency?: number;
   currency?: string;
   original_transaction_id?: string;
   cancel_reason?: string;
@@ -43,6 +44,22 @@ export interface RevenueCatEvent {
   transferred_to?: string[];
 }
 /* eslint-enable camelcase */
+
+// RevenueCat's `price` is normalized to USD, while `currency` describes
+// `price_in_purchased_currency` (the amount the customer actually paid). Pairing
+// `price` with `currency` mislabels USD amounts as the local currency. Return a
+// consistent (amount, currency) pair: the local charge when present, else USD.
+export function getRevenueCatPaymentAmount(
+  event: RevenueCatEvent,
+): { amount?: number; currency?: string } {
+  if (event.price_in_purchased_currency != null && event.currency) {
+    return { amount: event.price_in_purchased_currency, currency: event.currency };
+  }
+  if (event.price != null) {
+    return { amount: event.price, currency: 'USD' };
+  }
+  return {};
+}
 
 const RC_ANONYMOUS_ID_PREFIX = '$RCAnonymousID:';
 
@@ -191,13 +208,16 @@ async function handleGrant(
   if (isInitial) logEvent = isTrial ? 'StartTrial' : 'Subscribe';
   else if (event.type === 'RENEWAL') logEvent = 'SubscriptionRenewed';
 
+  // Resolve once and reuse across Slack, analytics, and the Airtable record.
+  const { amount: paymentAmount, currency: paymentCurrency } = getRevenueCatPaymentAmount(event);
+
   // Independent notifications/analytics — fire in parallel (matches the Stripe path).
   const sideEffects: Promise<unknown>[] = [
     sendPlusSubscriptionSlackNotification({
       subscriptionId: transactionId || 'N/A',
       email: user.email || 'N/A',
-      priceWithCurrency: event.price != null && event.currency
-        ? `${event.price.toFixed(2)} ${event.currency}`
+      priceWithCurrency: paymentAmount != null && paymentCurrency
+        ? `${paymentAmount.toFixed(2)} ${paymentCurrency}`
         : 'N/A',
       isNew: isInitial,
       userId: likerId,
@@ -209,8 +229,8 @@ async function handleGrant(
     sideEffects.push(logServerEvents(logEvent, {
       email: user.email,
       evmWallet: user.evmWallet,
-      value: event.price,
-      currency: event.currency,
+      value: paymentAmount,
+      currency: paymentCurrency,
       paymentId: transactionId,
       items: period ? [{ productId: `plus-${period}ly`, quantity: 1 }] : undefined,
       extraProperties: {
@@ -231,8 +251,8 @@ async function handleGrant(
       customerUserId: likerId,
       customerWallet: user.evmWallet || '',
       productId: event.product_id,
-      price: event.price,
-      currency: event.currency,
+      price: paymentAmount,
+      currency: paymentCurrency,
       since,
       periodInterval: period || '',
       periodStartAt: purchasedAtMs,

--- a/test/unit/plus-revenuecat-currency.test.ts
+++ b/test/unit/plus-revenuecat-currency.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { getRevenueCatPaymentAmount } from '../../src/util/api/plus/revenuecat';
+
+describe('getRevenueCatPaymentAmount', () => {
+  it('pairs the local amount with the local currency when present', () => {
+    // RevenueCat sends the local charge in price_in_purchased_currency + currency.
+    expect(getRevenueCatPaymentAmount({
+      type: 'RENEWAL',
+      price: 4.78, // USD-normalized
+      price_in_purchased_currency: 700,
+      currency: 'JPY',
+    })).toEqual({ amount: 700, currency: 'JPY' });
+  });
+
+  it('never labels the USD price with the local currency (the reported bug)', () => {
+    // Local amount absent: must fall back to USD, not pair the USD price with JPY.
+    expect(getRevenueCatPaymentAmount({
+      type: 'RENEWAL',
+      price: 4.78,
+      currency: 'JPY',
+    })).toEqual({ amount: 4.78, currency: 'USD' });
+  });
+
+  it('treats a USD purchase consistently', () => {
+    expect(getRevenueCatPaymentAmount({
+      type: 'INITIAL_PURCHASE',
+      price: 9.99,
+      price_in_purchased_currency: 9.99,
+      currency: 'USD',
+    })).toEqual({ amount: 9.99, currency: 'USD' });
+  });
+
+  it('returns an empty pair when there is no price (e.g. trial grant)', () => {
+    expect(getRevenueCatPaymentAmount({ type: 'INITIAL_PURCHASE' })).toEqual({});
+  });
+});


### PR DESCRIPTION
RevenueCat's webhook `price` is normalized to USD, while `currency` describes `price_in_purchased_currency` (the amount the customer actually paid). The code paired `price` with `currency`, so a non-USD subscriber's payment was recorded with the USD amount under the local currency label — e.g. a ¥700 charge logged as "4.78 JPY" in the Airtable payment record.

Resolve a consistent (amount, currency) pair via getRevenueCatPaymentAmount — the local charge when present, else the USD price under 'USD' — and use it for the Airtable record, the Slack notification, and the analytics event, which all shared the same mismatch.