### PR TITLE
[TAS-5912] ✨ Accrue Plus subscription daily value for reading revenue share

### DIFF
--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -20,6 +20,10 @@ export interface LikerPlusData {
   currentType?: string;
   since: number;
   period?: string;
+  // Per-day value of the current term (in `dailyValueCurrency`), used to fund the
+  // reading-library revenue-share pool. 0 for trials. See calculatePlusDailyValue.
+  dailyValue?: number;
+  dailyValueCurrency?: string;
   subscriptionId?: string;
   customerId?: string;
   subscriptionStatus?: LikerPlusSubscriptionStatus;

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -42,6 +42,23 @@ export interface LikerPlusData {
   environment?: 'SANDBOX' | 'PRODUCTION';
 }
 
+/**
+ * Immutable per-term funding record for the reading-library revenue-share pool,
+ * written at invoice time under `users/{likerId}/plusReadingAccrual/{termKey}`.
+ * One doc per paid subscription term; settlement sums each term's day-overlap with
+ * the settlement month. `dailyValueUSD` is pre-normalized so the pool is single-currency.
+ */
+export interface PlusReadingAccrualData {
+  dailyValueUSD: number;
+  // Original charge currency, kept for audit only — the pool itself is USD.
+  currency: string;
+  currentPeriodStart: number;
+  currentPeriodEnd: number;
+  paidDays: number;
+  provider: LikerPlusProvider;
+  subscriptionId: string;
+}
+
 export interface UserData {
   // Identity fields
   isDeleted?: boolean;

--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -25,6 +25,7 @@ import {
   LIKER_PLUS_LTV,
 } from '../../../../config/config';
 import { getUserWithCivicLikerPropertiesByWallet } from '../users/getPublicInfo';
+import { calculatePlusDailyValue } from './revenueShare';
 import { sendPlusSubscriptionSlackNotification } from '../../slack';
 import { createAirtableSubscriptionPaymentRecord } from '../../airtable';
 import { createFreeBookCartFromSubscription } from '../likernft/book/cart';
@@ -267,6 +268,22 @@ export async function processStripeSubscriptionInvoice(
   const since = startDate * 1000; // Convert to milliseconds
   const currentPeriodStart = item.current_period_start * 1000; // Convert to milliseconds
   const currentPeriodEnd = item.current_period_end * 1000; // Convert to milliseconds
+  // A proration invoice pays a partial amount that doesn't match the full
+  // current_period_start/end term, so dividing would understate per-day value;
+  // recompute only for full-term charges, else preserve the stored value.
+  const isFullTermInvoice = isSubscriptionCreation
+    || isTrialToPaidUpgrade
+    || billingReason === 'subscription_cycle';
+  const dailyValue = isFullTermInvoice
+    ? calculatePlusDailyValue({
+      amountPaid: isTrial ? 0 : amountPaid,
+      currentPeriodStart,
+      currentPeriodEnd,
+    })
+    : (user.likerPlus?.dailyValue ?? 0);
+  const dailyValueCurrency = isFullTermInvoice
+    ? currency
+    : (user.likerPlus?.dailyValueCurrency ?? currency);
   const userUpdate: Record<string, unknown> = {
     likerPlus: {
       period,
@@ -274,6 +291,8 @@ export async function processStripeSubscriptionInvoice(
       currentPeriodStart,
       currentPeriodEnd,
       currentType: isTrial ? 'trial' : 'paid',
+      dailyValue,
+      dailyValueCurrency,
       subscriptionId,
       customerId,
       subscriptionStatus: 'active',

--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -10,7 +10,7 @@ import {
   STRIPE_PAYMENT_INTENT_EXPAND_OBJECTS,
 } from '../../../constant';
 import type { SupportedCheckoutUIMode, SupportedPlusCurrency } from '../../../constant';
-import { convertUSDPriceToCurrency } from '../../pricing';
+import { convertCurrencyToUSDPrice, convertUSDPriceToCurrency } from '../../pricing';
 import { getBookUserInfoFromWallet, getBookUserInfoFromLikerId } from '../likernft/book/user';
 import { getStripeClient, getStripePromotionFromCode } from '../../stripe';
 import { userCollection } from '../../firebase';
@@ -25,7 +25,7 @@ import {
   LIKER_PLUS_LTV,
 } from '../../../../config/config';
 import { getUserWithCivicLikerPropertiesByWallet } from '../users/getPublicInfo';
-import { calculatePlusDailyValue } from './revenueShare';
+import { calculatePlusDailyValue, recordPlusSubscriptionAccrual } from './revenueShare';
 import { sendPlusSubscriptionSlackNotification } from '../../slack';
 import { createAirtableSubscriptionPaymentRecord } from '../../airtable';
 import { createFreeBookCartFromSubscription } from '../likernft/book/cart';
@@ -306,6 +306,42 @@ export async function processStripeSubscriptionInvoice(
     Object.assign(userUpdate, getPaymentUpdateFields(!!user.firstPaidAt));
   }
   await userCollection.doc(likerId).update(userUpdate);
+
+  // Accrue this term's USD value to the rev-share pool. Full-term paid charges only:
+  // proration invoices reuse the stored dailyValue (already accrued at the cycle), and
+  // trials fund nothing. The charge is normalized from its invoice currency to USD so
+  // the pool stays single-currency.
+  if (isFullTermInvoice && !isTrial && dailyValue > 0) {
+    // Stripe settles in USD, so the charge's balance transaction amount is the real
+    // converted USD value (actual FX, net of spread). Prefer it; fall back to tier-based
+    // conversion only when the balance transaction couldn't be fetched.
+    const amountPaidUSD = balanceTxAmount
+      ?? convertCurrencyToUSDPrice(
+        amountPaid,
+        currency.toLowerCase() as SupportedPlusCurrency,
+      );
+    const dailyValueUSD = calculatePlusDailyValue({
+      amountPaid: amountPaidUSD,
+      currentPeriodStart,
+      currentPeriodEnd,
+    });
+    // Best-effort: accrual is not yet used for payouts, so a transient Firestore
+    // failure must not fail (and make Stripe retry) the subscription webhook.
+    try {
+      await recordPlusSubscriptionAccrual({
+        likerId,
+        subscriptionId,
+        dailyValueUSD,
+        currency,
+        currentPeriodStart,
+        currentPeriodEnd,
+        provider: 'stripe',
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`Error recording Plus reading accrual for ${likerId}:`, err);
+    }
+  }
 
   await updateIntercomUserAttributes(likerId, {
     is_liker_plus: true,

--- a/src/util/api/plus/revenueShare.ts
+++ b/src/util/api/plus/revenueShare.ts
@@ -1,0 +1,33 @@
+/* eslint-disable import/prefer-default-export */
+import { ONE_DAY_IN_MS } from '../../../constant';
+
+/**
+ * Computes the per-day value of a Plus subscription term — the funding basis for
+ * the reading-library revenue-share pool, which accrues per complete paid day.
+ *
+ * `amountPaid` is the net (post-discount) charge for the current term, so the
+ * early/beta/full price tiers and the monthly/yearly discount are all captured by
+ * the actual amount — no price table is needed. Term length is derived from the
+ * provider period bounds (Stripe invoice periods or RevenueCat expirations), so
+ * it is accurate to the day (28-31, 365/366).
+ *
+ * Returns 0 for trials, free periods, or malformed bounds: those contribute
+ * nothing to the pool.
+ */
+export function calculatePlusDailyValue({
+  amountPaid,
+  currentPeriodStart,
+  currentPeriodEnd,
+}: {
+  amountPaid: number;
+  currentPeriodStart: number; // ms
+  currentPeriodEnd: number; // ms
+}): number {
+  // `!(x > 0)` (not `x <= 0`) so NaN bounds are rejected rather than divided by.
+  if (!(amountPaid > 0)) return 0;
+  const termMs = currentPeriodEnd - currentPeriodStart;
+  if (!(termMs > 0)) return 0;
+  const termDays = Math.round(termMs / ONE_DAY_IN_MS);
+  if (termDays <= 0) return 0;
+  return amountPaid / termDays;
+}

--- a/src/util/api/plus/revenueShare.ts
+++ b/src/util/api/plus/revenueShare.ts
@@ -1,9 +1,19 @@
-/* eslint-disable import/prefer-default-export */
 import { ONE_DAY_IN_MS } from '../../../constant';
+import { FieldValue, userCollection } from '../../firebase';
+import type { PlusReadingAccrualData } from '../../../types/user';
+
+/**
+ * Whole paid days in a term, rounding sub-day clock jitter. The stored accrual
+ * `paidDays` and the settle-time overlap basis must round identically or pool
+ * conservation (Σ monthly overlaps = term paidDays) breaks — so both derive it here.
+ */
+function roundTermDays(termMs: number): number {
+  return Math.round(termMs / ONE_DAY_IN_MS);
+}
 
 /**
  * Computes the per-day value of a Plus subscription term — the funding basis for
- * the reading-library revenue-share pool, which accrues per complete paid day.
+ * the reading-library revenue-share pool, which accrues proportionally over the term.
  *
  * `amountPaid` is the net (post-discount) charge for the current term, so the
  * early/beta/full price tiers and the monthly/yearly discount are all captured by
@@ -27,7 +37,110 @@ export function calculatePlusDailyValue({
   if (!(amountPaid > 0)) return 0;
   const termMs = currentPeriodEnd - currentPeriodStart;
   if (!(termMs > 0)) return 0;
-  const termDays = Math.round(termMs / ONE_DAY_IN_MS);
+  const termDays = roundTermDays(termMs);
   if (termDays <= 0) return 0;
   return amountPaid / termDays;
+}
+
+/**
+ * Records a per-term accrual entry that funds the reading-library
+ * revenue-share pool, under `users/{likerId}/plusReadingAccrual/{termKey}`.
+ *
+ * Written at invoice time rather than recomputed at settle time: the shared
+ * `likerPlus` record is latest-write-wins, so a renewal would overwrite a prior
+ * term's dailyValue before settlement reads it. One doc per paid term, keyed by
+ * `${subscriptionId}_${currentPeriodStart}` — reprocessing the same invoice overwrites
+ * the same accrual fields (only `updatedAt` changes), so it is idempotent. `dailyValueUSD`
+ * is already normalized to USD so settlement sums a single currency. No-op for trials / malformed
+ * terms (they fund nothing).
+ */
+export async function recordPlusSubscriptionAccrual({
+  likerId,
+  subscriptionId,
+  dailyValueUSD,
+  currency,
+  currentPeriodStart,
+  currentPeriodEnd,
+  provider,
+}: {
+  likerId: string;
+  subscriptionId: string;
+  dailyValueUSD: number;
+  currency: string;
+  currentPeriodStart: number;
+  currentPeriodEnd: number;
+  provider: PlusReadingAccrualData['provider'];
+}): Promise<void> {
+  if (!(dailyValueUSD > 0)) return;
+  const termMs = currentPeriodEnd - currentPeriodStart;
+  if (!(termMs > 0)) return;
+  const paidDays = roundTermDays(termMs);
+  if (paidDays <= 0) return;
+
+  const termKey = `${subscriptionId}_${currentPeriodStart}`;
+  const accrual: PlusReadingAccrualData = {
+    dailyValueUSD,
+    currency,
+    currentPeriodStart,
+    currentPeriodEnd,
+    paidDays,
+    provider,
+    subscriptionId,
+  };
+  await userCollection
+    .doc(likerId)
+    .collection('plusReadingAccrual')
+    .doc(termKey)
+    .set({ ...accrual, updatedAt: FieldValue.serverTimestamp() });
+}
+
+/**
+ * UTC millisecond bounds `[startMs, endMs)` of a `YYYY-MM` settlement period.
+ */
+export function getUsageMonthBoundsMs(periodId: string): { startMs: number; endMs: number } {
+  const [year, month] = periodId.split('-').map(Number);
+  return {
+    startMs: Date.UTC(year, month - 1, 1),
+    endMs: Date.UTC(year, month, 1),
+  };
+}
+
+/**
+ * Fractional paid days of an accrual term that fall inside a settlement month,
+ * distributed proportionally so summing across every month a term spans returns the
+ * term's full `paidDays` exactly (no month-boundary rounding drift).
+ */
+export function getAccrualOverlapDays(
+  termStartMs: number,
+  termEndMs: number,
+  monthStartMs: number,
+  monthEndMs: number,
+): number {
+  const termMs = termEndMs - termStartMs;
+  if (!(termMs > 0)) return 0;
+  const overlapMs = Math.min(termEndMs, monthEndMs) - Math.max(termStartMs, monthStartMs);
+  if (!(overlapMs > 0)) return 0;
+  const paidDays = roundTermDays(termMs);
+  return paidDays * (overlapMs / termMs);
+}
+
+/**
+ * Sums the USD funding attributable to a settlement period: each accrual term
+ * contributes `dailyValueUSD × overlapDays(term, month)`. Pure — settlement reads the
+ * accrual docs from Firestore and passes them in.
+ */
+export function accruePoolUSD(
+  accruals: Array<Pick<PlusReadingAccrualData, 'dailyValueUSD' | 'currentPeriodStart' | 'currentPeriodEnd'>>,
+  periodId: string,
+): number {
+  const { startMs, endMs } = getUsageMonthBoundsMs(periodId);
+  return accruals.reduce(
+    (sum, a) => sum + a.dailyValueUSD * getAccrualOverlapDays(
+      a.currentPeriodStart,
+      a.currentPeriodEnd,
+      startMs,
+      endMs,
+    ),
+    0,
+  );
 }

--- a/src/util/api/plus/revenuecat.ts
+++ b/src/util/api/plus/revenuecat.ts
@@ -3,7 +3,7 @@ import type { LikerPlusData } from '../../../types/user';
 import { IS_TESTNET, PUBSUB_TOPIC_MISC, SUBSCRIPTION_GRACE_PERIOD } from '../../../constant';
 import { userCollection } from '../../firebase';
 import { getUserWithCivicLikerProperties } from '../users/getPublicInfo';
-import { calculatePlusDailyValue } from './revenueShare';
+import { calculatePlusDailyValue, recordPlusSubscriptionAccrual } from './revenueShare';
 import { updateIntercomUserAttributes, sendIntercomEvent } from '../../intercom';
 import { sendPlusSubscriptionSlackNotification } from '../../slack';
 import { createAirtableSubscriptionPaymentRecord } from '../../airtable';
@@ -212,6 +212,32 @@ async function handleGrant(
   // analytics, and Airtable so it doesn't contaminate prod metrics. Testnet's
   // own testnet-scoped integrations still fire as usual.
   if (isQuarantinedSandbox(isSandbox)) return;
+
+  // Accrue this term's value to the rev-share pool. Only on a real new charge
+  // (`price` present) — never trials or uncancel/extend grants, which carry no price
+  // and would otherwise re-fund a term. RC `price` is already USD. Placed after the
+  // quarantine return so reviewer/sandbox traffic never funds real payouts.
+  if (!isTrial && event.price != null && dailyValue > 0 && transactionId) {
+    // Best-effort: accrual is not yet used for payouts, so a transient Firestore
+    // failure must not fail (and make RevenueCat retry) the subscription webhook.
+    try {
+      await recordPlusSubscriptionAccrual({
+        likerId,
+        subscriptionId: transactionId,
+        dailyValueUSD: dailyValue,
+        // Original charge currency for audit; `dailyValueUSD` itself is always USD.
+        // `event.currency` is the ISO code the product was purchased in (NULL when
+        // unknown — RevenueCat's `price` is already USD, so fall back to USD).
+        currency: event.currency || 'USD',
+        currentPeriodStart: purchasedAtMs,
+        currentPeriodEnd,
+        provider: 'revenuecat',
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`Error recording Plus reading accrual for ${likerId}:`, err);
+    }
+  }
 
   await updateIntercomUserAttributes(likerId, {
     is_liker_plus: true,

--- a/src/util/api/plus/revenuecat.ts
+++ b/src/util/api/plus/revenuecat.ts
@@ -3,6 +3,7 @@ import type { LikerPlusData } from '../../../types/user';
 import { IS_TESTNET, PUBSUB_TOPIC_MISC, SUBSCRIPTION_GRACE_PERIOD } from '../../../constant';
 import { userCollection } from '../../firebase';
 import { getUserWithCivicLikerProperties } from '../users/getPublicInfo';
+import { calculatePlusDailyValue } from './revenueShare';
 import { updateIntercomUserAttributes, sendIntercomEvent } from '../../intercom';
 import { sendPlusSubscriptionSlackNotification } from '../../slack';
 import { createAirtableSubscriptionPaymentRecord } from '../../airtable';
@@ -171,11 +172,30 @@ async function handleGrant(
     ? purchasedAtMs
     : (user.likerPlus?.since || purchasedAtMs);
 
+  // Per-day value of this term, funding the reading-library revenue-share pool.
+  // Gated on the same `isTrial` as currentType so the two always agree. RevenueCat's
+  // `price` is normalized to USD, so the pool funds in USD — the actual transaction
+  // price still captures intro/promotional and monthly/yearly differences.
+  // Uncancel/extend/product-change grants carry no `price` (no new charge); preserve
+  // the stored dailyValue rather than zeroing accrual until the next priced renewal.
+  let dailyValue = 0;
+  if (!isTrial) {
+    dailyValue = event.price != null
+      ? calculatePlusDailyValue({
+        amountPaid: event.price,
+        currentPeriodStart: purchasedAtMs,
+        currentPeriodEnd,
+      })
+      : (user.likerPlus?.dailyValue ?? 0);
+  }
+
   const likerPlus: LikerPlusData = {
     since,
     currentPeriodStart: purchasedAtMs,
     currentPeriodEnd,
     currentType: isTrial ? 'trial' : 'paid',
+    dailyValue,
+    dailyValueCurrency: 'USD',
     subscriptionStatus: 'active',
     provider: 'revenuecat',
   };

--- a/test/unit/plus-revenue-share.test.ts
+++ b/test/unit/plus-revenue-share.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { ONE_DAY_IN_MS } from '../../src/constant';
+import { calculatePlusDailyValue } from '../../src/util/api/plus/revenueShare';
+
+const monthStart = Date.UTC(2026, 0, 1);
+
+describe('calculatePlusDailyValue', () => {
+  it('divides a monthly charge by the exact term days', () => {
+    // 31-day January term, $9.99 → 9.99 / 31
+    const daily = calculatePlusDailyValue({
+      amountPaid: 9.99,
+      currentPeriodStart: monthStart,
+      currentPeriodEnd: monthStart + 31 * ONE_DAY_IN_MS,
+    });
+    expect(daily).toBeCloseTo(9.99 / 31, 10);
+  });
+
+  it('divides a yearly charge by the exact term days', () => {
+    // 365-day term, $99.99 → 99.99 / 365 (smaller daily value reflects the yearly discount)
+    const daily = calculatePlusDailyValue({
+      amountPaid: 99.99,
+      currentPeriodStart: monthStart,
+      currentPeriodEnd: monthStart + 365 * ONE_DAY_IN_MS,
+    });
+    expect(daily).toBeCloseTo(99.99 / 365, 10);
+  });
+
+  it('captures price tiers via the actual amount (no price table)', () => {
+    // Same 30-day term, different tier prices → proportional daily values.
+    const term = {
+      currentPeriodStart: monthStart,
+      currentPeriodEnd: monthStart + 30 * ONE_DAY_IN_MS,
+    };
+    expect(calculatePlusDailyValue({ amountPaid: 6, ...term })).toBeCloseTo(0.2, 10);
+    expect(calculatePlusDailyValue({ amountPaid: 9, ...term })).toBeCloseTo(0.3, 10);
+  });
+
+  it('returns 0 for trials / free periods (no amount paid)', () => {
+    expect(calculatePlusDailyValue({
+      amountPaid: 0,
+      currentPeriodStart: monthStart,
+      currentPeriodEnd: monthStart + 14 * ONE_DAY_IN_MS,
+    })).toBe(0);
+  });
+
+  it('returns 0 for malformed or non-positive term bounds', () => {
+    expect(calculatePlusDailyValue({
+      amountPaid: 9.99,
+      currentPeriodStart: monthStart,
+      currentPeriodEnd: monthStart,
+    })).toBe(0);
+    expect(calculatePlusDailyValue({
+      amountPaid: 9.99,
+      currentPeriodStart: monthStart + ONE_DAY_IN_MS,
+      currentPeriodEnd: monthStart,
+    })).toBe(0);
+  });
+
+  it('rounds sub-day jitter to whole days (accurate-to-day unit)', () => {
+    // 30 days minus a few seconds (clock jitter) still rounds to a 30-day term.
+    const daily = calculatePlusDailyValue({
+      amountPaid: 9,
+      currentPeriodStart: monthStart,
+      currentPeriodEnd: monthStart + 30 * ONE_DAY_IN_MS - 5000,
+    });
+    expect(daily).toBeCloseTo(9 / 30, 10);
+  });
+});

--- a/test/unit/plus-revenue-share.test.ts
+++ b/test/unit/plus-revenue-share.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { ONE_DAY_IN_MS } from '../../src/constant';
-import { calculatePlusDailyValue } from '../../src/util/api/plus/revenueShare';
+import {
+  accruePoolUSD,
+  calculatePlusDailyValue,
+  getAccrualOverlapDays,
+  getUsageMonthBoundsMs,
+} from '../../src/util/api/plus/revenueShare';
 
 const monthStart = Date.UTC(2026, 0, 1);
 
@@ -64,5 +69,88 @@ describe('calculatePlusDailyValue', () => {
       currentPeriodEnd: monthStart + 30 * ONE_DAY_IN_MS - 5000,
     });
     expect(daily).toBeCloseTo(9 / 30, 10);
+  });
+});
+
+describe('getUsageMonthBoundsMs', () => {
+  it('returns UTC [start, end) bounds for a YYYY-MM period', () => {
+    expect(getUsageMonthBoundsMs('2026-03')).toEqual({
+      startMs: Date.UTC(2026, 2, 1),
+      endMs: Date.UTC(2026, 3, 1),
+    });
+  });
+
+  it('rolls December into the next year for the end bound', () => {
+    expect(getUsageMonthBoundsMs('2026-12')).toEqual({
+      startMs: Date.UTC(2026, 11, 1),
+      endMs: Date.UTC(2027, 0, 1),
+    });
+  });
+});
+
+describe('getAccrualOverlapDays', () => {
+  const janStart = Date.UTC(2026, 0, 1);
+  const febStart = Date.UTC(2026, 1, 1);
+  const marStart = Date.UTC(2026, 2, 1);
+
+  it('returns the full paid days when the term sits inside the month', () => {
+    // 31-day January term, entirely within January.
+    expect(getAccrualOverlapDays(janStart, febStart, janStart, febStart)).toBeCloseTo(31, 10);
+  });
+
+  it('returns 0 when the term does not overlap the month', () => {
+    // February term measured against January.
+    expect(getAccrualOverlapDays(febStart, marStart, janStart, febStart)).toBe(0);
+  });
+
+  it('returns 0 for a malformed (non-positive) term', () => {
+    expect(getAccrualOverlapDays(febStart, janStart, janStart, febStart)).toBe(0);
+  });
+
+  it('splits a boundary-spanning term so the parts sum to the full paid days', () => {
+    // Term Jan 15 → Feb 15 (31 days); 17 days land in January, 14 in February.
+    const termStart = Date.UTC(2026, 0, 15);
+    const termEnd = Date.UTC(2026, 1, 15);
+    const inJan = getAccrualOverlapDays(termStart, termEnd, janStart, febStart);
+    const inFeb = getAccrualOverlapDays(termStart, termEnd, febStart, marStart);
+    expect(inJan).toBeCloseTo(17, 10);
+    expect(inFeb).toBeCloseTo(14, 10);
+    expect(inJan + inFeb).toBeCloseTo(31, 10); // conserves the full term
+  });
+});
+
+describe('accruePoolUSD', () => {
+  it('sums dailyValueUSD × overlap days across terms for the period', () => {
+    const accruals = [
+      // Fully in March (31 days) → 0.3 × 31 = 9.3
+      {
+        dailyValueUSD: 0.3,
+        currentPeriodStart: Date.UTC(2026, 2, 1),
+        currentPeriodEnd: Date.UTC(2026, 3, 1),
+      },
+      // Mar 20 → Apr 20 (31 days); 12 days in March → 0.5 × 12 = 6
+      {
+        dailyValueUSD: 0.5,
+        currentPeriodStart: Date.UTC(2026, 2, 20),
+        currentPeriodEnd: Date.UTC(2026, 3, 20),
+      },
+    ];
+    expect(accruePoolUSD(accruals, '2026-03')).toBeCloseTo(9.3 + 6, 6);
+  });
+
+  it('excludes terms outside the settlement month', () => {
+    const accruals = [
+      // Entirely in April → contributes nothing to March.
+      {
+        dailyValueUSD: 0.3,
+        currentPeriodStart: Date.UTC(2026, 3, 1),
+        currentPeriodEnd: Date.UTC(2026, 4, 1),
+      },
+    ];
+    expect(accruePoolUSD(accruals, '2026-03')).toBe(0);
+  });
+
+  it('returns 0 for no accruals', () => {
+    expect(accruePoolUSD([], '2026-03')).toBe(0);
   });
 });


### PR DESCRIPTION
Compute a per-day value for each active non-trial Plus term — the funding basis for the upcoming reading-library revenue-share pool. dailyValue divides the actual net charge by the real term length (accurate to the day), so the early/beta/full price tiers and the monthly/yearly discount are captured without a price table.

Wired into both providers: Stripe invoices (in the invoice currency) and RevenueCat purchases/renewals (in USD, RevenueCat's normalized price). Trials contribute 0. Stored on the likerPlus record as dailyValue/dailyValueCurrency.