### PR TITLE
🐛 Label trial-to-paid Plus conversion as new sub in Slack

### DIFF
--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -383,7 +383,9 @@ export async function processStripeSubscriptionInvoice(
       subscriptionId,
       email: user.email || 'N/A',
       priceWithCurrency,
-      isNew: isNewSubscription,
+      // Treat the first payment converted from a trial as a new subscription,
+      // not a renewal (start_date is unchanged so isNewSubscription is false).
+      isNew: isNewSubscription || !!isTrialToPaidUpgrade,
       userId: likerId,
       stripeCustomerId: customerId,
       method: 'stripe',


### PR DESCRIPTION
The first invoice converted from a trial kept the subscription's original start_date, so isNewSubscription was false and the Slack notification read "Plus subscription renewal". Fold isTrialToPaidUpgrade into the isNew flag so the conversion is reported as a new subscription.