### PR TITLE
✨ Gate sponsored gas to registered book users via Alchemy webhook

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -41,6 +41,12 @@ config.LIKE_NFT_EVM_INDEXER_API_KEY = '';
 config.EVM_RPC_ENDPOINT_OVERRIDE = '';
 config.EVM_BASE_FEE_MULTIPLIER = 3;
 
+// Alchemy Gas Manager (sponsored gas for Magic Link users via EIP-7702).
+// The webhook secret guards the custom-rules endpoint Alchemy POSTs to; it is
+// embedded in the configured webhookUrl path (Alchemy sends no auth header).
+config.ALCHEMY_GAS_POLICY_ID = process.env.ALCHEMY_GAS_POLICY_ID || '';
+config.ALCHEMY_SPONSORSHIP_WEBHOOK_SECRET = process.env.ALCHEMY_SPONSORSHIP_WEBHOOK_SECRET || '';
+
 config.LIKER_PLUS_TRIAL_CONVERSION_RATE = 0.5;
 config.LIKER_PLUS_LTV = 100;
 config.LIKER_PLUS_PRODUCT_ID = '';

--- a/src/middleware/alchemy-sponsorship-webhook.ts
+++ b/src/middleware/alchemy-sponsorship-webhook.ts
@@ -1,0 +1,35 @@
+import { Request, Response, NextFunction } from 'express';
+
+import { ALCHEMY_SPONSORSHIP_WEBHOOK_SECRET } from '../../config/config';
+
+import { constantTimeEqual } from '../util/misc';
+
+// Guards the Alchemy Gas Manager custom-rules webhook. Alchemy lets us configure
+// only a URL (no auth header, no signature), so the shared secret is carried in
+// the URL path (:secret) and compared in constant time here.
+export function alchemySponsorshipWebhookAuth(req: Request, res: Response, next: NextFunction) {
+  const { secret } = req.params as Record<string, string>;
+  if (secret) {
+    // The shared secret rides in the URL path; strip every occurrence from
+    // req.url/originalUrl (and thus req.path) so error logging never records it.
+    // req.params.secret is URL-decoded, so also redact the encoded form in case
+    // the secret contains reserved characters.
+    const encodedSecret = encodeURIComponent(secret);
+    const redact = (s: string) => s.split(secret).join('[REDACTED]')
+      .split(encodedSecret).join('[REDACTED]');
+    req.url = redact(req.url);
+    req.originalUrl = redact(req.originalUrl);
+  }
+  // Fail closed: Alchemy treats any non-200 as a failure and falls back to
+  // approveOnFailure (fail-open), so a missing/unconfigured secret must still
+  // answer 200 { approved: false } rather than 401/500.
+  if (!ALCHEMY_SPONSORSHIP_WEBHOOK_SECRET
+    || !secret
+    || !constantTimeEqual(secret, ALCHEMY_SPONSORSHIP_WEBHOOK_SECRET)) {
+    res.status(200).json({ approved: false });
+    return;
+  }
+  next();
+}
+
+export default alchemySponsorshipWebhookAuth;

--- a/src/routes/likernft/book/index.ts
+++ b/src/routes/likernft/book/index.ts
@@ -1,12 +1,14 @@
 import { Router } from 'express';
 
 import purchase from './purchase';
+import sponsorship from './sponsorship';
 import store from './store';
 import user from './user';
 
 const router = Router();
 
 router.use('/purchase', purchase);
+router.use('/sponsorship', sponsorship);
 router.use('/store', store);
 router.use('/user', user);
 

--- a/src/routes/likernft/book/sponsorship.ts
+++ b/src/routes/likernft/book/sponsorship.ts
@@ -1,0 +1,57 @@
+import { Router, Request } from 'express';
+
+import { alchemySponsorshipWebhookAuth } from '../../../middleware/alchemy-sponsorship-webhook';
+import { validateBody } from '../../../middleware/validate';
+import { evaluateSponsorship, VerifySchema } from '../../../util/api/likernft/book/sponsorship';
+import publisher from '../../../util/gcloudPub';
+import { PUBSUB_TOPIC_MISC } from '../../../constant';
+
+const router = Router();
+
+// The auth middleware already redacted the shared secret from req.originalUrl,
+// so these fields are safe to log.
+const buildLoggedReq = (req: Request) => ({
+  headers: req.headers,
+  ip: req.ip,
+  auth: (req as any).auth,
+  originalUrl: req.originalUrl,
+});
+
+// Alchemy Gas Manager custom-rules webhook. Alchemy POSTs a userOperation and
+// expects HTTP 200 { approved: boolean }. The decision must always be expressed
+// as a 200 body — a non-200 is treated by Alchemy as a failure and falls through
+// to approveOnFailure. The :secret path segment authenticates the caller.
+router.post(
+  '/verify/:secret',
+  alchemySponsorshipWebhookAuth,
+  validateBody(VerifySchema),
+  async (req, res) => {
+    try {
+      const decision = await evaluateSponsorship(req.body);
+      if (!decision.approved) {
+        publisher.publish(PUBSUB_TOPIC_MISC, buildLoggedReq(req), {
+          logType: 'SponsorshipRejected',
+          reason: decision.reason,
+          sender: req.body?.userOperation?.sender,
+          policyId: req.body?.policyId,
+          chainId: req.body?.chainId,
+        });
+      }
+      res.json({ approved: decision.approved });
+    } catch (err) {
+      // Fail closed: a runtime error (e.g. Firestore) must not propagate to the
+      // global error handler and return non-200, which Alchemy treats as a
+      // failure and may approveOnFailure (fail-open). Log and deny instead.
+      publisher.publish(PUBSUB_TOPIC_MISC, buildLoggedReq(req), {
+        logType: 'SponsorshipVerifyError',
+        error: (err as Error)?.message || String(err),
+        sender: req.body?.userOperation?.sender,
+        policyId: req.body?.policyId,
+        chainId: req.body?.chainId,
+      });
+      res.status(200).json({ approved: false });
+    }
+  },
+);
+
+export default router;

--- a/src/util/api/likernft/book/sponsorship.ts
+++ b/src/util/api/likernft/book/sponsorship.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+import { base, baseSepolia } from 'viem/chains';
+
+import { IS_TESTNET } from '../../../../constant';
+import { ALCHEMY_GAS_POLICY_ID } from '../../../../../config/config';
+import { isRegisteredEVMWallet } from '../../wallet';
+
+const EXPECTED_CHAIN_ID = (IS_TESTNET ? baseSepolia : base).id;
+
+// Every field tolerates unexpected shapes so validateBody never 400s: a non-object
+// body is coerced to {}, and any field that fails to parse falls back to undefined.
+// The decision is then made by evaluateSponsorship (an explicit 200 { approved:
+// false }) rather than 400-ing into Alchemy's approveOnFailure (fail-open) path.
+export const VerifySchema = z.preprocess(
+  (val) => (typeof val === 'object' && val !== null && !Array.isArray(val) ? val : {}),
+  z.object({
+    userOperation: z.object({ sender: z.string().optional() }).passthrough()
+      .optional().catch(undefined),
+    policyId: z.string().optional().catch(undefined),
+    chainId: z.union([z.string(), z.number()]).optional().catch(undefined),
+    webhookData: z.string().optional().catch(undefined),
+  }).passthrough(),
+);
+
+type SponsorshipReason =
+  | 'POLICY_MISMATCH'
+  | 'CHAIN_MISMATCH'
+  | 'NO_SENDER'
+  | 'NOT_REGISTERED'
+  | 'REGISTERED';
+
+interface SponsorshipDecision {
+  approved: boolean;
+  reason: SponsorshipReason;
+}
+
+// Tier A gate: sponsor only operations whose sender is a registered likerId user
+// (present in userCollection), on the expected chain, for our policy. Returns a
+// decision (never throws on a rejection — the caller must surface it as HTTP 200
+// { approved: false }).
+export async function evaluateSponsorship(
+  body: z.infer<typeof VerifySchema>,
+): Promise<SponsorshipDecision> {
+  const { userOperation, policyId, chainId } = body;
+
+  // Defence-in-depth: only enforce policy match when a policy id is configured,
+  // so a missing env never silently blocks all sponsorship.
+  if (ALCHEMY_GAS_POLICY_ID && policyId !== ALCHEMY_GAS_POLICY_ID) {
+    return { approved: false, reason: 'POLICY_MISMATCH' };
+  }
+
+  if (Number(chainId) !== EXPECTED_CHAIN_ID) {
+    return { approved: false, reason: 'CHAIN_MISMATCH' };
+  }
+
+  const sender = userOperation?.sender;
+  if (!sender) {
+    return { approved: false, reason: 'NO_SENDER' };
+  }
+
+  const isRegistered = await isRegisteredEVMWallet(sender);
+  return isRegistered
+    ? { approved: true, reason: 'REGISTERED' }
+    : { approved: false, reason: 'NOT_REGISTERED' };
+}
+
+export default evaluateSponsorship;

--- a/src/util/api/wallet/index.ts
+++ b/src/util/api/wallet/index.ts
@@ -2,6 +2,7 @@ import { checksumAddress } from 'viem';
 import { createAirtablePublicationRecord } from '../../airtable';
 import { isValidLikeAddress } from '../../cosmos';
 import { getNFTClassDataById, isEVMClassId } from '../../evm/nft';
+import { isValidEVMAddress } from '../../evm';
 import {
   admin,
   db,
@@ -30,6 +31,20 @@ export async function findLikeWalletByEVMWallet(evmWallet: string) {
     return docId;
   }
   return null;
+}
+
+// Existence-only check for sponsorship gating: is this EVM address a registered
+// likerId user? Queries userCollection (not the book-user collection), where
+// evmWallet is consistently stored checksummed; only needs one hit.
+export async function isRegisteredEVMWallet(evmWallet: string): Promise<boolean> {
+  if (!isValidEVMAddress(evmWallet)) {
+    return false;
+  }
+  const userQuery = await userCollection
+    .where('evmWallet', '==', checksumAddress(evmWallet as `0x${string}`))
+    .limit(1)
+    .get();
+  return !userQuery.empty;
 }
 
 export async function checkBookUserEVMWallet(likeWallet: string) {

--- a/test/api/likernft-book-sponsorship.test.ts
+++ b/test/api/likernft-book-sponsorship.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { checksumAddress } from 'viem';
+import axiosist from './axiosist';
+import mockEVMAddress from './address';
+import { userCollection } from '../../src/util/firebase';
+
+const SECRET = 'test-alchemy-webhook-secret';
+const POLICY_ID = 'test-alchemy-policy-id';
+const CHAIN_ID = 84532; // IS_TESTNET in tests → Base Sepolia
+const BASE_URL = `/api/likernft/book/sponsorship/verify/${SECRET}`;
+
+const REGISTERED_ADDR = mockEVMAddress(0xb001);
+const UNREGISTERED_ADDR = mockEVMAddress(0xb002);
+
+async function makeUser(id: string, evmWallet: string) {
+  // Stored checksummed in userCollection, matching how the app persists evmWallet.
+  await userCollection.doc(id).set({
+    evmWallet: checksumAddress(evmWallet as `0x${string}`),
+  } as any);
+}
+
+const post = (path: string, body: any) => axiosist
+  .post(path, body)
+  .catch((err: any) => err.response);
+
+describe('POST /likernft/book/sponsorship/verify/:secret', () => {
+  it('approves a registered user (sender normalised by checksum)', async () => {
+    await makeUser('user1registered', REGISTERED_ADDR);
+    const res = await post(BASE_URL, {
+      userOperation: { sender: REGISTERED_ADDR }, // lowercase on the wire
+      policyId: POLICY_ID,
+      chainId: CHAIN_ID,
+    });
+    expect(res.status).toBe(200);
+    expect(res.data).toEqual({ approved: true });
+  });
+
+  it('rejects an unregistered sender with HTTP 200 (not an error status)', async () => {
+    const res = await post(BASE_URL, {
+      userOperation: { sender: UNREGISTERED_ADDR },
+      policyId: POLICY_ID,
+      chainId: CHAIN_ID,
+    });
+    expect(res.status).toBe(200);
+    expect(res.data).toEqual({ approved: false });
+  });
+
+  it('rejects a policy id mismatch with HTTP 200', async () => {
+    await makeUser('user1registered', REGISTERED_ADDR);
+    const res = await post(BASE_URL, {
+      userOperation: { sender: REGISTERED_ADDR },
+      policyId: 'some-other-policy',
+      chainId: CHAIN_ID,
+    });
+    expect(res.status).toBe(200);
+    expect(res.data).toEqual({ approved: false });
+  });
+
+  it('rejects a chain id mismatch with HTTP 200', async () => {
+    await makeUser('user1registered', REGISTERED_ADDR);
+    const res = await post(BASE_URL, {
+      userOperation: { sender: REGISTERED_ADDR },
+      policyId: POLICY_ID,
+      chainId: 8453, // Base mainnet, not the testnet chain tests expect
+    });
+    expect(res.status).toBe(200);
+    expect(res.data).toEqual({ approved: false });
+  });
+
+  it('rejects (200) rather than 400-ing when sender is missing', async () => {
+    const res = await post(BASE_URL, {
+      userOperation: {},
+      policyId: POLICY_ID,
+      chainId: CHAIN_ID,
+    });
+    expect(res.status).toBe(200);
+    expect(res.data).toEqual({ approved: false });
+  });
+
+  it('fails closed (200 { approved: false }) when the URL secret is wrong', async () => {
+    await makeUser('user1registered', REGISTERED_ADDR);
+    const res = await post('/api/likernft/book/sponsorship/verify/wrong-secret', {
+      userOperation: { sender: REGISTERED_ADDR },
+      policyId: POLICY_ID,
+      chainId: CHAIN_ID,
+    });
+    expect(res.status).toBe(200);
+    expect(res.data).toEqual({ approved: false });
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -12,11 +12,15 @@ process.env.REVENUECAT_PLUS_MONTHLY_PRODUCT_IDS = 'rc_plus_monthly';
 process.env.REVENUECAT_PLUS_YEARLY_PRODUCT_IDS = 'rc_plus_yearly';
 process.env.AIRTABLE_AUTOMATION_TOKEN = 'test-airtable-automation-token';
 process.env.PLUS_READING_SERVICE_TOKEN = 'test-plus-reading-service-token';
+process.env.ALCHEMY_GAS_POLICY_ID = 'test-alchemy-policy-id';
+process.env.ALCHEMY_SPONSORSHIP_WEBHOOK_SECRET = 'test-alchemy-webhook-secret';
 
 // Mock config files
 vi.mock('../../config/config', () => ({
   AIRTABLE_AUTOMATION_TOKEN: 'test-airtable-automation-token',
   PLUS_READING_SERVICE_TOKEN: 'test-plus-reading-service-token',
+  ALCHEMY_GAS_POLICY_ID: 'test-alchemy-policy-id',
+  ALCHEMY_SPONSORSHIP_WEBHOOK_SECRET: 'test-alchemy-webhook-secret',
   FIREBASE_STORAGE_BUCKET: 'test-bucket',
   FIRESTORE_USER_ROOT: 'users',
   FIRESTORE_USER_AUTH_ROOT: 'user-auth',


### PR DESCRIPTION
Add an Alchemy Gas Manager custom-rules webhook endpoint that approves gas sponsorship only when the userOp sender is a registered book user, on the expected chain and policy. Decisions are always returned as HTTP 200 { approved } so a rejection never trips Alchemy's approveOnFailure (fail-open) path; only auth/config errors are non-200.

The endpoint is authenticated by a secret carried in the URL path, since Alchemy custom rules send no auth header.