### PR TITLE
✨ Add Plus reading-usage ingest endpoint

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -148,6 +148,10 @@ config.AIRTABLE_API_KEY = process.env.AIRTABLE_API_KEY;
 config.AIRTABLE_BASE_ID = '';
 config.AIRTABLE_AUTOMATION_TOKEN = process.env.AIRTABLE_AUTOMATION_TOKEN;
 
+// Shared secret for the internal Plus reading-usage ingest endpoint, called
+// server-to-server by the liker-land-v3 web backend.
+config.PLUS_READING_SERVICE_TOKEN = process.env.PLUS_READING_SERVICE_TOKEN;
+
 config.SLACK_COMMAND_TOKEN = '';
 
 config.USER_ALLOWED_CHANNEL_IDS = '';

--- a/config/config.js
+++ b/config/config.js
@@ -149,7 +149,7 @@ config.AIRTABLE_BASE_ID = '';
 config.AIRTABLE_AUTOMATION_TOKEN = process.env.AIRTABLE_AUTOMATION_TOKEN;
 
 // Shared secret for the internal Plus reading-usage ingest endpoint, called
-// server-to-server by the liker-land-v3 web backend.
+// server-to-server by the 3ook.com backend.
 config.PLUS_READING_SERVICE_TOKEN = process.env.PLUS_READING_SERVICE_TOKEN;
 
 config.SLACK_COMMAND_TOKEN = '';

--- a/src/middleware/plus-reading-service-auth.ts
+++ b/src/middleware/plus-reading-service-auth.ts
@@ -7,9 +7,9 @@ import { ValidationError } from '../util/ValidationError';
 
 const BEARER_PREFIX = 'Bearer ';
 
-// Guards the internal Plus reading-usage ingest endpoint. The liker-land-v3 web
-// backend forwards already-paced (anti-fraud) usage deltas server-to-server, so
-// a shared secret is sufficient — no user JWT is involved.
+// Guards the internal Plus reading-usage ingest endpoint. The 3ook.com backend
+// forwards already-paced (anti-fraud) usage deltas server-to-server, so a shared
+// secret is sufficient — no user JWT is involved.
 export function plusReadingServiceAuth(req: Request, res: Response, next: NextFunction) {
   if (!PLUS_READING_SERVICE_TOKEN) {
     next(new ValidationError('PLUS_READING_SERVICE_TOKEN_NOT_CONFIGURED', 500));

--- a/src/middleware/plus-reading-service-auth.ts
+++ b/src/middleware/plus-reading-service-auth.ts
@@ -1,0 +1,31 @@
+import { Request, Response, NextFunction } from 'express';
+
+import { PLUS_READING_SERVICE_TOKEN } from '../../config/config';
+
+import { constantTimeEqual } from '../util/misc';
+import { ValidationError } from '../util/ValidationError';
+
+const BEARER_PREFIX = 'Bearer ';
+
+// Guards the internal Plus reading-usage ingest endpoint. The liker-land-v3 web
+// backend forwards already-paced (anti-fraud) usage deltas server-to-server, so
+// a shared secret is sufficient — no user JWT is involved.
+export function plusReadingServiceAuth(req: Request, res: Response, next: NextFunction) {
+  if (!PLUS_READING_SERVICE_TOKEN) {
+    next(new ValidationError('PLUS_READING_SERVICE_TOKEN_NOT_CONFIGURED', 500));
+    return;
+  }
+  const header = req.get('Authorization');
+  if (!header || !header.startsWith(BEARER_PREFIX)) {
+    next(new ValidationError('PLUS_READING_SERVICE_TOKEN_MALFORMED', 401));
+    return;
+  }
+  const provided = header.slice(BEARER_PREFIX.length);
+  if (!constantTimeEqual(provided, PLUS_READING_SERVICE_TOKEN)) {
+    next(new ValidationError('UNAUTHORIZED', 401));
+    return;
+  }
+  next();
+}
+
+export default plusReadingServiceAuth;

--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -16,7 +16,11 @@ import {
   PlusNewResponseSchema,
   PlusPortalResponseSchema,
   PlusPriceBodySchema,
+  PlusReadingUsageBodySchema,
+  PlusReadingUsageResponseSchema,
 } from '../../util/api/plus/schemas';
+import { plusReadingServiceAuth } from '../../middleware/plus-reading-service-auth';
+import { getUsagePeriodId, recordPlusReadingUsage } from '../../util/api/plus/revenueShare';
 import { getBookUserInfoFromWallet, getBookUserInfoFromLikerId } from '../../util/api/likernft/book/user';
 import { getStripeClient } from '../../util/stripe';
 import {
@@ -38,6 +42,41 @@ import revenueCatRouter from './revenuecat';
 const router = Router();
 
 router.use('/revenuecat', revenueCatRouter);
+
+// Internal: the liker-land-v3 web backend forwards already-paced Plus reading/TTS
+// usage deltas here (service-secret auth, no user JWT) to fund the reading-library
+// revenue share. Recorded into a per-(book, period) ledger with a per-reader grain.
+router.post('/reading/usage', plusReadingServiceAuth, validateBody(PlusReadingUsageBodySchema), async (req, res, next) => {
+  try {
+    const {
+      readerWallet,
+      classId,
+      readingTimeMs,
+      ttsTimeMs,
+      occurredAt,
+    } = req.body;
+
+    // Nothing to record, but ack so the forwarder doesn't retry.
+    if (readingTimeMs <= 0 && ttsTimeMs <= 0) {
+      sendValidatedJSON(res, PlusReadingUsageResponseSchema, {
+        success: true,
+        periodId: getUsagePeriodId(occurredAt || Date.now()),
+      });
+      return;
+    }
+
+    const { periodId } = await recordPlusReadingUsage({
+      readerWallet,
+      classId,
+      readingTimeMs,
+      ttsTimeMs,
+      occurredAt,
+    });
+    sendValidatedJSON(res, PlusReadingUsageResponseSchema, { success: true, periodId });
+  } catch (err) {
+    next(err);
+  }
+});
 
 router.post('/new', jwtAuth('write:plus'), validateQuery(PlusNewQuerySchema), validateBody(PlusNewBodySchema), async (req, res, next) => {
   const { period = 'monthly' } = req.query as Record<string, string>;

--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -43,8 +43,8 @@ const router = Router();
 
 router.use('/revenuecat', revenueCatRouter);
 
-// Internal: the liker-land-v3 web backend forwards already-paced Plus reading/TTS
-// usage deltas here (service-secret auth, no user JWT) to fund the reading-library
+// Internal: the 3ook.com backend forwards already-paced Plus reading/TTS usage
+// deltas here (service-secret auth, no user JWT) to fund the reading-library
 // revenue share. Recorded into a per-(book, period) ledger with a per-reader grain.
 router.post('/reading/usage', plusReadingServiceAuth, validateBody(PlusReadingUsageBodySchema), async (req, res, next) => {
   try {

--- a/src/util/api/plus/revenueShare.ts
+++ b/src/util/api/plus/revenueShare.ts
@@ -2,6 +2,7 @@ import { ONE_DAY_IN_MS } from '../../../constant';
 import {
   FieldValue, db, likeNFTBookCollection, userCollection,
 } from '../../firebase';
+import { ValidationError } from '../../ValidationError';
 import type { PlusReadingAccrualData } from '../../../types/user';
 
 /**
@@ -57,21 +58,14 @@ export function getUsagePeriodId(timestampMs: number): string {
 }
 
 /**
- * Records Plus reading/TTS usage into the period-bucketed ledger that funds the
- * reading-library revenue share. Durations are already paced (anti-fraud) by the
- * web backend, so this is a trusted write.
- *
- * Dual-write in one batch (mirrors the web backend's incrementBookReadingTime):
- *   likeNFTBookCollection/{classId}/plusUsage/{periodId}                  ← book rollup
- *   likeNFTBookCollection/{classId}/plusUsage/{periodId}/readers/{wallet} ← reader grain
- *
- * The book rollup hangs off the book doc so settlement reads ownerWallet /
- * connectedWallets live from the parent (no snapshot drift). `classId` is
- * lowercased to a canonical key: EVM class ids arrive in mixed (EIP-55) casing
- * from different callers, and the web backend already lowercases the same id for
- * its per-user books subcollection — keying the ledger consistently dedups casing
- * variants. Settlement resolves the book doc by the same lowercase key. The reader
- * grain feeds the future per-reader/author stats without a backfill.
+ * Records already-paced (anti-fraud) Plus reading/TTS usage into the period-bucketed
+ * ledger funding the reading-library revenue share — a trusted write. Dual-writes the
+ * book rollup and a per-reader grain in one batch, both hanging off the book doc so
+ * settlement reads ownerWallet/connectedWallets live from the parent (no snapshot drift).
+ * Requires the parent book doc to exist — Firestore would otherwise happily create an
+ * orphan ledger under a missing parent that settlement could never attribute.
+ * `classId` and `readerWallet` are lowercased to canonical keys so EIP-55 casing variants
+ * don't split the same book/reader across docs (the web backend lowercases the same ids).
  */
 export async function recordPlusReadingUsage({
   readerWallet,
@@ -88,12 +82,14 @@ export async function recordPlusReadingUsage({
 }): Promise<{ periodId: string }> {
   const periodId = getUsagePeriodId(occurredAt || Date.now());
   const normalizedClassId = classId.toLowerCase();
+  const normalizedReaderWallet = readerWallet.toLowerCase();
 
-  const periodDocRef = likeNFTBookCollection
-    .doc(normalizedClassId)
-    .collection('plusUsage')
-    .doc(periodId);
-  const readerDocRef = periodDocRef.collection('readers').doc(readerWallet);
+  const bookDocRef = likeNFTBookCollection.doc(normalizedClassId);
+  const bookDoc = await bookDocRef.get();
+  if (!bookDoc.exists) throw new ValidationError('CLASS_ID_NOT_FOUND', 404);
+
+  const periodDocRef = bookDocRef.collection('plusUsage').doc(periodId);
+  const readerDocRef = periodDocRef.collection('readers').doc(normalizedReaderWallet);
 
   const usageIncrement = {
     readingTimeMs: FieldValue.increment(readingTimeMs),

--- a/src/util/api/plus/revenueShare.ts
+++ b/src/util/api/plus/revenueShare.ts
@@ -1,5 +1,7 @@
 import { ONE_DAY_IN_MS } from '../../../constant';
-import { FieldValue, userCollection } from '../../firebase';
+import {
+  FieldValue, db, likeNFTBookCollection, userCollection,
+} from '../../firebase';
 import type { PlusReadingAccrualData } from '../../../types/user';
 
 /**
@@ -40,6 +42,71 @@ export function calculatePlusDailyValue({
   const termDays = roundTermDays(termMs);
   if (termDays <= 0) return 0;
   return amountPaid / termDays;
+}
+
+/**
+ * Settlement-period bucket for a usage timestamp: a UTC calendar month, `YYYY-MM`.
+ * UTC (not the project's HK timezone) keeps bucketing deterministic and matches the
+ * web backend's UTC date handling for reading streaks.
+ */
+export function getUsagePeriodId(timestampMs: number): string {
+  const date = new Date(timestampMs);
+  const year = date.getUTCFullYear();
+  const month = `${date.getUTCMonth() + 1}`.padStart(2, '0');
+  return `${year}-${month}`;
+}
+
+/**
+ * Records Plus reading/TTS usage into the period-bucketed ledger that funds the
+ * reading-library revenue share. Durations are already paced (anti-fraud) by the
+ * web backend, so this is a trusted write.
+ *
+ * Dual-write in one batch (mirrors the web backend's incrementBookReadingTime):
+ *   likeNFTBookCollection/{classId}/plusUsage/{periodId}                  ← book rollup
+ *   likeNFTBookCollection/{classId}/plusUsage/{periodId}/readers/{wallet} ← reader grain
+ *
+ * The book rollup hangs off the book doc so settlement reads ownerWallet /
+ * connectedWallets live from the parent (no snapshot drift). `classId` is
+ * lowercased to a canonical key: EVM class ids arrive in mixed (EIP-55) casing
+ * from different callers, and the web backend already lowercases the same id for
+ * its per-user books subcollection — keying the ledger consistently dedups casing
+ * variants. Settlement resolves the book doc by the same lowercase key. The reader
+ * grain feeds the future per-reader/author stats without a backfill.
+ */
+export async function recordPlusReadingUsage({
+  readerWallet,
+  classId,
+  readingTimeMs,
+  ttsTimeMs,
+  occurredAt,
+}: {
+  readerWallet: string;
+  classId: string;
+  readingTimeMs: number;
+  ttsTimeMs: number;
+  occurredAt?: number;
+}): Promise<{ periodId: string }> {
+  const periodId = getUsagePeriodId(occurredAt || Date.now());
+  const normalizedClassId = classId.toLowerCase();
+
+  const periodDocRef = likeNFTBookCollection
+    .doc(normalizedClassId)
+    .collection('plusUsage')
+    .doc(periodId);
+  const readerDocRef = periodDocRef.collection('readers').doc(readerWallet);
+
+  const usageIncrement = {
+    readingTimeMs: FieldValue.increment(readingTimeMs),
+    ttsTimeMs: FieldValue.increment(ttsTimeMs),
+    updatedAt: FieldValue.serverTimestamp(),
+  };
+
+  const batch = db.batch();
+  batch.set(periodDocRef, usageIncrement, { merge: true });
+  batch.set(readerDocRef, usageIncrement, { merge: true });
+  await batch.commit();
+
+  return { periodId };
 }
 
 /**

--- a/src/util/api/plus/schemas.ts
+++ b/src/util/api/plus/schemas.ts
@@ -135,3 +135,22 @@ export const RevenueCatConfigResponseSchema = z.object({
   appUserId: z.string(),
   entitlementId: z.string(),
 });
+
+// Internal Plus reading-usage ingest (POST /plus/reading/usage), called
+// server-to-server by liker-land-v3. Durations are already paced (anti-fraud)
+// upstream; cap each at 4h — the reader's per-session ceiling — as a sanity bound.
+const MAX_USAGE_DELTA_MS = 4 * 60 * 60 * 1000;
+const UsageDurationSchema = z.number().int().min(0).max(MAX_USAGE_DELTA_MS);
+
+export const PlusReadingUsageBodySchema = z.object({
+  readerWallet: z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'INVALID_READER_WALLET'),
+  classId: z.string().min(1),
+  readingTimeMs: UsageDurationSchema,
+  ttsTimeMs: UsageDurationSchema,
+  occurredAt: z.number().int().positive().optional(),
+});
+
+export const PlusReadingUsageResponseSchema = z.object({
+  success: z.literal(true),
+  periodId: z.string(),
+});

--- a/src/util/api/plus/schemas.ts
+++ b/src/util/api/plus/schemas.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { SUPPORTED_CHECKOUT_UI_MODES } from '../../../constant';
+import { EVM_ADDRESS_REGEX } from '../../evm';
 import {
   BookGiftInfoBodySchema,
   BookGiftInfoSchema,
@@ -137,14 +138,14 @@ export const RevenueCatConfigResponseSchema = z.object({
 });
 
 // Internal Plus reading-usage ingest (POST /plus/reading/usage), called
-// server-to-server by liker-land-v3. Durations are already paced (anti-fraud)
+// server-to-server by 3ook.com. Durations are already paced (anti-fraud)
 // upstream; cap each at 4h — the reader's per-session ceiling — as a sanity bound.
 const MAX_USAGE_DELTA_MS = 4 * 60 * 60 * 1000;
 const UsageDurationSchema = z.number().int().min(0).max(MAX_USAGE_DELTA_MS);
 
 export const PlusReadingUsageBodySchema = z.object({
-  readerWallet: z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'INVALID_READER_WALLET'),
-  classId: z.string().min(1),
+  readerWallet: z.string().regex(EVM_ADDRESS_REGEX, 'INVALID_READER_WALLET'),
+  classId: z.string().regex(EVM_ADDRESS_REGEX, 'INVALID_CLASS_ID'),
   readingTimeMs: UsageDurationSchema,
   ttsTimeMs: UsageDurationSchema,
   occurredAt: z.number().int().positive().optional(),

--- a/src/util/evm/index.ts
+++ b/src/util/evm/index.ts
@@ -1,5 +1,7 @@
+export const EVM_ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/;
+
 export function isValidEVMAddress(address) {
-  return /^0x[0-9a-fA-F]{40}$/.test(address);
+  return EVM_ADDRESS_REGEX.test(address);
 }
 
 export default isValidEVMAddress;

--- a/test/api/plus-reading-usage.test.ts
+++ b/test/api/plus-reading-usage.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import axiosist from './axiosist';
+import { likeNFTBookCollection } from '../../src/util/firebase';
+
+const PATH = '/api/plus/reading/usage';
+const AUTH = 'test-plus-reading-service-token'; // matches PLUS_READING_SERVICE_TOKEN in test/setup.ts
+const AUTH_HEADER = { Authorization: `Bearer ${AUTH}` };
+const CLASS_ID = '0x1111111111111111111111111111111111111111';
+const READER = '0x2222222222222222222222222222222222222222';
+const OWNER = '0x3333333333333333333333333333333333333333';
+
+const post = (body: Record<string, unknown>, headers?: Record<string, string>) => axiosist
+  .post(PATH, body, headers ? { headers } : undefined)
+  .catch((err) => (err as any).response);
+
+describe('POST /plus/reading/usage', () => {
+  it('rejects requests without the service token', async () => {
+    const noAuth = await post({
+      readerWallet: READER, classId: CLASS_ID, readingTimeMs: 1000, ttsTimeMs: 0,
+    });
+    expect(noAuth.status).toBe(401);
+  });
+
+  it('rejects an invalid reader wallet', async () => {
+    const res = await post({
+      readerWallet: 'not-a-wallet', classId: CLASS_ID, readingTimeMs: 1000, ttsTimeMs: 0,
+    }, AUTH_HEADER);
+    expect(res.status).toBe(400);
+  });
+
+  it('records usage into the book rollup under the lowercase class id', async () => {
+    // Post a mixed-case (EIP-55) class id; the ledger key must be lowercased.
+    const mixedCaseClassId = '0xAbCdEf1111111111111111111111111111111111';
+    const lowerClassId = mixedCaseClassId.toLowerCase();
+    await likeNFTBookCollection.doc(lowerClassId)
+      .set({ classId: lowerClassId, ownerWallet: OWNER } as any);
+
+    const res = await post({
+      readerWallet: READER,
+      classId: mixedCaseClassId,
+      readingTimeMs: 1500,
+      ttsTimeMs: 4200,
+      occurredAt: Date.UTC(2026, 2, 10, 8), // 2026-03
+    }, AUTH_HEADER);
+    expect(res.status).toBe(200);
+    expect(res.data).toEqual({ success: true, periodId: '2026-03' });
+
+    const doc = await likeNFTBookCollection
+      .doc(lowerClassId)
+      .collection('plusUsage')
+      .doc('2026-03')
+      .get();
+    // increment() is identity in the stub, so a single write stores the posted value.
+    const data = doc.data() as any;
+    expect(data.readingTimeMs).toBe(1500);
+    expect(data.ttsTimeMs).toBe(4200);
+  });
+
+  it('acks a no-op (zero duration) without requiring a book', async () => {
+    const res = await post({
+      readerWallet: READER,
+      classId: CLASS_ID,
+      readingTimeMs: 0,
+      ttsTimeMs: 0,
+      occurredAt: Date.UTC(2026, 4, 1), // 2026-05
+    }, AUTH_HEADER);
+    expect(res.status).toBe(200);
+    expect(res.data).toEqual({ success: true, periodId: '2026-05' });
+  });
+});

--- a/test/api/plus-reading-usage.test.ts
+++ b/test/api/plus-reading-usage.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import axiosist from './axiosist';
+import mockEVMAddress from './address';
 import { likeNFTBookCollection } from '../../src/util/firebase';
 
 const PATH = '/api/plus/reading/usage';
 const AUTH = 'test-plus-reading-service-token'; // matches PLUS_READING_SERVICE_TOKEN in test/setup.ts
 const AUTH_HEADER = { Authorization: `Bearer ${AUTH}` };
-const CLASS_ID = '0x1111111111111111111111111111111111111111';
-const READER = '0x2222222222222222222222222222222222222222';
-const OWNER = '0x3333333333333333333333333333333333333333';
+const CLASS_ID = mockEVMAddress(0x11);
+const READER = mockEVMAddress(0x22);
+const OWNER = mockEVMAddress(0x33);
 
 const post = (body: Record<string, unknown>, headers?: Record<string, string>) => axiosist
   .post(PATH, body, headers ? { headers } : undefined)
@@ -54,6 +55,18 @@ describe('POST /plus/reading/usage', () => {
     const data = doc.data() as any;
     expect(data.readingTimeMs).toBe(1500);
     expect(data.ttsTimeMs).toBe(4200);
+  });
+
+  it('rejects usage for a class id with no book doc', async () => {
+    const orphanClassId = mockEVMAddress(0x44);
+    const res = await post({
+      readerWallet: READER,
+      classId: orphanClassId,
+      readingTimeMs: 1000,
+      ttsTimeMs: 0,
+      occurredAt: Date.UTC(2026, 2, 10),
+    }, AUTH_HEADER);
+    expect(res.status).toBe(404);
   });
 
   it('acks a no-op (zero duration) without requiring a book', async () => {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -11,10 +11,12 @@ process.env.REVENUECAT_WEBHOOK_AUTHORIZATION = 'test-rc-webhook-secret';
 process.env.REVENUECAT_PLUS_MONTHLY_PRODUCT_IDS = 'rc_plus_monthly';
 process.env.REVENUECAT_PLUS_YEARLY_PRODUCT_IDS = 'rc_plus_yearly';
 process.env.AIRTABLE_AUTOMATION_TOKEN = 'test-airtable-automation-token';
+process.env.PLUS_READING_SERVICE_TOKEN = 'test-plus-reading-service-token';
 
 // Mock config files
 vi.mock('../../config/config', () => ({
   AIRTABLE_AUTOMATION_TOKEN: 'test-airtable-automation-token',
+  PLUS_READING_SERVICE_TOKEN: 'test-plus-reading-service-token',
   FIREBASE_STORAGE_BUCKET: 'test-bucket',
   FIRESTORE_USER_ROOT: 'users',
   FIRESTORE_USER_AUTH_ROOT: 'user-auth',

--- a/test/unit/plus-revenue-share.test.ts
+++ b/test/unit/plus-revenue-share.test.ts
@@ -5,6 +5,7 @@ import {
   calculatePlusDailyValue,
   getAccrualOverlapDays,
   getUsageMonthBoundsMs,
+  getUsagePeriodId,
 } from '../../src/util/api/plus/revenueShare';
 
 const monthStart = Date.UTC(2026, 0, 1);
@@ -69,6 +70,38 @@ describe('calculatePlusDailyValue', () => {
       currentPeriodEnd: monthStart + 30 * ONE_DAY_IN_MS - 5000,
     });
     expect(daily).toBeCloseTo(9 / 30, 10);
+  });
+});
+
+describe('getUsagePeriodId', () => {
+  it('buckets a timestamp into its UTC YYYY-MM month', () => {
+    expect(getUsagePeriodId(Date.UTC(2026, 2, 15, 12))).toBe('2026-03');
+  });
+
+  it('zero-pads single-digit months', () => {
+    expect(getUsagePeriodId(Date.UTC(2026, 0, 1))).toBe('2026-01');
+  });
+
+  it('keeps the first millisecond of a month in that month', () => {
+    expect(getUsagePeriodId(Date.UTC(2026, 1, 1, 0, 0, 0, 0))).toBe('2026-02');
+  });
+
+  it('keeps the last millisecond of a month in that month', () => {
+    expect(getUsagePeriodId(Date.UTC(2026, 1, 1) - 1)).toBe('2026-01');
+  });
+
+  it('buckets by UTC, not local time, across a day boundary', () => {
+    // 2026-01-31T23:30 UTC is still January in UTC even though it is February
+    // in any positive-offset local zone (e.g. the project's HK timezone).
+    expect(getUsagePeriodId(Date.UTC(2026, 0, 31, 23, 30))).toBe('2026-01');
+  });
+
+  it('round-trips into getUsageMonthBoundsMs bounds', () => {
+    const periodId = getUsagePeriodId(Date.UTC(2026, 11, 25));
+    const { startMs, endMs } = getUsageMonthBoundsMs(periodId);
+    expect(periodId).toBe('2026-12');
+    expect(getUsagePeriodId(startMs)).toBe(periodId);
+    expect(getUsagePeriodId(endMs - 1)).toBe(periodId);
   });
 });
 


### PR DESCRIPTION
POST /plus/reading/usage records the Plus reading/TTS durations forwarded by the liker-land-v3 web backend into a period-bucketed ledger that funds the reading-library revenue share — the numerator the settlement job divides the accrued pool across.

- Service-secret auth (PLUS_READING_SERVICE_TOKEN), no user JWT: durations are already paced (anti-fraud) upstream, so this is a trusted server-to-server write.
- recordPlusReadingUsage dual-writes in one batch: a per-(book, UTC month) rollup hanging off the book doc (so settlement reads ownerWallet live, no snapshot drift) plus a per-reader grain for future reader/author stats.
- getUsagePeriodId buckets by UTC calendar month for deterministic settlement.
- Unit tests for period bucketing; API tests for auth, validation, and the book-rollup write.