### PR TITLE
[TAS-5912] ✨ Add Plus reading revenue-share settlement and payout sweep

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -157,6 +157,8 @@ config.AIRTABLE_AUTOMATION_TOKEN = process.env.AIRTABLE_AUTOMATION_TOKEN;
 // Shared secret for the internal Plus reading-usage ingest endpoint, called
 // server-to-server by the 3ook.com backend.
 config.PLUS_READING_SERVICE_TOKEN = process.env.PLUS_READING_SERVICE_TOKEN;
+// Guards the admin-triggered Plus reading revenue-share settle endpoint.
+config.PLUS_SETTLE_ADMIN_TOKEN = process.env.PLUS_SETTLE_ADMIN_TOKEN;
 
 config.SLACK_COMMAND_TOKEN = '';
 

--- a/src/constant/index.ts
+++ b/src/constant/index.ts
@@ -103,6 +103,7 @@ export const QUERY_STRING_TO_REMOVE = [
 
 export const ONE_HOUR_IN_S = 3600;
 export const ONE_DAY_IN_S = 86400;
+export const ONE_MINUTE_IN_MS = 60000;
 export const ONE_DAY_IN_MS = 86400000;
 export const CIVIC_LIKER_START_DATE = 1546272000000; // 2019-01-01T00:00:00+0800
 export const SUBSCRIPTION_GRACE_PERIOD = 0 * ONE_DAY_IN_MS;

--- a/src/middleware/plus-settle-admin-auth.ts
+++ b/src/middleware/plus-settle-admin-auth.ts
@@ -1,0 +1,31 @@
+import { Request, Response, NextFunction } from 'express';
+
+import { PLUS_SETTLE_ADMIN_TOKEN } from '../../config/config';
+
+import { constantTimeEqual } from '../util/misc';
+import { ValidationError } from '../util/ValidationError';
+
+const BEARER_PREFIX = 'Bearer ';
+
+// Guards the admin-triggered Plus reading revenue-share settle endpoint. This moves
+// money (Stripe Connect transfers), so it uses a dedicated secret separate from the
+// reading-usage ingest token — triggered by Cloud Scheduler or an operator.
+export function plusSettleAdminAuth(req: Request, res: Response, next: NextFunction) {
+  if (!PLUS_SETTLE_ADMIN_TOKEN) {
+    next(new ValidationError('PLUS_SETTLE_ADMIN_TOKEN_NOT_CONFIGURED', 500));
+    return;
+  }
+  const header = req.get('Authorization');
+  if (!header || !header.startsWith(BEARER_PREFIX)) {
+    next(new ValidationError('PLUS_SETTLE_ADMIN_TOKEN_MALFORMED', 401));
+    return;
+  }
+  const provided = header.slice(BEARER_PREFIX.length);
+  if (!constantTimeEqual(provided, PLUS_SETTLE_ADMIN_TOKEN)) {
+    next(new ValidationError('UNAUTHORIZED', 401));
+    return;
+  }
+  next();
+}
+
+export default plusSettleAdminAuth;

--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -84,9 +84,10 @@ router.post('/reading/usage', plusReadingServiceAuth, validateBody(PlusReadingUs
   }
 });
 
-// Admin/cron: settle the Plus reading revenue share for a `YYYY-MM` period — accrue the
-// pool, freeze usage, price each book, and pay payees via Stripe Connect. `dryRun` returns
-// the full allocation without writing or transferring (run it first to eyeball the split).
+// Admin/cron: settle the Plus reading revenue share for a `YYYY-MM` (month) or `YYYY-MM-DD`
+// (day) period — accrue the pool, freeze usage, price each book, and pay payees via Stripe
+// Connect. `dryRun` returns the full allocation without writing or transferring (run it first
+// to eyeball the split, or to preview an in-progress day).
 router.post('/admin/reading/settle', plusSettleAdminAuth, validateBody(PlusSettleBodySchema), async (req, res, next) => {
   try {
     const { periodId, dryRun = false, mode } = req.body;

--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -18,9 +18,13 @@ import {
   PlusPriceBodySchema,
   PlusReadingUsageBodySchema,
   PlusReadingUsageResponseSchema,
+  PlusSettleBodySchema,
+  PlusSettleResponseSchema,
 } from '../../util/api/plus/schemas';
 import { plusReadingServiceAuth } from '../../middleware/plus-reading-service-auth';
+import { plusSettleAdminAuth } from '../../middleware/plus-settle-admin-auth';
 import { getUsageDayId, recordPlusReadingUsage } from '../../util/api/plus/revenueShare';
+import { settlePlusReadingPeriod } from '../../util/api/plus/settleJob';
 import { getBookUserInfoFromWallet, getBookUserInfoFromLikerId } from '../../util/api/likernft/book/user';
 import { getStripeClient } from '../../util/stripe';
 import {
@@ -73,6 +77,19 @@ router.post('/reading/usage', plusReadingServiceAuth, validateBody(PlusReadingUs
       occurredAt,
     });
     sendValidatedJSON(res, PlusReadingUsageResponseSchema, { success: true, dayId });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Admin/cron: settle the Plus reading revenue share for a `YYYY-MM` period — accrue the
+// pool, freeze usage, price each book, and pay payees via Stripe Connect. `dryRun` returns
+// the full allocation without writing or transferring (run it first to eyeball the split).
+router.post('/admin/reading/settle', plusSettleAdminAuth, validateBody(PlusSettleBodySchema), async (req, res, next) => {
+  try {
+    const { periodId, dryRun = false, mode } = req.body;
+    const result = await settlePlusReadingPeriod({ periodId, dryRun, mode });
+    sendValidatedJSON(res, PlusSettleResponseSchema, { success: true, ...result });
   } catch (err) {
     next(err);
   }

--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -20,11 +20,13 @@ import {
   PlusReadingUsageResponseSchema,
   PlusSettleBodySchema,
   PlusSettleResponseSchema,
+  PlusSweepBodySchema,
+  PlusSweepResponseSchema,
 } from '../../util/api/plus/schemas';
 import { plusReadingServiceAuth } from '../../middleware/plus-reading-service-auth';
 import { plusSettleAdminAuth } from '../../middleware/plus-settle-admin-auth';
 import { getUsageDayId, recordPlusReadingUsage } from '../../util/api/plus/revenueShare';
-import { settlePlusReadingPeriod } from '../../util/api/plus/settleJob';
+import { settlePlusReadingPeriod, sweepPlusReadingPendingPayouts } from '../../util/api/plus/settleJob';
 import { getBookUserInfoFromWallet, getBookUserInfoFromLikerId } from '../../util/api/likernft/book/user';
 import { getStripeClient } from '../../util/stripe';
 import {
@@ -90,6 +92,18 @@ router.post('/admin/reading/settle', plusSettleAdminAuth, validateBody(PlusSettl
     const { periodId, dryRun = false, mode } = req.body;
     const result = await settlePlusReadingPeriod({ periodId, dryRun, mode });
     sendValidatedJSON(res, PlusSettleResponseSchema, { success: true, ...result });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Admin/cron: re-attempt payouts left `pending` by earlier settles (payees who have
+// since completed Stripe Connect onboarding). Idempotent; `dryRun` previews only.
+router.post('/admin/reading/sweep', plusSettleAdminAuth, validateBody(PlusSweepBodySchema), async (req, res, next) => {
+  try {
+    const { dryRun = false } = req.body;
+    const result = await sweepPlusReadingPendingPayouts({ dryRun });
+    sendValidatedJSON(res, PlusSweepResponseSchema, { success: true, ...result });
   } catch (err) {
     next(err);
   }

--- a/src/util/api/plus/revenueShare.ts
+++ b/src/util/api/plus/revenueShare.ts
@@ -172,14 +172,17 @@ export async function recordPlusSubscriptionAccrual({
 }
 
 /**
- * UTC millisecond bounds `[startMs, endMs)` of a `YYYY-MM` settlement period.
+ * UTC millisecond bounds `[startMs, endMs)` of a settlement period — either a whole month
+ * (`YYYY-MM`) or a single day (`YYYY-MM-DD`). A 2-part id is a month, a 3-part id a day;
+ * format/validity is enforced upstream by `PlusSettleBodySchema`. `Date.UTC` normalizes the
+ * end bound's overflow, so a month-end or Dec-31 day rolls into the next month/year.
  */
-export function getUsageMonthBoundsMs(periodId: string): { startMs: number; endMs: number } {
-  const [year, month] = periodId.split('-').map(Number);
-  return {
-    startMs: Date.UTC(year, month - 1, 1),
-    endMs: Date.UTC(year, month, 1),
-  };
+export function getPeriodBoundsMs(periodId: string): { startMs: number; endMs: number } {
+  const [year, month, day] = periodId.split('-').map(Number);
+  if (day === undefined) {
+    return { startMs: Date.UTC(year, month - 1, 1), endMs: Date.UTC(year, month, 1) };
+  }
+  return { startMs: Date.UTC(year, month - 1, day), endMs: Date.UTC(year, month - 1, day + 1) };
 }
 
 /**
@@ -202,15 +205,15 @@ export function getAccrualOverlapDays(
 }
 
 /**
- * Sums the USD funding attributable to a settlement period: each accrual term
- * contributes `dailyValueUSD × overlapDays(term, month)`. Pure — settlement reads the
+ * Sums the USD funding attributable to a settlement window `[startMs, endMs)`: each accrual
+ * term contributes `dailyValueUSD × overlapDays(term, window)`. Pure — settlement reads the
  * accrual docs from Firestore and passes them in.
  */
 export function accruePoolUSD(
   accruals: Array<Pick<PlusReadingAccrualData, 'dailyValueUSD' | 'currentPeriodStart' | 'currentPeriodEnd'>>,
-  periodId: string,
+  startMs: number,
+  endMs: number,
 ): number {
-  const { startMs, endMs } = getUsageMonthBoundsMs(periodId);
   return accruals.reduce(
     (sum, a) => sum + a.dailyValueUSD * getAccrualOverlapDays(
       a.currentPeriodStart,

--- a/src/util/api/plus/schemas.ts
+++ b/src/util/api/plus/schemas.ts
@@ -157,9 +157,18 @@ export const PlusReadingUsageResponseSchema = z.object({
   dayId: z.string(),
 });
 
-// Admin Plus reading revenue-share settle (POST /plus/admin/reading/settle).
+// Admin Plus reading revenue-share settle (POST /plus/admin/reading/settle). `periodId` is a
+// whole month (`YYYY-MM`) or a single day (`YYYY-MM-DD`).
 export const PlusSettleBodySchema = z.object({
-  periodId: z.string().regex(/^\d{4}-(0[1-9]|1[0-2])$/, 'INVALID_PERIOD_ID'),
+  periodId: z.string()
+    .regex(/^\d{4}-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01]))?$/, 'INVALID_PERIOD_ID')
+    // Reject impossible calendar days (e.g. 2026-02-30): a YYYY-MM-DD id must round-trip
+    // through Date.UTC unchanged. Month-only ids have no day to validate.
+    .refine((id) => {
+      const [y, m, d] = id.split('-').map(Number);
+      if (d === undefined) return true;
+      return new Date(Date.UTC(y, m - 1, d)).getUTCDate() === d;
+    }, 'INVALID_PERIOD_ID'),
   dryRun: z.boolean().optional(),
   mode: z.enum(PLUS_READING_ALLOCATION_MODES).optional(),
 });

--- a/src/util/api/plus/schemas.ts
+++ b/src/util/api/plus/schemas.ts
@@ -7,6 +7,7 @@ import {
   StripeCheckoutResponseSchema,
   TrackingFieldsSchema,
 } from '../likernft/book/schemas';
+import { PLUS_READING_ALLOCATION_MODES } from './settle';
 
 const TrialPeriodDaysSchema = z.union([
   z.literal(0),
@@ -154,4 +155,38 @@ export const PlusReadingUsageBodySchema = z.object({
 export const PlusReadingUsageResponseSchema = z.object({
   success: z.literal(true),
   dayId: z.string(),
+});
+
+// Admin Plus reading revenue-share settle (POST /plus/admin/reading/settle).
+export const PlusSettleBodySchema = z.object({
+  periodId: z.string().regex(/^\d{4}-(0[1-9]|1[0-2])$/, 'INVALID_PERIOD_ID'),
+  dryRun: z.boolean().optional(),
+  mode: z.enum(PLUS_READING_ALLOCATION_MODES).optional(),
+});
+
+export const PlusSettleResponseSchema = z.object({
+  success: z.literal(true),
+  dryRun: z.boolean(),
+  periodId: z.string(),
+  mode: z.enum(PLUS_READING_ALLOCATION_MODES),
+  revShareRate: z.number(),
+  poolUSD: z.number(),
+  allocatableUSD: z.number(),
+  allocatedUSD: z.number(),
+  revSharePct: z.number(),
+  readRatePerMin: z.number(),
+  ttsRatePerMin: z.number(),
+  totalReadingTimeMs: z.number(),
+  totalTTSTimeMs: z.number(),
+  bookCount: z.number(),
+  paidCount: z.number(),
+  pendingCount: z.number(),
+  paidCents: z.number(),
+  pendingCents: z.number(),
+  books: z.array(z.object({
+    classId: z.string(),
+    amountCents: z.number(),
+    readingTimeMs: z.number(),
+    ttsTimeMs: z.number(),
+  })),
 });

--- a/src/util/api/plus/schemas.ts
+++ b/src/util/api/plus/schemas.ts
@@ -190,3 +190,17 @@ export const PlusSettleResponseSchema = z.object({
     ttsTimeMs: z.number(),
   })),
 });
+
+// Admin Plus reading pending-payout sweep (POST /plus/admin/reading/sweep).
+export const PlusSweepBodySchema = z.object({
+  dryRun: z.boolean().optional(),
+});
+
+export const PlusSweepResponseSchema = z.object({
+  success: z.literal(true),
+  dryRun: z.boolean(),
+  sweptCount: z.number(),
+  paidCount: z.number(),
+  stillPendingCount: z.number(),
+  paidCents: z.number(),
+});

--- a/src/util/api/plus/settle.ts
+++ b/src/util/api/plus/settle.ts
@@ -1,0 +1,148 @@
+import { ONE_MINUTE_IN_MS } from '../../../constant';
+
+/**
+ * How the per-minute reading/TTS rates are derived. The first three split a fixed
+ * pool across actual usage (so the rate floats); `static` instead pays a fixed rate
+ * per minute regardless of the pool:
+ * - `static`   — a fixed USD/min rate per channel (default `DEFAULT_STATIC_RATE_PER_MIN_USD`),
+ *                independent of the pool. The settle job logs the resulting payout as a
+ *                % of Plus revenue so it can be watched against the rev-share target.
+ * - `blended`  — one rate over all minutes (a reading minute and a TTS minute pay equally).
+ * - `split`    — the pool is divided into reading vs TTS sub-pools by `readShare`, each
+ *                priced against its own minutes (lets the two channels pay differently).
+ * - `weighted` — minutes are weighted (a TTS minute counts `ttsWeight` of a reading
+ *                minute) then blended; `blended` is exactly `weighted(1, 1)`.
+ */
+export const PLUS_READING_ALLOCATION_MODES = ['static', 'blended', 'split', 'weighted'] as const;
+export type PlusReadingAllocationMode = typeof PLUS_READING_ALLOCATION_MODES[number];
+
+// Default static per-minute rate (USD). Live-tunable via the config doc's
+// `readRatePerMinUSD` / `ttsRatePerMinUSD`, like the rev-share rate.
+export const DEFAULT_STATIC_RATE_PER_MIN_USD = 0.01;
+
+export interface PlusReadingAllocationConfig {
+  mode: PlusReadingAllocationMode;
+  // `static` only: fixed USD paid per reading / TTS minute. Each defaults to
+  // `DEFAULT_STATIC_RATE_PER_MIN_USD`.
+  readRatePerMinUSD?: number;
+  ttsRatePerMinUSD?: number;
+  // `split` only: fraction of the pool reserved for reading (0..1). Default 0.5.
+  readShare?: number;
+  // `weighted` only: relative value of a reading vs TTS minute. Default 1 / 1.
+  readWeight?: number;
+  ttsWeight?: number;
+}
+
+export interface PlusReadingUsageTotals {
+  readingTimeMs: number;
+  ttsTimeMs: number;
+}
+
+export interface PlusReadingRates {
+  // USD paid per minute of reading / TTS for the settlement period.
+  readRatePerMin: number;
+  ttsRatePerMin: number;
+}
+
+const ZERO_RATES: PlusReadingRates = { readRatePerMin: 0, ttsRatePerMin: 0 };
+
+// Coerce an externally-configured number (Firestore config doc) to a safe value: keep it
+// only when finite and within [min, max], else fall back. Guards the money math against a
+// malformed config (NaN / Infinity / out-of-range) before rates feed Stripe transfers.
+export function configNumber(
+  value: number | undefined,
+  fallback: number,
+  min: number,
+  max = Infinity,
+): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= min && value <= max
+    ? value : fallback;
+}
+
+/**
+ * Derives the per-minute reading/TTS rates for the period, per the allocation mode.
+ * The pool modes distribute `allocatableUSD` (the pool after the rev-share cut) across
+ * the period's usage; a channel with no minutes gets a 0 rate, and under `split` that
+ * can strand its sub-pool, which the settle job surfaces rather than silently dropping.
+ * `static` ignores the pool entirely and returns the configured fixed per-minute rates.
+ */
+export function computePlusReadingRates(
+  allocatableUSD: number,
+  totals: PlusReadingUsageTotals,
+  config: PlusReadingAllocationConfig,
+): PlusReadingRates {
+  // Static rate is pool-independent — resolve it before the allocatable-pool guard.
+  if (config.mode === 'static') {
+    return {
+      readRatePerMin: configNumber(config.readRatePerMinUSD, DEFAULT_STATIC_RATE_PER_MIN_USD, 0),
+      ttsRatePerMin: configNumber(config.ttsRatePerMinUSD, DEFAULT_STATIC_RATE_PER_MIN_USD, 0),
+    };
+  }
+  if (!(allocatableUSD > 0)) return ZERO_RATES;
+  const readMin = totals.readingTimeMs / ONE_MINUTE_IN_MS;
+  const ttsMin = totals.ttsTimeMs / ONE_MINUTE_IN_MS;
+
+  if (config.mode === 'split') {
+    const readShare = configNumber(config.readShare, 0.5, 0, 1);
+    const readPool = allocatableUSD * readShare;
+    const ttsPool = allocatableUSD - readPool;
+    return {
+      readRatePerMin: readMin > 0 ? readPool / readMin : 0,
+      ttsRatePerMin: ttsMin > 0 ? ttsPool / ttsMin : 0,
+    };
+  }
+
+  // blended === weighted(1, 1) — fold both into the weighted path.
+  const readWeight = config.mode === 'weighted' ? configNumber(config.readWeight, 1, 0) : 1;
+  const ttsWeight = config.mode === 'weighted' ? configNumber(config.ttsWeight, 1, 0) : 1;
+  const weightedMin = readMin * readWeight + ttsMin * ttsWeight;
+  if (!(weightedMin > 0)) return ZERO_RATES;
+  const baseRate = allocatableUSD / weightedMin;
+  return {
+    readRatePerMin: baseRate * readWeight,
+    ttsRatePerMin: baseRate * ttsWeight,
+  };
+}
+
+/**
+ * USD owed to one book for a period: its reading and TTS minutes priced at the period rates.
+ */
+export function allocateBookUSD(
+  rates: PlusReadingRates,
+  usage: PlusReadingUsageTotals,
+): number {
+  return rates.readRatePerMin * (usage.readingTimeMs / ONE_MINUTE_IN_MS)
+    + rates.ttsRatePerMin * (usage.ttsTimeMs / ONE_MINUTE_IN_MS);
+}
+
+/**
+ * Splits an integer-cent amount across weighted payee wallets (mirrors the book
+ * commission split). Uses the largest-remainder method so the parts sum to `amountCents`
+ * exactly — no dust lost to flooring. Returns no entry for a wallet that rounds to 0.
+ * Empty when there is nothing to split or no positive weight (caller handles the fallback).
+ */
+export function splitAmountToWallets(
+  amountCents: number,
+  connectedWallets: Record<string, number>,
+): Array<{ wallet: string; amountCents: number }> {
+  const wallets = Object.keys(connectedWallets);
+  const totalWeight = wallets.reduce((sum, w) => sum + connectedWallets[w], 0);
+  if (!(amountCents > 0) || !(totalWeight > 0)) return [];
+
+  const parts = wallets.map((wallet) => {
+    const exact = (amountCents * connectedWallets[wallet]) / totalWeight;
+    const floored = Math.floor(exact);
+    return { wallet, amountCents: floored, frac: exact - floored };
+  });
+  // Hand each leftover cent to the highest fractional parts so the split is exact.
+  // Tie-break by wallet so equal fractions resolve deterministically across re-runs —
+  // the Stripe idempotency key omits the amount, so the cent must land on the same wallet.
+  let remainder = amountCents - parts.reduce((sum, p) => sum + p.amountCents, 0);
+  parts.sort((a, b) => (b.frac - a.frac) || a.wallet.localeCompare(b.wallet));
+  for (let i = 0; remainder > 0; i += 1, remainder -= 1) {
+    parts[i % parts.length].amountCents += 1;
+  }
+  return parts
+    .filter((p) => p.amountCents > 0)
+    .map(({ wallet, amountCents: cents }) => ({ wallet, amountCents: cents }));
+}

--- a/src/util/api/plus/settleJob.ts
+++ b/src/util/api/plus/settleJob.ts
@@ -1,0 +1,285 @@
+/* eslint-disable no-await-in-loop, no-restricted-syntax */
+/* eslint-disable no-continue, import/prefer-default-export */
+import {
+  FieldValue, db, configCollection, likeNFTBookCollection, likeNFTBookUserCollection,
+} from '../../firebase';
+import { getStripeClient } from '../../stripe';
+import { getBookUserInfo } from '../likernft/book/user';
+import { ValidationError } from '../../ValidationError';
+import { accruePoolUSD, getUsageMonthBoundsMs } from './revenueShare';
+import {
+  PLUS_READING_ALLOCATION_MODES, allocateBookUSD, computePlusReadingRates, configNumber,
+  splitAmountToWallets,
+} from './settle';
+import type { PlusReadingAllocationConfig, PlusReadingAllocationMode } from './settle';
+import type { PlusReadingAccrualData } from '../../../types/user';
+
+const REVSHARE_CONFIG_DOC_ID = 'plusReadingRevShare';
+const DEFAULT_REVSHARE_RATE = 0.3;
+
+interface BookUsage {
+  classId: string;
+  readingTimeMs: number;
+  ttsTimeMs: number;
+}
+
+type PayoutOutcome = 'paid' | 'pending' | 'skipped';
+
+/**
+ * Pays one payee its share of a book for the period, returning how it resolved.
+ * - dryRun: reports already-paid as skipped, else classifies by Connect-readiness, without
+ *   writing or transferring.
+ * - already-paid (same period+book): skipped (idempotent re-run).
+ * - not Connect-ready or transfer failed: carried forward as `pending` for a later run.
+ * - otherwise: a Stripe Connect transfer (idempotency-keyed) + a `paid` payout record.
+ */
+async function settleWalletPayout({
+  periodId, book, wallet, walletCents, dryRun,
+}: {
+  periodId: string;
+  book: BookUsage;
+  wallet: string;
+  walletCents: number;
+  dryRun: boolean;
+}): Promise<PayoutOutcome> {
+  const userInfo = await getBookUserInfo(wallet);
+  const isReady = !!userInfo?.isStripeConnectReady && !!userInfo.stripeConnectAccountId;
+
+  const payoutDocRef = likeNFTBookUserCollection
+    .doc(wallet)
+    .collection('plusReadingPayouts')
+    .doc(`${periodId}_${book.classId}`);
+  // Two-layer idempotency: this `paid` record skips re-processing on a clean re-run,
+  // and the Stripe idempotencyKey below is the real backstop — if a transfer succeeded
+  // but its Firestore write failed, the retry reuses the same transfer (no double pay).
+  // Checked before the dryRun return so a preview also reports already-paid as skipped.
+  const existing = await payoutDocRef.get();
+  if (existing.exists && existing.data()?.status === 'paid') return 'skipped';
+
+  if (dryRun) return isReady ? 'paid' : 'pending';
+
+  const baseRecord = {
+    periodId,
+    classId: book.classId,
+    wallet,
+    amountCents: walletCents,
+    currency: 'usd',
+    readingTimeMs: book.readingTimeMs,
+    ttsTimeMs: book.ttsTimeMs,
+    updatedAt: FieldValue.serverTimestamp(),
+  };
+
+  if (!userInfo?.isStripeConnectReady || !userInfo.stripeConnectAccountId) {
+    // Carry forward: hold until the payee finishes Stripe Connect onboarding.
+    await payoutDocRef.set({ ...baseRecord, status: 'pending' }, { merge: true });
+    return 'pending';
+  }
+  const { stripeConnectAccountId } = userInfo;
+
+  // Pool-funded transfer from the platform balance — no source_transaction (unlike a
+  // per-charge commission). Idempotency key makes a re-run reuse the same transfer.
+  const transfer = await getStripeClient().transfers.create({
+    amount: walletCents,
+    currency: 'usd',
+    destination: stripeConnectAccountId,
+    transfer_group: `plus-revshare-${periodId}`,
+    description: `Plus reading revenue share ${periodId} (${book.classId})`,
+    metadata: {
+      type: 'plusReadingRevShare',
+      periodId,
+      classId: book.classId,
+      wallet,
+    },
+  }, {
+    idempotencyKey: `plus-revshare-${periodId}-${book.classId}-${wallet}`,
+  }).catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error(`Plus reading revshare transfer failed for ${wallet} (${book.classId}):`, err);
+    return null;
+  });
+
+  if (!transfer) {
+    await payoutDocRef.set({ ...baseRecord, status: 'pending' }, { merge: true });
+    return 'pending';
+  }
+  await payoutDocRef.set({
+    ...baseRecord,
+    status: 'paid',
+    transferId: transfer.id,
+    stripeConnectAccountId,
+  }, { merge: true });
+  return 'paid';
+}
+
+/**
+ * Settles the Plus reading-library revenue share for one `YYYY-MM` period: accrues the
+ * funding pool, freezes the usage snapshot, prices each book, and pays its payees via
+ * Stripe Connect (carrying forward anyone not yet Connect-ready). `dryRun` computes and
+ * returns the full allocation without writing or transferring. Idempotent: a completed
+ * period is refused, and per-payout records guard against double payment on re-run.
+ */
+export async function settlePlusReadingPeriod({
+  periodId,
+  dryRun,
+  mode,
+}: {
+  periodId: string;
+  dryRun: boolean;
+  mode?: PlusReadingAllocationMode;
+}) {
+  const configDocRef = configCollection.doc(REVSHARE_CONFIG_DOC_ID);
+  const periodDocRef = configDocRef.collection('periods').doc(periodId);
+  const [configSnap, periodSnap] = await Promise.all([configDocRef.get(), periodDocRef.get()]);
+
+  if (!dryRun && periodSnap.exists && periodSnap.data()?.status === 'completed') {
+    throw new ValidationError('PLUS_SETTLE_PERIOD_ALREADY_COMPLETED', 409);
+  }
+
+  const cfg = (configSnap.data() || {}) as {
+    revShareRate?: number;
+    mode?: PlusReadingAllocationMode;
+    readRatePerMinUSD?: number;
+    ttsRatePerMinUSD?: number;
+    readShare?: number;
+    readWeight?: number;
+    ttsWeight?: number;
+  };
+  // Reject a malformed config doc (NaN / Infinity / out-of-range) before money math.
+  const revShareRate = configNumber(cfg.revShareRate, DEFAULT_REVSHARE_RATE, 0, 1);
+  // Default to `static` ($0.01/min): we pay a fixed per-minute rate and treat the
+  // rev-share cut as a target to watch, not a hard pool divisor. An unrecognized stored
+  // mode (config doc isn't schema-validated) falls back to `static` rather than misprice.
+  const requestedMode = mode || cfg.mode;
+  const resolvedMode: PlusReadingAllocationMode = requestedMode
+    && PLUS_READING_ALLOCATION_MODES.includes(requestedMode) ? requestedMode : 'static';
+  const allocConfig: PlusReadingAllocationConfig = {
+    mode: resolvedMode,
+    readRatePerMinUSD: cfg.readRatePerMinUSD,
+    ttsRatePerMinUSD: cfg.ttsRatePerMinUSD,
+    readShare: cfg.readShare,
+    readWeight: cfg.readWeight,
+    ttsWeight: cfg.ttsWeight,
+  };
+
+  // Pool: sum each accrual term's USD overlap with the settlement month. Full
+  // collection-group scan (monthly batch) — bound with an index on currentPeriodEnd
+  // if the accrual ledger grows large.
+  const { startMs, endMs } = getUsageMonthBoundsMs(periodId);
+  const accrualSnap = await db.collectionGroup('plusReadingAccrual').get();
+  const accruals = accrualSnap.docs
+    .map((doc) => doc.data() as PlusReadingAccrualData)
+    .filter((a) => a.currentPeriodStart < endMs && a.currentPeriodEnd > startMs);
+  const poolUSD = accruePoolUSD(accruals, periodId);
+  const allocatableUSD = poolUSD * revShareRate;
+
+  // Freeze the period's per-book usage snapshot.
+  const usageSnap = await db.collectionGroup('plusUsage').get();
+  const bookUsages: BookUsage[] = usageSnap.docs
+    .filter((doc) => doc.id === periodId)
+    .map((doc) => {
+      const data = doc.data() || {};
+      return {
+        classId: doc.ref.parent.parent?.id || '',
+        readingTimeMs: data.readingTimeMs || 0,
+        ttsTimeMs: data.ttsTimeMs || 0,
+      };
+    })
+    .filter((b) => b.classId && (b.readingTimeMs > 0 || b.ttsTimeMs > 0));
+
+  const totals = bookUsages.reduce(
+    (acc, b) => ({
+      readingTimeMs: acc.readingTimeMs + b.readingTimeMs,
+      ttsTimeMs: acc.ttsTimeMs + b.ttsTimeMs,
+    }),
+    { readingTimeMs: 0, ttsTimeMs: 0 },
+  );
+  const rates = computePlusReadingRates(allocatableUSD, totals, allocConfig);
+
+  let paidCount = 0;
+  let pendingCount = 0;
+  let paidCents = 0;
+  let pendingCents = 0;
+  const books: Array<BookUsage & { amountCents: number }> = [];
+
+  for (const book of bookUsages) {
+    // Round each book down: per-book rounding then never sums past the pool (under the
+    // pool modes), so we can't overpay from the platform balance. The sub-cent dust just
+    // stays unallocated. Sub-cent allocations floor to 0 and are skipped below.
+    const amountCents = Math.floor(allocateBookUSD(rates, book) * 100);
+    books.push({ ...book, amountCents });
+    if (amountCents <= 0) continue;
+
+    const bookData = (await likeNFTBookCollection.doc(book.classId).get()).data();
+    if (!bookData) continue; // usage with no book doc — skip
+    const hasConnected = bookData.connectedWallets
+      && Object.keys(bookData.connectedWallets).length > 0;
+    if (!hasConnected && !bookData.ownerWallet) {
+      // No resolvable payee — skip rather than synthesize a `{ '': 1 }` split that would
+      // write to an empty doc id. The amount stays unallocated (surfaced in the log).
+      // eslint-disable-next-line no-console
+      console.warn(`Plus settle ${periodId}: ${book.classId} has usage but no payee; skipping`);
+      continue;
+    }
+    const connectedWallets = hasConnected
+      ? bookData.connectedWallets
+      : { [bookData.ownerWallet]: 1 };
+
+    const splits = splitAmountToWallets(amountCents, connectedWallets);
+    if (splits.length === 0) {
+      // connectedWallets present but no positive weight — surface rather than silently
+      // drop it. The amount (guaranteed > 0 above) stays unallocated, like the no-payee case.
+      // eslint-disable-next-line no-console
+      console.warn(`Plus settle ${periodId}: ${book.classId} has connectedWallets but no positive weight; skipping`);
+      continue;
+    }
+    for (const { wallet, amountCents: walletCents } of splits) {
+      const outcome = await settleWalletPayout({
+        periodId, book, wallet, walletCents, dryRun,
+      });
+      if (outcome === 'paid') {
+        paidCount += 1;
+        paidCents += walletCents;
+      } else if (outcome === 'pending') {
+        pendingCount += 1;
+        pendingCents += walletCents;
+      }
+    }
+  }
+
+  // What we actually pay out this period (pre cent-rounding), and how it compares to
+  // the Plus revenue it draws from. Under `static` the rate is fixed, so this fraction
+  // floats with usage — log it to watch it against the rev-share target (e.g. 30%).
+  const allocatedUSD = allocateBookUSD(rates, totals);
+  const revSharePct = poolUSD > 0 ? allocatedUSD / poolUSD : 0;
+  // eslint-disable-next-line no-console
+  console.log(`Plus settle ${periodId} [${allocConfig.mode}]: paying $${allocatedUSD.toFixed(2)} = ${(revSharePct * 100).toFixed(1)}% of $${poolUSD.toFixed(2)} Plus revenue (rev-share target ${(revShareRate * 100).toFixed(0)}%)`);
+
+  const summary = {
+    periodId,
+    mode: allocConfig.mode,
+    revShareRate,
+    poolUSD,
+    allocatableUSD,
+    allocatedUSD,
+    revSharePct,
+    readRatePerMin: rates.readRatePerMin,
+    ttsRatePerMin: rates.ttsRatePerMin,
+    totalReadingTimeMs: totals.readingTimeMs,
+    totalTTSTimeMs: totals.ttsTimeMs,
+    bookCount: books.length,
+    paidCount,
+    pendingCount,
+    paidCents,
+    pendingCents,
+  };
+
+  if (!dryRun) {
+    await periodDocRef.set({
+      ...summary,
+      status: 'completed',
+      settledAt: FieldValue.serverTimestamp(),
+    }, { merge: true });
+  }
+
+  return { dryRun, ...summary, books };
+}

--- a/src/util/api/plus/settleJob.ts
+++ b/src/util/api/plus/settleJob.ts
@@ -6,7 +6,7 @@ import {
 import { getStripeClient } from '../../stripe';
 import { getBookUserInfo } from '../likernft/book/user';
 import { ValidationError } from '../../ValidationError';
-import { accruePoolUSD, getUsageMonthBoundsMs } from './revenueShare';
+import { accruePoolUSD, getPeriodBoundsMs } from './revenueShare';
 import {
   PLUS_READING_ALLOCATION_MODES, allocateBookUSD, computePlusReadingRates, configNumber,
   splitAmountToWallets,
@@ -112,11 +112,13 @@ async function settleWalletPayout({
 }
 
 /**
- * Settles the Plus reading-library revenue share for one `YYYY-MM` period: accrues the
- * funding pool, freezes the usage snapshot, prices each book, and pays its payees via
- * Stripe Connect (carrying forward anyone not yet Connect-ready). `dryRun` computes and
- * returns the full allocation without writing or transferring. Idempotent: a completed
- * period is refused, and per-payout records guard against double payment on re-run.
+ * Settles the Plus reading-library revenue share for one period — a whole month (`YYYY-MM`)
+ * or a single day (`YYYY-MM-DD`): accrues the funding pool, freezes the usage snapshot,
+ * prices each book, and pays its payees via Stripe Connect (carrying forward anyone not yet
+ * Connect-ready). `dryRun` computes and returns the full allocation without writing or
+ * transferring. Idempotent and non-overlapping: a completed or overlapping period is refused,
+ * a window whose last day hasn't elapsed is refused, and per-payout records guard against
+ * double payment on re-run.
  */
 export async function settlePlusReadingPeriod({
   periodId,
@@ -128,11 +130,32 @@ export async function settlePlusReadingPeriod({
   mode?: PlusReadingAllocationMode;
 }) {
   const configDocRef = configCollection.doc(REVSHARE_CONFIG_DOC_ID);
-  const periodDocRef = configDocRef.collection('periods').doc(periodId);
+  const periodsCol = configDocRef.collection('periods');
+  const periodDocRef = periodsCol.doc(periodId);
   const [configSnap, periodSnap] = await Promise.all([configDocRef.get(), periodDocRef.get()]);
 
   if (!dryRun && periodSnap.exists && periodSnap.data()?.status === 'completed') {
     throw new ValidationError('PLUS_SETTLE_PERIOD_ALREADY_COMPLETED', 409);
+  }
+
+  const { startMs, endMs } = getPeriodBoundsMs(periodId);
+  // Refuse to settle a window whose last day hasn't fully elapsed — it could still receive
+  // usage that the completed + overlap guards would then lock out. A dry run may still
+  // preview an in-progress day.
+  if (!dryRun && endMs > Date.now()) {
+    throw new ValidationError('PLUS_SETTLE_PERIOD_NOT_ENDED', 400);
+  }
+  // Refuse a window overlapping an already-settled period: settling both a day and the month
+  // containing it would pay the overlap twice (different periodId → different idempotency
+  // keys). Each completed period stores its [startMs, endMs) for this interval test.
+  if (!dryRun) {
+    const completedSnap = await periodsCol.where('status', '==', 'completed').get();
+    const hasOverlap = completedSnap.docs.some((d) => {
+      if (d.id === periodId) return false;
+      const { startMs: s, endMs: e } = d.data();
+      return typeof s === 'number' && typeof e === 'number' && s < endMs && e > startMs;
+    });
+    if (hasOverlap) throw new ValidationError('PLUS_SETTLE_PERIOD_OVERLAP', 409);
   }
 
   const cfg = (configSnap.data() || {}) as {
@@ -161,30 +184,37 @@ export async function settlePlusReadingPeriod({
     ttsWeight: cfg.ttsWeight,
   };
 
-  // Pool: sum each accrual term's USD overlap with the settlement month. Full
-  // collection-group scan (monthly batch) — bound with an index on currentPeriodEnd
-  // if the accrual ledger grows large.
-  const { startMs, endMs } = getUsageMonthBoundsMs(periodId);
-  const accrualSnap = await db.collectionGroup('plusReadingAccrual').get();
+  // Pool: sum each accrual term's USD overlap with the settlement window. Push the
+  // currentPeriodEnd > startMs bound server-side; the other half (currentPeriodStart < endMs)
+  // is a second field, so it stays an in-memory filter.
+  const accrualSnap = await db.collectionGroup('plusReadingAccrual')
+    .where('currentPeriodEnd', '>', startMs)
+    .get();
   const accruals = accrualSnap.docs
     .map((doc) => doc.data() as PlusReadingAccrualData)
-    .filter((a) => a.currentPeriodStart < endMs && a.currentPeriodEnd > startMs);
-  const poolUSD = accruePoolUSD(accruals, periodId);
+    .filter((a) => a.currentPeriodStart < endMs);
+  const poolUSD = accruePoolUSD(accruals, startMs, endMs);
   const allocatableUSD = poolUSD * revShareRate;
 
-  // Freeze the period's per-book usage snapshot.
-  const usageSnap = await db.collectionGroup('plusUsage').get();
-  const bookUsages: BookUsage[] = usageSnap.docs
-    .filter((doc) => doc.id === periodId)
-    .map((doc) => {
-      const data = doc.data() || {};
-      return {
-        classId: doc.ref.parent.parent?.id || '',
-        readingTimeMs: data.readingTimeMs || 0,
-        ttsTimeMs: data.ttsTimeMs || 0,
-      };
-    })
-    .filter((b) => b.classId && (b.readingTimeMs > 0 || b.ttsTimeMs > 0));
+  // Freeze the window's per-book usage snapshot: sum every daily rollup whose `dayMs` falls in
+  // [startMs, endMs) per book (a month sums its days; a single day reads one doc). Both bounds
+  // are on `dayMs` so the range pushes server-side (needs a `dayMs` collection-group index).
+  const usageSnap = await db.collectionGroup('plusUsage')
+    .where('dayMs', '>=', startMs)
+    .where('dayMs', '<', endMs)
+    .get();
+  const usageByClass = new Map<string, BookUsage>();
+  for (const doc of usageSnap.docs) {
+    const data = doc.data() || {};
+    const classId = doc.ref.parent.parent?.id || '';
+    if (!classId) continue;
+    const acc = usageByClass.get(classId) || { classId, readingTimeMs: 0, ttsTimeMs: 0 };
+    acc.readingTimeMs += data.readingTimeMs || 0;
+    acc.ttsTimeMs += data.ttsTimeMs || 0;
+    usageByClass.set(classId, acc);
+  }
+  const bookUsages: BookUsage[] = [...usageByClass.values()]
+    .filter((b) => b.readingTimeMs > 0 || b.ttsTimeMs > 0);
 
   const totals = bookUsages.reduce(
     (acc, b) => ({
@@ -276,6 +306,8 @@ export async function settlePlusReadingPeriod({
   if (!dryRun) {
     await periodDocRef.set({
       ...summary,
+      startMs,
+      endMs,
       status: 'completed',
       settledAt: FieldValue.serverTimestamp(),
     }, { merge: true });
@@ -292,10 +324,14 @@ export async function settlePlusReadingPeriod({
  * own cadence, independent of the monthly period settle.
  */
 export async function sweepPlusReadingPendingPayouts({ dryRun }: { dryRun: boolean }) {
-  const snap = await db.collectionGroup('plusReadingPayouts').get();
+  // Only pending payouts need re-attempting — filter server-side rather than scanning every
+  // historical payout doc (needs a single-field `status` collection-group index).
+  const snap = await db.collectionGroup('plusReadingPayouts')
+    .where('status', '==', 'pending')
+    .get();
   const pending = snap.docs
     .map((doc) => doc.data())
-    .filter((p) => p.status === 'pending' && p.wallet && p.classId && p.periodId);
+    .filter((p) => p.wallet && p.classId && p.periodId);
 
   let paidCount = 0;
   let stillPendingCount = 0;

--- a/src/util/api/plus/settleJob.ts
+++ b/src/util/api/plus/settleJob.ts
@@ -283,3 +283,51 @@ export async function settlePlusReadingPeriod({
 
   return { dryRun, ...summary, books };
 }
+
+/**
+ * Re-attempts payouts left `pending` by earlier runs — typically payees who have since
+ * completed Stripe Connect onboarding (or whose earlier transfer failed). Reuses
+ * settleWalletPayout with the same idempotency key, so a payout that already went through
+ * is never double-paid. `dryRun` classifies without writing or transferring. Run on its
+ * own cadence, independent of the monthly period settle.
+ */
+export async function sweepPlusReadingPendingPayouts({ dryRun }: { dryRun: boolean }) {
+  const snap = await db.collectionGroup('plusReadingPayouts').get();
+  const pending = snap.docs
+    .map((doc) => doc.data())
+    .filter((p) => p.status === 'pending' && p.wallet && p.classId && p.periodId);
+
+  let paidCount = 0;
+  let stillPendingCount = 0;
+  let paidCents = 0;
+  for (const p of pending) {
+    const walletCents = Number(p.amountCents) || 0;
+    if (walletCents <= 0) continue;
+    const book = {
+      classId: String(p.classId),
+      readingTimeMs: Number(p.readingTimeMs) || 0,
+      ttsTimeMs: Number(p.ttsTimeMs) || 0,
+    };
+    const outcome = await settleWalletPayout({
+      periodId: String(p.periodId),
+      book,
+      wallet: String(p.wallet),
+      walletCents,
+      dryRun,
+    });
+    if (outcome === 'paid') {
+      paidCount += 1;
+      paidCents += walletCents;
+    } else if (outcome === 'pending') {
+      stillPendingCount += 1;
+    }
+  }
+
+  return {
+    dryRun,
+    sweptCount: pending.length,
+    paidCount,
+    stillPendingCount,
+    paidCents,
+  };
+}

--- a/test/api/plus-settle.test.ts
+++ b/test/api/plus-settle.test.ts
@@ -1,10 +1,23 @@
 import { describe, it, expect } from 'vitest';
 import axiosist from './axiosist';
+import mockEVMAddress from './address';
+import { configCollection, likeNFTBookCollection } from '../../src/util/firebase';
+import { ONE_MINUTE_IN_MS } from '../../src/constant';
 
 const PATH = '/api/plus/admin/reading/settle';
 const SWEEP_PATH = '/api/plus/admin/reading/sweep';
 const AUTH = 'test-plus-settle-admin-token'; // matches PLUS_SETTLE_ADMIN_TOKEN in test/setup.ts
 const AUTH_HEADER = { Authorization: `Bearer ${AUTH}` };
+
+const min = (n: number) => n * ONE_MINUTE_IN_MS;
+
+// Seed a book with a daily usage rollup (the shape recordPlusReadingUsage writes).
+async function seedUsage(classId: string, dayId: string, dayMs: number, readingTimeMs: number) {
+  await likeNFTBookCollection.doc(classId)
+    .set({ classId, ownerWallet: mockEVMAddress(0x66) } as any, { merge: true });
+  await likeNFTBookCollection.doc(classId).collection('plusUsage').doc(dayId)
+    .set({ readingTimeMs, ttsTimeMs: 0, dayMs } as any);
+}
 
 const postTo = (path: string) => (
   body: Record<string, unknown>,
@@ -47,6 +60,63 @@ describe('POST /plus/admin/reading/settle', () => {
       pendingCount: 0,
       books: [],
     });
+  });
+
+  it('accepts a single-day periodId', async () => {
+    const res = await post({ periodId: '2026-03-10', dryRun: true }, AUTH_HEADER);
+    expect(res.status).toBe(200);
+    expect(res.data).toMatchObject({ success: true, dryRun: true, periodId: '2026-03-10' });
+  });
+
+  it('rejects an impossible calendar day', async () => {
+    const res = await post({ periodId: '2026-02-30', dryRun: true }, AUTH_HEADER);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /plus/admin/reading/settle — range allocation', () => {
+  const CLASS_ID = mockEVMAddress(0x55);
+
+  it('sums a book\'s daily usage across the month', async () => {
+    await seedUsage(CLASS_ID, '2026-03-05', Date.UTC(2026, 2, 5), min(60));
+    await seedUsage(CLASS_ID, '2026-03-20', Date.UTC(2026, 2, 20), min(40));
+
+    const res = await post({ periodId: '2026-03', dryRun: true, mode: 'static' }, AUTH_HEADER);
+    expect(res.status).toBe(200);
+    expect(res.data.totalReadingTimeMs).toBe(min(100));
+    expect(res.data.books).toHaveLength(1);
+    // static $0.01/min × 100 min = $1.00 = 100 cents.
+    expect(res.data.books[0]).toMatchObject({
+      classId: CLASS_ID, amountCents: 100, readingTimeMs: min(100),
+    });
+  });
+
+  it('a single-day settle reads only that day', async () => {
+    await seedUsage(CLASS_ID, '2026-03-05', Date.UTC(2026, 2, 5), min(60));
+    await seedUsage(CLASS_ID, '2026-03-20', Date.UTC(2026, 2, 20), min(40));
+
+    const res = await post({ periodId: '2026-03-05', dryRun: true, mode: 'static' }, AUTH_HEADER);
+    expect(res.status).toBe(200);
+    expect(res.data.totalReadingTimeMs).toBe(min(60));
+    expect(res.data.books[0]).toMatchObject({ classId: CLASS_ID, amountCents: 60 });
+  });
+});
+
+describe('POST /plus/admin/reading/settle — settle guards', () => {
+  it('rejects a real settle whose window has not fully elapsed', async () => {
+    const res = await post({ periodId: '2099-01' }, AUTH_HEADER);
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a real settle overlapping an already-settled period', async () => {
+    // The completion doc lives under the revshare config doc; seed it so the `periods`
+    // subcollection persists between the two settles.
+    await configCollection.doc('plusReadingRevShare').set({} as any);
+    // Settle a day (no usage → just writes the completion doc), then the month containing it.
+    const day = await post({ periodId: '2020-03-10' }, AUTH_HEADER);
+    expect(day.status).toBe(200);
+    const month = await post({ periodId: '2020-03' }, AUTH_HEADER);
+    expect(month.status).toBe(409);
   });
 });
 

--- a/test/api/plus-settle.test.ts
+++ b/test/api/plus-settle.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import axiosist from './axiosist';
+
+const PATH = '/api/plus/admin/reading/settle';
+const AUTH = 'test-plus-settle-admin-token'; // matches PLUS_SETTLE_ADMIN_TOKEN in test/setup.ts
+const AUTH_HEADER = { Authorization: `Bearer ${AUTH}` };
+
+const post = (body: Record<string, unknown>, headers?: Record<string, string>) => axiosist
+  .post(PATH, body, headers ? { headers } : undefined)
+  .catch((err) => (err as any).response);
+
+describe('POST /plus/admin/reading/settle', () => {
+  it('rejects requests without the admin token', async () => {
+    const res = await post({ periodId: '2026-03', dryRun: true });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a malformed periodId', async () => {
+    const res = await post({ periodId: '2026-3', dryRun: true }, AUTH_HEADER);
+    expect(res.status).toBe(400);
+  });
+
+  it('dry-run with no accrual or usage settles to an empty zero allocation', async () => {
+    const res = await post({ periodId: '2026-03', dryRun: true }, AUTH_HEADER);
+    expect(res.status).toBe(200);
+    expect(res.data).toMatchObject({
+      success: true,
+      dryRun: true,
+      periodId: '2026-03',
+      mode: 'static',
+      revShareRate: 0.3,
+      poolUSD: 0,
+      allocatableUSD: 0,
+      allocatedUSD: 0,
+      revSharePct: 0,
+      // static default $0.01/min; no usage so nothing is actually allocated.
+      readRatePerMin: 0.01,
+      ttsRatePerMin: 0.01,
+      bookCount: 0,
+      paidCount: 0,
+      pendingCount: 0,
+      books: [],
+    });
+  });
+});

--- a/test/api/plus-settle.test.ts
+++ b/test/api/plus-settle.test.ts
@@ -2,12 +2,18 @@ import { describe, it, expect } from 'vitest';
 import axiosist from './axiosist';
 
 const PATH = '/api/plus/admin/reading/settle';
+const SWEEP_PATH = '/api/plus/admin/reading/sweep';
 const AUTH = 'test-plus-settle-admin-token'; // matches PLUS_SETTLE_ADMIN_TOKEN in test/setup.ts
 const AUTH_HEADER = { Authorization: `Bearer ${AUTH}` };
 
-const post = (body: Record<string, unknown>, headers?: Record<string, string>) => axiosist
-  .post(PATH, body, headers ? { headers } : undefined)
+const postTo = (path: string) => (
+  body: Record<string, unknown>,
+  headers?: Record<string, string>,
+) => axiosist
+  .post(path, body, headers ? { headers } : undefined)
   .catch((err) => (err as any).response);
+const post = postTo(PATH);
+const postSweep = postTo(SWEEP_PATH);
 
 describe('POST /plus/admin/reading/settle', () => {
   it('rejects requests without the admin token', async () => {
@@ -40,6 +46,26 @@ describe('POST /plus/admin/reading/settle', () => {
       paidCount: 0,
       pendingCount: 0,
       books: [],
+    });
+  });
+});
+
+describe('POST /plus/admin/reading/sweep', () => {
+  it('rejects requests without the admin token', async () => {
+    const res = await postSweep({ dryRun: true });
+    expect(res.status).toBe(401);
+  });
+
+  it('dry-run with no pending payouts sweeps nothing', async () => {
+    const res = await postSweep({ dryRun: true }, AUTH_HEADER);
+    expect(res.status).toBe(200);
+    expect(res.data).toMatchObject({
+      success: true,
+      dryRun: true,
+      sweptCount: 0,
+      paidCount: 0,
+      stillPendingCount: 0,
+      paidCents: 0,
     });
   });
 });

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -14,6 +14,7 @@ process.env.AIRTABLE_AUTOMATION_TOKEN = 'test-airtable-automation-token';
 process.env.PLUS_READING_SERVICE_TOKEN = 'test-plus-reading-service-token';
 process.env.ALCHEMY_GAS_POLICY_ID = 'test-alchemy-policy-id';
 process.env.ALCHEMY_SPONSORSHIP_WEBHOOK_SECRET = 'test-alchemy-webhook-secret';
+process.env.PLUS_SETTLE_ADMIN_TOKEN = 'test-plus-settle-admin-token';
 
 // Mock config files
 vi.mock('../../config/config', () => ({
@@ -21,6 +22,7 @@ vi.mock('../../config/config', () => ({
   PLUS_READING_SERVICE_TOKEN: 'test-plus-reading-service-token',
   ALCHEMY_GAS_POLICY_ID: 'test-alchemy-policy-id',
   ALCHEMY_SPONSORSHIP_WEBHOOK_SECRET: 'test-alchemy-webhook-secret',
+  PLUS_SETTLE_ADMIN_TOKEN: 'test-plus-settle-admin-token',
   FIREBASE_STORAGE_BUCKET: 'test-bucket',
   FIRESTORE_USER_ROOT: 'users',
   FIRESTORE_USER_AUTH_ROOT: 'user-auth',

--- a/test/stub/firebase.ts
+++ b/test/stub/firebase.ts
@@ -69,6 +69,11 @@ let subscriptionData: StubData[] = [];
 let txData: StubData[] = [];
 let missionData: StubData[] = [];
 let likerNftData: StubData[] = [];
+// Not JSON-backed: seeded per-test. Kept as stable references (mutated in place on reset, see
+// resetTestData) so `dbData` and their collections never lose the binding. `likeNftBookData` is
+// in `dbData` so collectionGroup() reaches book subcollections (e.g. plusUsage).
+const likeNftBookData: StubData[] = [];
+const configData: StubData[] = [];
 
 // Load test data
 try {
@@ -102,6 +107,9 @@ export function resetTestData() {
   } catch (e) {
     // Ignore errors
   }
+  // Clear per-test seeded (non-JSON) collections in place — keep the array references intact.
+  likeNftBookData.length = 0;
+  configData.length = 0;
 }
 
 function docData(obj: StubData): any {
@@ -219,39 +227,26 @@ function resolveField(d: StubData, field: string): unknown {
   return field.split('.').reduce<any>((acc, f) => (acc == null ? acc : acc[f]), d);
 }
 
-function collectionWhere(data: StubData[], field = '', op = '', value: any = ''): any {
-  let whereData = data;
-  if (op === '==') {
-    if (field.includes('.')) {
-      whereData = data.filter((d) => resolveField(d, field) === value);
-    } else {
-      whereData = data.filter((d) => d[field] === value);
-    }
-  } else if (op === 'array-contains') {
-    whereData = data.filter((d) => Array.isArray(d[field]) && d[field].includes(value));
-  } else if (op === '>=') {
-    whereData = data.filter((d) => {
-      const v = resolveField(d, field);
-      return v !== undefined && (v as any) >= value;
-    });
-  } else if (op === '<=') {
-    whereData = data.filter((d) => {
-      const v = resolveField(d, field);
-      return v !== undefined && (v as any) <= value;
-    });
-  } else if (op === '!=') {
-    // Real Firestore excludes docs missing the field;
-    // match that, else `undefined !== value` would let them leak through.
-    whereData = data.filter((d) => {
-      const v = resolveField(d, field);
-      return v !== undefined && v !== value;
-    });
-  } else if (op === 'in') {
-    whereData = data.filter((d) => {
-      const v = resolveField(d, field);
-      return v !== undefined && (value as any[]).includes(v);
-    });
+// Evaluate one where() clause against a doc. Range ops exclude docs missing the field,
+// matching Firestore (a missing field never satisfies an inequality / equality / membership).
+function matchesWhereClause(d: StubData, field: string, op: string, value: any): boolean {
+  const v = resolveField(d, field);
+  switch (op) {
+    case '==': return v === value;
+    case '!=': return v !== undefined && v !== value;
+    case '>': return v !== undefined && (v as any) > value;
+    case '>=': return v !== undefined && (v as any) >= value;
+    case '<': return v !== undefined && (v as any) < value;
+    case '<=': return v !== undefined && (v as any) <= value;
+    case 'in': return v !== undefined && (value as any[]).includes(v);
+    case 'array-contains': return Array.isArray(v) && (v as any[]).includes(value);
+    default: throw new Error(`stub firestore: unsupported where operator '${op}'`);
   }
+}
+
+function collectionWhere(data: StubData[], field = '', op = '', value: any = ''): any {
+  // Empty op (orderBy/startAt/limit call this with no clause) means no filtering.
+  const whereData = op ? data.filter((d) => matchesWhereClause(d, field, op, value)) : data;
   const docs = querySnapshotDocs(whereData, data);
   const queryObj = {
     where: (sField: string, sOp: string, sValue: any) => (
@@ -371,6 +366,7 @@ const dbData: StubData[][] = [
   txData,
   missionData,
   likerNftData,
+  likeNftBookData,
 ];
 
 export const userCollection = createCollection(userData) as
@@ -388,7 +384,7 @@ export const missionCollection = createCollection(missionData) as
   CollectionReference<MissionData>;
 export const payoutCollection = createCollection([]) as
   CollectionReference<PayoutData>;
-export const configCollection = createCollection([]) as
+export const configCollection = createCollection(configData) as
   CollectionReference<ConfigData>;
 export const oAuthClientCollection = createCollection([]) as
   CollectionReference<OAuthClientInfo>;
@@ -401,7 +397,7 @@ export const likeNFTFreeMintTxCollection = createCollection([]) as
   CollectionReference<FreeMintTxData>;
 export const likeNFTBookCartCollection = createCollection([]) as
   CollectionReference<BookPurchaseCartData>;
-export const likeNFTBookCollection = createCollection([]) as
+export const likeNFTBookCollection = createCollection(likeNftBookData) as
   CollectionReference<NFTBookListingInfo>;
 export const likeNFTBookCMSTagCollection = createCollection([]) as
   CollectionReference<NFTBookCMSTag>;
@@ -515,20 +511,41 @@ function createDb(): Firestore {
       return Promise.resolve();
     },
     collectionGroup: (group: string) => {
-      let data: StubData[] = [];
-      dbData.forEach((root) => {
-        root.forEach((d) => {
-          if (d.collection) {
-            if (d.collection[group]) data = data.concat(d.collection[group]);
-            Object.values(d.collection).forEach((c: any) => {
-              c.forEach((cd: StubData) => {
-                if (cd.collection && cd.collection[group]) data = data.concat(cd.collection[group]);
-              });
-            });
-          }
-        });
-      });
-      return collectionWhere(data);
+      // Flatten every `group` subcollection across roots, tagging each doc with its owning
+      // doc id so `doc.ref.parent.parent.id` resolves (settlement reads the book classId
+      // from a plusUsage doc this way). Real Firestore exposes the full ref chain; the stub
+      // only carries the one hop callers actually use.
+      const entries: Array<{ d: StubData; parentId: string }> = [];
+      const collect = (owner: StubData) => {
+        if (!owner.collection) return;
+        if (owner.collection[group]) {
+          owner.collection[group].forEach((d) => entries.push({ d, parentId: owner.id }));
+        }
+        Object.values(owner.collection).forEach((c) => c.forEach(collect));
+      };
+      dbData.forEach((root) => root.forEach(collect));
+      // Build a chainable query that keeps the parentId tagging through where() so a filtered
+      // collection-group snapshot still resolves doc.ref.parent.parent.id (real Firestore does).
+      const makeQuery = (rows: Array<{ d: StubData; parentId: string }>): any => {
+        const docs = rows.map(({ d, parentId }) => ({
+          id: d.id,
+          data: () => docData(d),
+          exists: true,
+          ref: { parent: { parent: { id: parentId } } },
+        }));
+        return {
+          get: () => Promise.resolve({
+            size: docs.length,
+            docs,
+            empty: docs.length === 0,
+            forEach: (f: (doc: any) => void) => docs.forEach(f),
+          }),
+          where: (field: string, op: string, value: any) => (
+            makeQuery(rows.filter(({ d }) => matchesWhereClause(d, field, op, value)))
+          ),
+        };
+      };
+      return makeQuery(entries);
     },
   } as unknown as Firestore;
 }

--- a/test/unit/plus-revenue-share.test.ts
+++ b/test/unit/plus-revenue-share.test.ts
@@ -5,8 +5,8 @@ import {
   calculatePlusDailyValue,
   getAccrualOverlapDays,
   getDayStartMs,
+  getPeriodBoundsMs,
   getUsageDayId,
-  getUsageMonthBoundsMs,
 } from '../../src/util/api/plus/revenueShare';
 
 const monthStart = Date.UTC(2026, 0, 1);
@@ -108,17 +108,38 @@ describe('getUsageDayId', () => {
   });
 });
 
-describe('getUsageMonthBoundsMs', () => {
-  it('returns UTC [start, end) bounds for a YYYY-MM period', () => {
-    expect(getUsageMonthBoundsMs('2026-03')).toEqual({
+describe('getPeriodBoundsMs', () => {
+  it('returns UTC [start, end) bounds for a YYYY-MM month', () => {
+    expect(getPeriodBoundsMs('2026-03')).toEqual({
       startMs: Date.UTC(2026, 2, 1),
       endMs: Date.UTC(2026, 3, 1),
     });
   });
 
-  it('rolls December into the next year for the end bound', () => {
-    expect(getUsageMonthBoundsMs('2026-12')).toEqual({
+  it('rolls December into the next year for the month end bound', () => {
+    expect(getPeriodBoundsMs('2026-12')).toEqual({
       startMs: Date.UTC(2026, 11, 1),
+      endMs: Date.UTC(2027, 0, 1),
+    });
+  });
+
+  it('returns UTC [start, end) bounds for a YYYY-MM-DD day', () => {
+    expect(getPeriodBoundsMs('2026-03-10')).toEqual({
+      startMs: Date.UTC(2026, 2, 10),
+      endMs: Date.UTC(2026, 2, 11),
+    });
+  });
+
+  it('rolls a month-end day into the next month for the end bound', () => {
+    expect(getPeriodBoundsMs('2026-01-31')).toEqual({
+      startMs: Date.UTC(2026, 0, 31),
+      endMs: Date.UTC(2026, 1, 1),
+    });
+  });
+
+  it('rolls Dec 31 into the next year for the end bound', () => {
+    expect(getPeriodBoundsMs('2026-12-31')).toEqual({
+      startMs: Date.UTC(2026, 11, 31),
       endMs: Date.UTC(2027, 0, 1),
     });
   });
@@ -156,7 +177,9 @@ describe('getAccrualOverlapDays', () => {
 });
 
 describe('accruePoolUSD', () => {
-  it('sums dailyValueUSD × overlap days across terms for the period', () => {
+  const mar = getPeriodBoundsMs('2026-03');
+
+  it('sums dailyValueUSD × overlap days across terms for the window', () => {
     const accruals = [
       // Fully in March (31 days) → 0.3 × 31 = 9.3
       {
@@ -171,10 +194,21 @@ describe('accruePoolUSD', () => {
         currentPeriodEnd: Date.UTC(2026, 3, 20),
       },
     ];
-    expect(accruePoolUSD(accruals, '2026-03')).toBeCloseTo(9.3 + 6, 6);
+    expect(accruePoolUSD(accruals, mar.startMs, mar.endMs)).toBeCloseTo(9.3 + 6, 6);
   });
 
-  it('excludes terms outside the settlement month', () => {
+  it('prorates a term to a single-day window', () => {
+    const day = getPeriodBoundsMs('2026-03-10');
+    // Term spans all of March (31 days) at 0.3/day → one day contributes exactly 0.3.
+    const accruals = [{
+      dailyValueUSD: 0.3,
+      currentPeriodStart: Date.UTC(2026, 2, 1),
+      currentPeriodEnd: Date.UTC(2026, 3, 1),
+    }];
+    expect(accruePoolUSD(accruals, day.startMs, day.endMs)).toBeCloseTo(0.3, 6);
+  });
+
+  it('excludes terms outside the settlement window', () => {
     const accruals = [
       // Entirely in April → contributes nothing to March.
       {
@@ -183,10 +217,10 @@ describe('accruePoolUSD', () => {
         currentPeriodEnd: Date.UTC(2026, 4, 1),
       },
     ];
-    expect(accruePoolUSD(accruals, '2026-03')).toBe(0);
+    expect(accruePoolUSD(accruals, mar.startMs, mar.endMs)).toBe(0);
   });
 
   it('returns 0 for no accruals', () => {
-    expect(accruePoolUSD([], '2026-03')).toBe(0);
+    expect(accruePoolUSD([], mar.startMs, mar.endMs)).toBe(0);
   });
 });

--- a/test/unit/plus-settle.test.ts
+++ b/test/unit/plus-settle.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import { ONE_MINUTE_IN_MS } from '../../src/constant';
+import {
+  DEFAULT_STATIC_RATE_PER_MIN_USD,
+  allocateBookUSD,
+  computePlusReadingRates,
+  splitAmountToWallets,
+} from '../../src/util/api/plus/settle';
+
+const min = (n: number) => n * ONE_MINUTE_IN_MS;
+const sumCents = (parts: Array<{ amountCents: number }>) => parts
+  .reduce((s, p) => s + p.amountCents, 0);
+
+describe('computePlusReadingRates', () => {
+  it('blended: one rate across all minutes', () => {
+    const rates = computePlusReadingRates(
+      100,
+      { readingTimeMs: min(60), ttsTimeMs: min(40) },
+      { mode: 'blended' },
+    );
+    // 100 USD / 100 min = 1 USD/min, applied equally to both channels.
+    expect(rates.readRatePerMin).toBeCloseTo(1, 10);
+    expect(rates.ttsRatePerMin).toBeCloseTo(1, 10);
+  });
+
+  it('split: each channel priced against its own minutes by readShare', () => {
+    const rates = computePlusReadingRates(
+      100,
+      { readingTimeMs: min(50), ttsTimeMs: min(100) },
+      { mode: 'split', readShare: 0.5 },
+    );
+    // readPool 50 / 50 min = 1; ttsPool 50 / 100 min = 0.5
+    expect(rates.readRatePerMin).toBeCloseTo(1, 10);
+    expect(rates.ttsRatePerMin).toBeCloseTo(0.5, 10);
+  });
+
+  it('weighted: a TTS minute counts ttsWeight of a reading minute', () => {
+    const rates = computePlusReadingRates(
+      100,
+      { readingTimeMs: min(50), ttsTimeMs: min(100) },
+      { mode: 'weighted', readWeight: 1, ttsWeight: 0.5 },
+    );
+    // weighted minutes = 50*1 + 100*0.5 = 100; baseRate 1 → read 1, tts 0.5
+    expect(rates.readRatePerMin).toBeCloseTo(1, 10);
+    expect(rates.ttsRatePerMin).toBeCloseTo(0.5, 10);
+  });
+
+  it('blended equals weighted(1, 1)', () => {
+    const totals = { readingTimeMs: min(37), ttsTimeMs: min(91) };
+    const blended = computePlusReadingRates(250, totals, { mode: 'blended' });
+    const weighted = computePlusReadingRates(
+      250,
+      totals,
+      { mode: 'weighted', readWeight: 1, ttsWeight: 1 },
+    );
+    expect(weighted).toEqual(blended);
+  });
+
+  it('returns zero rates when there is nothing to allocate', () => {
+    expect(computePlusReadingRates(0, { readingTimeMs: min(10), ttsTimeMs: min(10) }, { mode: 'blended' }))
+      .toEqual({ readRatePerMin: 0, ttsRatePerMin: 0 });
+  });
+
+  it('returns zero rates when there is no usage', () => {
+    expect(computePlusReadingRates(100, { readingTimeMs: 0, ttsTimeMs: 0 }, { mode: 'blended' }))
+      .toEqual({ readRatePerMin: 0, ttsRatePerMin: 0 });
+  });
+
+  it('static: fixed configured rates, independent of the pool', () => {
+    const rates = computePlusReadingRates(
+      100,
+      { readingTimeMs: min(60), ttsTimeMs: min(40) },
+      { mode: 'static', readRatePerMinUSD: 0.02, ttsRatePerMinUSD: 0.005 },
+    );
+    expect(rates.readRatePerMin).toBe(0.02);
+    expect(rates.ttsRatePerMin).toBe(0.005);
+  });
+
+  it('static: defaults each channel to DEFAULT_STATIC_RATE_PER_MIN_USD', () => {
+    const rates = computePlusReadingRates(
+      100,
+      { readingTimeMs: min(60), ttsTimeMs: min(40) },
+      { mode: 'static' },
+    );
+    expect(rates.readRatePerMin).toBe(DEFAULT_STATIC_RATE_PER_MIN_USD);
+    expect(rates.ttsRatePerMin).toBe(DEFAULT_STATIC_RATE_PER_MIN_USD);
+  });
+
+  it('static: still pays when there is no pool to allocate', () => {
+    const rates = computePlusReadingRates(
+      0,
+      { readingTimeMs: min(60), ttsTimeMs: min(40) },
+      { mode: 'static' },
+    );
+    expect(rates.readRatePerMin).toBe(DEFAULT_STATIC_RATE_PER_MIN_USD);
+    expect(rates.ttsRatePerMin).toBe(DEFAULT_STATIC_RATE_PER_MIN_USD);
+  });
+
+  it('static: falls back to the default when a configured rate is non-finite', () => {
+    const rates = computePlusReadingRates(
+      0,
+      { readingTimeMs: min(60), ttsTimeMs: min(40) },
+      { mode: 'static', readRatePerMinUSD: NaN, ttsRatePerMinUSD: -1 },
+    );
+    expect(rates.readRatePerMin).toBe(DEFAULT_STATIC_RATE_PER_MIN_USD);
+    expect(rates.ttsRatePerMin).toBe(DEFAULT_STATIC_RATE_PER_MIN_USD);
+  });
+
+  it('split: an out-of-range readShare falls back to the 0.5 default', () => {
+    const rates = computePlusReadingRates(
+      100,
+      { readingTimeMs: min(50), ttsTimeMs: min(100) },
+      { mode: 'split', readShare: 1.5 },
+    );
+    // 1.5 is rejected → readShare 0.5: readPool 50 / 50 min = 1; ttsPool 50 / 100 min = 0.5.
+    expect(rates.readRatePerMin).toBeCloseTo(1, 10);
+    expect(rates.ttsRatePerMin).toBeCloseTo(0.5, 10);
+  });
+
+  it('split: a channel with no minutes gets a 0 rate (its sub-pool strands)', () => {
+    const rates = computePlusReadingRates(
+      100,
+      { readingTimeMs: 0, ttsTimeMs: min(50) },
+      { mode: 'split', readShare: 0.5 },
+    );
+    expect(rates.readRatePerMin).toBe(0);
+    expect(rates.ttsRatePerMin).toBeCloseTo(1, 10); // ttsPool 50 / 50 min
+  });
+});
+
+describe('allocateBookUSD', () => {
+  it('prices a book by its reading and TTS minutes', () => {
+    const amount = allocateBookUSD(
+      { readRatePerMin: 1, ttsRatePerMin: 0.5 },
+      { readingTimeMs: min(10), ttsTimeMs: min(20) },
+    );
+    expect(amount).toBeCloseTo(1 * 10 + 0.5 * 20, 10); // 20
+  });
+
+  it('is 0 when rates are 0', () => {
+    const zeroRates = { readRatePerMin: 0, ttsRatePerMin: 0 };
+    expect(allocateBookUSD(zeroRates, { readingTimeMs: min(5), ttsTimeMs: min(5) })).toBe(0);
+  });
+});
+
+describe('splitAmountToWallets', () => {
+  it('splits evenly and conserves every cent', () => {
+    const parts = splitAmountToWallets(100, { a: 1, b: 1, c: 1 });
+    expect(sumCents(parts)).toBe(100);
+    expect(parts.map((p) => p.amountCents).sort()).toEqual([33, 33, 34]);
+  });
+
+  it('splits by weight, leftover cent to the higher fractional part', () => {
+    const parts = splitAmountToWallets(100, { a: 2, b: 1 });
+    const byWallet = Object.fromEntries(parts.map((p) => [p.wallet, p.amountCents]));
+    expect(byWallet).toEqual({ a: 67, b: 33 });
+    expect(sumCents(parts)).toBe(100);
+  });
+
+  it('conserves cents that do not divide evenly', () => {
+    expect(sumCents(splitAmountToWallets(101, { a: 1, b: 1, c: 1 }))).toBe(101);
+  });
+
+  it('sends everything to a single wallet', () => {
+    expect(splitAmountToWallets(100, { a: 1 })).toEqual([{ wallet: 'a', amountCents: 100 }]);
+  });
+
+  it('drops wallets that round down to zero', () => {
+    const parts = splitAmountToWallets(1, { a: 1, b: 1000000 });
+    expect(parts).toEqual([{ wallet: 'b', amountCents: 1 }]);
+  });
+
+  it('returns empty when there is nothing to split or no weight', () => {
+    expect(splitAmountToWallets(0, { a: 1 })).toEqual([]);
+    expect(splitAmountToWallets(100, {})).toEqual([]);
+  });
+});


### PR DESCRIPTION
Settles the Plus reading-library revenue share for a `YYYY-MM` period and pays participating publishers via Stripe Connect. Built in three layers (one per commit):

### Allocation math — `settle.ts` (pure, unit-tested)
`computePlusReadingRates` derives per-minute reading/TTS rates under four modes:
- **`static` (default)** — a fixed, configurable USD/min rate per channel (`$0.01/min` default, live-tunable via `readRatePerMinUSD` / `ttsRatePerMinUSD`), independent of the pool.
- `blended` — one rate across all minutes.
- `split` — pool divided into reading vs TTS sub-pools by `readShare`.
- `weighted` — a TTS minute counts a fraction of a reading minute (`blended === weighted(1, 1)`).

Plus `allocateBookUSD` (prices a book by its reading + TTS minutes) and `splitAmountToWallets` (largest-remainder split across weighted payees, conserving every cent).

### Settle job — `POST /plus/admin/reading/settle`
Admin-triggered (dedicated `PLUS_SETTLE_ADMIN_TOKEN`), settles one period:
- Accrues the funding pool from the immutable accrual ledger (overlap with the month) and records the rev-share cut (default 30%, live-tunable via the `plusReadingRevShare` config doc).
- Freezes the per-book usage snapshot, prices each book, splits across connected wallets, and pays via idempotency-keyed Stripe Connect transfers. Payees not yet Connect-ready are carried forward as `pending`; transfer failures retry next run.
- Under `static` mode the payout is no longer bounded by the pool, so the job **logs the actual payout as a % of Plus revenue** to watch it against the rev-share target.
- `dryRun` returns the full allocation without writing or transferring.
- Idempotent: a completed period is refused, and per-(period, book) payout records guard against double payment.

### Pending-payout sweep — `POST /plus/admin/reading/sweep`
Re-attempts payouts left `pending` by earlier settles (payees who have since finished Stripe Connect onboarding, or whose transfer failed). Reuses the same idempotency key, so an already-completed payout is never double-paid. Runs on its own cadence, independent of the monthly settle.

### Tests
Allocation math is unit-tested (including `static` mode and pool-independence); an integration test covers admin auth, validation, and the empty dry-run.
