### PR TITLE
🔒️ Filter PII from unauthenticated EVM migrate lookup

### DIFF
--- a/src/routes/wallet/index.ts
+++ b/src/routes/wallet/index.ts
@@ -26,7 +26,9 @@ import {
 import { validateBody, validateParams } from '../../middleware/validate';
 import publisher from '../../util/gcloudPub';
 import { PUBSUB_TOPIC_MISC } from '../../constant';
-import { checkAddressValid, checkCosmosAddressValid, sendValidatedJSON } from '../../util/ValidationHelper';
+import {
+  checkAddressValid, checkCosmosAddressValid, filterUserDataMin, sendValidatedJSON,
+} from '../../util/ValidationHelper';
 import { verifyEmailByMagicDIDToken } from '../../util/magic';
 import { createIntercomTokenForUser } from '../../util/intercom';
 
@@ -146,7 +148,9 @@ router.get('/evm/migrate/user/addr/:likeWallet', validateParams(WalletLikeWallet
       getUserWithCivicLikerPropertiesByWallet(likeWallet),
       checkBookUserEVMWallet(likeWallet),
     ]);
-    res.json({ likerIdInfo, evmWallet });
+    // This endpoint is unauthenticated; filter to the public-safe field set
+    // so email, phone and Stripe ids never leak. Mirrors /users/addr/:addr/min.
+    res.json({ likerIdInfo: likerIdInfo ? filterUserDataMin(likerIdInfo) : null, evmWallet });
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
The /wallet/evm/migrate/user/addr/:likeWallet endpoint returned the raw user doc (email, Stripe customerId/subscriptionId) without auth. Wrap likerIdInfo in filterUserDataMin so only public-safe fields leave, matching /users/addr/:addr/min.

Special thanks to @codevispera (Vincent C. from CodeVispera) for responsibly disclosing the high-severity unauthenticated PII issue addressed in this PR. Their professional report allowed us to identify and patch the vulnerability on the exact same day. Appreciate their efforts in helping us keep the platform secure.