### PR TITLE
🔧 Make Alchemy sponsorship webhook secret optional

### DIFF
--- a/src/middleware/alchemy-sponsorship-webhook.ts
+++ b/src/middleware/alchemy-sponsorship-webhook.ts
@@ -10,22 +10,26 @@ import { constantTimeEqual } from '../util/misc';
 export function alchemySponsorshipWebhookAuth(req: Request, res: Response, next: NextFunction) {
   const { secret } = req.params as Record<string, string>;
   if (secret) {
-    // The shared secret rides in the URL path; strip every occurrence from
-    // req.url/originalUrl (and thus req.path) so error logging never records it.
-    // req.params.secret is URL-decoded, so also redact the encoded form in case
-    // the secret contains reserved characters.
+    // Strip the path secret from req.url/originalUrl before any return so it never
+    // reaches logs — even under config drift (secret sent while env var is unset).
+    // params.secret is URL-decoded, so redact the encoded form too.
     const encodedSecret = encodeURIComponent(secret);
     const redact = (s: string) => s.split(secret).join('[REDACTED]')
       .split(encodedSecret).join('[REDACTED]');
     req.url = redact(req.url);
     req.originalUrl = redact(req.originalUrl);
   }
-  // Fail closed: Alchemy treats any non-200 as a failure and falls back to
-  // approveOnFailure (fail-open), so a missing/unconfigured secret must still
-  // answer 200 { approved: false } rather than 401/500.
-  if (!ALCHEMY_SPONSORSHIP_WEBHOOK_SECRET
-    || !secret
-    || !constantTimeEqual(secret, ALCHEMY_SPONSORSHIP_WEBHOOK_SECRET)) {
+  // When no shared secret is configured, leave the webhook open: it only reveals
+  // whether an EVM address is a registered likerId user, which is already public
+  // via the /addr/min endpoint. The secret is opt-in hardening, not confidentiality.
+  if (!ALCHEMY_SPONSORSHIP_WEBHOOK_SECRET) {
+    next();
+    return;
+  }
+  // A secret is configured: require a constant-time match. Fail closed — Alchemy
+  // treats any non-200 as a failure and falls back to approveOnFailure (fail-open),
+  // so a missing/wrong secret must still answer 200 { approved: false }, not 401/500.
+  if (!secret || !constantTimeEqual(secret, ALCHEMY_SPONSORSHIP_WEBHOOK_SECRET)) {
     res.status(200).json({ approved: false });
     return;
   }

--- a/src/routes/likernft/book/sponsorship.ts
+++ b/src/routes/likernft/book/sponsorship.ts
@@ -20,9 +20,10 @@ const buildLoggedReq = (req: Request) => ({
 // Alchemy Gas Manager custom-rules webhook. Alchemy POSTs a userOperation and
 // expects HTTP 200 { approved: boolean }. The decision must always be expressed
 // as a 200 body — a non-200 is treated by Alchemy as a failure and falls through
-// to approveOnFailure. The :secret path segment authenticates the caller.
+// to approveOnFailure. The :secret path segment authenticates the caller, and is
+// optional: when no secret is configured the bare /verify URL is accepted.
 router.post(
-  '/verify/:secret',
+  '/verify{/:secret}',
   alchemySponsorshipWebhookAuth,
   validateBody(VerifySchema),
   async (req, res) => {

--- a/test/api/likernft-book-sponsorship.test.ts
+++ b/test/api/likernft-book-sponsorship.test.ts
@@ -87,4 +87,17 @@ describe('POST /likernft/book/sponsorship/verify/:secret', () => {
     expect(res.status).toBe(200);
     expect(res.data).toEqual({ approved: false });
   });
+
+  it('accepts the bare /verify path, failing closed while a secret is configured', async () => {
+    // The :secret segment is optional; with a secret configured, the missing
+    // segment must still fail closed rather than 404.
+    await makeUser('user1registered', REGISTERED_ADDR);
+    const res = await post('/api/likernft/book/sponsorship/verify', {
+      userOperation: { sender: REGISTERED_ADDR },
+      policyId: POLICY_ID,
+      chainId: CHAIN_ID,
+    });
+    expect(res.status).toBe(200);
+    expect(res.data).toEqual({ approved: false });
+  });
 });

--- a/test/middleware/alchemy-sponsorship-webhook.test.ts
+++ b/test/middleware/alchemy-sponsorship-webhook.test.ts
@@ -1,0 +1,45 @@
+import {
+  describe, it, expect, vi,
+} from 'vitest';
+
+// Override config to an empty secret to exercise the open-when-unconfigured
+// branch. From test/middleware/ this path resolves to the repo's config/config,
+// unlike setup.ts whose shallower path resolves outside the repo (a no-op).
+vi.mock('../../config/config', () => ({ ALCHEMY_SPONSORSHIP_WEBHOOK_SECRET: '' }));
+
+// eslint-disable-next-line import/first
+import { alchemySponsorshipWebhookAuth } from '../../src/middleware/alchemy-sponsorship-webhook';
+
+function mockRes() {
+  const res: any = {};
+  res.status = vi.fn(() => res);
+  res.json = vi.fn(() => res);
+  return res;
+}
+
+describe('alchemySponsorshipWebhookAuth (no secret configured)', () => {
+  it('passes through when no shared secret is configured', () => {
+    const req: any = { params: {}, url: '/verify', originalUrl: '/verify' };
+    const res = mockRes();
+    const next = vi.fn();
+    alchemySponsorshipWebhookAuth(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('passes through but still redacts a stray secret segment (config drift)', () => {
+    // Under config drift the path value may be a live secret, so it must be
+    // redacted from the URL even though it is not enforced in open mode.
+    const req: any = {
+      params: { secret: 'whatever' },
+      url: '/verify/whatever',
+      originalUrl: '/verify/whatever',
+    };
+    const res = mockRes();
+    const next = vi.fn();
+    alchemySponsorshipWebhookAuth(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.json).not.toHaveBeenCalled();
+    expect(req.originalUrl).toBe('/verify/[REDACTED]');
+  });
+});


### PR DESCRIPTION
The webhook only reveals whether an EVM address is a registered likerId user, which is already public via /addr/min, so the shared secret is opt-in hardening rather than confidentiality. When ALCHEMY_SPONSORSHIP_WEBHOOK_SECRET is unset, the bare /verify URL is accepted; when set, the constant-time match is still enforced and fails closed.