### PR TITLE
♻️ Bucket Plus reading usage by day

### DIFF
--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -20,7 +20,7 @@ import {
   PlusReadingUsageResponseSchema,
 } from '../../util/api/plus/schemas';
 import { plusReadingServiceAuth } from '../../middleware/plus-reading-service-auth';
-import { getUsagePeriodId, recordPlusReadingUsage } from '../../util/api/plus/revenueShare';
+import { getUsageDayId, recordPlusReadingUsage } from '../../util/api/plus/revenueShare';
 import { getBookUserInfoFromWallet, getBookUserInfoFromLikerId } from '../../util/api/likernft/book/user';
 import { getStripeClient } from '../../util/stripe';
 import {
@@ -45,7 +45,7 @@ router.use('/revenuecat', revenueCatRouter);
 
 // Internal: the 3ook.com backend forwards already-paced Plus reading/TTS usage
 // deltas here (service-secret auth, no user JWT) to fund the reading-library
-// revenue share. Recorded into a per-(book, period) ledger with a per-reader grain.
+// revenue share. Recorded into a per-(book, day) ledger with a per-reader grain.
 router.post('/reading/usage', plusReadingServiceAuth, validateBody(PlusReadingUsageBodySchema), async (req, res, next) => {
   try {
     const {
@@ -60,19 +60,19 @@ router.post('/reading/usage', plusReadingServiceAuth, validateBody(PlusReadingUs
     if (readingTimeMs <= 0 && ttsTimeMs <= 0) {
       sendValidatedJSON(res, PlusReadingUsageResponseSchema, {
         success: true,
-        periodId: getUsagePeriodId(occurredAt || Date.now()),
+        dayId: getUsageDayId(occurredAt || Date.now()),
       });
       return;
     }
 
-    const { periodId } = await recordPlusReadingUsage({
+    const { dayId } = await recordPlusReadingUsage({
       readerWallet,
       classId,
       readingTimeMs,
       ttsTimeMs,
       occurredAt,
     });
-    sendValidatedJSON(res, PlusReadingUsageResponseSchema, { success: true, periodId });
+    sendValidatedJSON(res, PlusReadingUsageResponseSchema, { success: true, dayId });
   } catch (err) {
     next(err);
   }

--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -60,7 +60,7 @@ router.post('/reading/usage', plusReadingServiceAuth, validateBody(PlusReadingUs
     if (readingTimeMs <= 0 && ttsTimeMs <= 0) {
       sendValidatedJSON(res, PlusReadingUsageResponseSchema, {
         success: true,
-        dayId: getUsageDayId(occurredAt || Date.now()),
+        dayId: getUsageDayId(occurredAt ?? Date.now()),
       });
       return;
     }

--- a/src/util/api/plus/revenueShare.ts
+++ b/src/util/api/plus/revenueShare.ts
@@ -91,7 +91,7 @@ export async function recordPlusReadingUsage({
   ttsTimeMs: number;
   occurredAt?: number;
 }): Promise<{ dayId: string }> {
-  const ts = occurredAt || Date.now();
+  const ts = occurredAt ?? Date.now();
   const dayId = getUsageDayId(ts);
   const dayMs = getDayStartMs(ts);
   const normalizedClassId = classId.toLowerCase();

--- a/src/util/api/plus/revenueShare.ts
+++ b/src/util/api/plus/revenueShare.ts
@@ -46,19 +46,30 @@ export function calculatePlusDailyValue({
 }
 
 /**
- * Settlement-period bucket for a usage timestamp: a UTC calendar month, `YYYY-MM`.
- * UTC (not the project's HK timezone) keeps bucketing deterministic and matches the
- * web backend's UTC date handling for reading streaks.
+ * Usage bucket for a timestamp: a UTC calendar day, `YYYY-MM-DD`. Daily granularity lets
+ * settlement run over any range — a single day, or a whole month summed from its days. UTC
+ * (not the project's HK timezone) keeps bucketing deterministic and matches the web backend's
+ * UTC date handling for reading streaks.
  */
-export function getUsagePeriodId(timestampMs: number): string {
+export function getUsageDayId(timestampMs: number): string {
   const date = new Date(timestampMs);
   const year = date.getUTCFullYear();
   const month = `${date.getUTCMonth() + 1}`.padStart(2, '0');
-  return `${year}-${month}`;
+  const day = `${date.getUTCDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 /**
- * Records already-paced (anti-fraud) Plus reading/TTS usage into the period-bucketed
+ * UTC start-of-day ms for a timestamp — stored on each daily usage rollup as `dayMs` so a
+ * settlement range can filter rollups by time without parsing their `YYYY-MM-DD` doc id.
+ */
+export function getDayStartMs(timestampMs: number): number {
+  const date = new Date(timestampMs);
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+/**
+ * Records already-paced (anti-fraud) Plus reading/TTS usage into the day-bucketed
  * ledger funding the reading-library revenue share — a trusted write. Dual-writes the
  * book rollup and a per-reader grain in one batch, both hanging off the book doc so
  * settlement reads ownerWallet/connectedWallets live from the parent (no snapshot drift).
@@ -79,8 +90,10 @@ export async function recordPlusReadingUsage({
   readingTimeMs: number;
   ttsTimeMs: number;
   occurredAt?: number;
-}): Promise<{ periodId: string }> {
-  const periodId = getUsagePeriodId(occurredAt || Date.now());
+}): Promise<{ dayId: string }> {
+  const ts = occurredAt || Date.now();
+  const dayId = getUsageDayId(ts);
+  const dayMs = getDayStartMs(ts);
   const normalizedClassId = classId.toLowerCase();
   const normalizedReaderWallet = readerWallet.toLowerCase();
 
@@ -88,8 +101,8 @@ export async function recordPlusReadingUsage({
   const bookDoc = await bookDocRef.get();
   if (!bookDoc.exists) throw new ValidationError('CLASS_ID_NOT_FOUND', 404);
 
-  const periodDocRef = bookDocRef.collection('plusUsage').doc(periodId);
-  const readerDocRef = periodDocRef.collection('readers').doc(normalizedReaderWallet);
+  const dayDocRef = bookDocRef.collection('plusUsage').doc(dayId);
+  const readerDocRef = dayDocRef.collection('readers').doc(normalizedReaderWallet);
 
   const usageIncrement = {
     readingTimeMs: FieldValue.increment(readingTimeMs),
@@ -98,11 +111,12 @@ export async function recordPlusReadingUsage({
   };
 
   const batch = db.batch();
-  batch.set(periodDocRef, usageIncrement, { merge: true });
+  // `dayMs` (UTC start-of-day) lets settlement filter rollups by range without parsing ids.
+  batch.set(dayDocRef, { ...usageIncrement, dayMs }, { merge: true });
   batch.set(readerDocRef, usageIncrement, { merge: true });
   await batch.commit();
 
-  return { periodId };
+  return { dayId };
 }
 
 /**

--- a/src/util/api/plus/schemas.ts
+++ b/src/util/api/plus/schemas.ts
@@ -153,5 +153,5 @@ export const PlusReadingUsageBodySchema = z.object({
 
 export const PlusReadingUsageResponseSchema = z.object({
   success: z.literal(true),
-  periodId: z.string(),
+  dayId: z.string(),
 });

--- a/test/api/plus-reading-usage.test.ts
+++ b/test/api/plus-reading-usage.test.ts
@@ -41,20 +41,22 @@ describe('POST /plus/reading/usage', () => {
       classId: mixedCaseClassId,
       readingTimeMs: 1500,
       ttsTimeMs: 4200,
-      occurredAt: Date.UTC(2026, 2, 10, 8), // 2026-03
+      occurredAt: Date.UTC(2026, 2, 10, 8), // 2026-03-10
     }, AUTH_HEADER);
     expect(res.status).toBe(200);
-    expect(res.data).toEqual({ success: true, periodId: '2026-03' });
+    expect(res.data).toEqual({ success: true, dayId: '2026-03-10' });
 
     const doc = await likeNFTBookCollection
       .doc(lowerClassId)
       .collection('plusUsage')
-      .doc('2026-03')
+      .doc('2026-03-10')
       .get();
     // increment() is identity in the stub, so a single write stores the posted value.
     const data = doc.data() as any;
     expect(data.readingTimeMs).toBe(1500);
     expect(data.ttsTimeMs).toBe(4200);
+    // Start-of-day ms stamped so settlement can filter rollups by range.
+    expect(data.dayMs).toBe(Date.UTC(2026, 2, 10));
   });
 
   it('rejects usage for a class id with no book doc', async () => {
@@ -75,9 +77,9 @@ describe('POST /plus/reading/usage', () => {
       classId: CLASS_ID,
       readingTimeMs: 0,
       ttsTimeMs: 0,
-      occurredAt: Date.UTC(2026, 4, 1), // 2026-05
+      occurredAt: Date.UTC(2026, 4, 1), // 2026-05-01
     }, AUTH_HEADER);
     expect(res.status).toBe(200);
-    expect(res.data).toEqual({ success: true, periodId: '2026-05' });
+    expect(res.data).toEqual({ success: true, dayId: '2026-05-01' });
   });
 });

--- a/test/unit/plus-revenue-share.test.ts
+++ b/test/unit/plus-revenue-share.test.ts
@@ -4,8 +4,9 @@ import {
   accruePoolUSD,
   calculatePlusDailyValue,
   getAccrualOverlapDays,
+  getDayStartMs,
+  getUsageDayId,
   getUsageMonthBoundsMs,
-  getUsagePeriodId,
 } from '../../src/util/api/plus/revenueShare';
 
 const monthStart = Date.UTC(2026, 0, 1);
@@ -73,35 +74,37 @@ describe('calculatePlusDailyValue', () => {
   });
 });
 
-describe('getUsagePeriodId', () => {
-  it('buckets a timestamp into its UTC YYYY-MM month', () => {
-    expect(getUsagePeriodId(Date.UTC(2026, 2, 15, 12))).toBe('2026-03');
+describe('getUsageDayId', () => {
+  it('buckets a timestamp into its UTC YYYY-MM-DD day', () => {
+    expect(getUsageDayId(Date.UTC(2026, 2, 15, 12))).toBe('2026-03-15');
   });
 
-  it('zero-pads single-digit months', () => {
-    expect(getUsagePeriodId(Date.UTC(2026, 0, 1))).toBe('2026-01');
+  it('zero-pads single-digit months and days', () => {
+    expect(getUsageDayId(Date.UTC(2026, 0, 5))).toBe('2026-01-05');
   });
 
-  it('keeps the first millisecond of a month in that month', () => {
-    expect(getUsagePeriodId(Date.UTC(2026, 1, 1, 0, 0, 0, 0))).toBe('2026-02');
+  it('keeps the first millisecond of a day in that day', () => {
+    expect(getUsageDayId(Date.UTC(2026, 1, 1, 0, 0, 0, 0))).toBe('2026-02-01');
   });
 
-  it('keeps the last millisecond of a month in that month', () => {
-    expect(getUsagePeriodId(Date.UTC(2026, 1, 1) - 1)).toBe('2026-01');
+  it('keeps the last millisecond of a day in that day', () => {
+    expect(getUsageDayId(Date.UTC(2026, 1, 2) - 1)).toBe('2026-02-01');
   });
 
   it('buckets by UTC, not local time, across a day boundary', () => {
-    // 2026-01-31T23:30 UTC is still January in UTC even though it is February
-    // in any positive-offset local zone (e.g. the project's HK timezone).
-    expect(getUsagePeriodId(Date.UTC(2026, 0, 31, 23, 30))).toBe('2026-01');
+    // 2026-01-31T23:30 UTC is still Jan 31 in UTC even though it is Feb 1 in any
+    // positive-offset local zone (e.g. the project's HK timezone).
+    expect(getUsageDayId(Date.UTC(2026, 0, 31, 23, 30))).toBe('2026-01-31');
   });
 
-  it('round-trips into getUsageMonthBoundsMs bounds', () => {
-    const periodId = getUsagePeriodId(Date.UTC(2026, 11, 25));
-    const { startMs, endMs } = getUsageMonthBoundsMs(periodId);
-    expect(periodId).toBe('2026-12');
-    expect(getUsagePeriodId(startMs)).toBe(periodId);
-    expect(getUsagePeriodId(endMs - 1)).toBe(periodId);
+  it('round-trips through getDayStartMs (start-of-day stays the same day)', () => {
+    const ts = Date.UTC(2026, 11, 25, 9, 30);
+    const dayId = getUsageDayId(ts);
+    const dayMs = getDayStartMs(ts);
+    expect(dayId).toBe('2026-12-25');
+    expect(dayMs).toBe(Date.UTC(2026, 11, 25));
+    expect(getUsageDayId(dayMs)).toBe(dayId);
+    expect(getUsageDayId(dayMs + ONE_DAY_IN_MS - 1)).toBe(dayId);
   });
 });
 


### PR DESCRIPTION
Record reading/TTS usage into per-day plusUsage docs (YYYY-MM-DD) instead of monthly buckets, stamping each rollup with a UTC start-of-day `dayMs` so settlement can later read any range. The usage ack field is renamed periodId → dayId.

Settlement still reads monthly; the range-aware settle job follows in a later commit.