### PR TITLE
[TAS-6072] ✨ Add publisher wallet allow-list to affiliate config

### DIFF
--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -502,6 +502,10 @@ router.get('/affiliate/:likerId', validateParams(PlusAffiliateParamsSchema), asy
     sendValidatedJSON(res, PlusAffiliateResponseSchema, {
       active: true,
       affiliateClassIds: affiliateConfig.affiliateClassIds || [],
+      affiliatePublisherWallets: (Array.isArray(affiliateConfig.affiliatePublisherWallets)
+        ? affiliateConfig.affiliatePublisherWallets : [])
+        .filter((w): w is string => typeof w === 'string')
+        .map((w) => w.toLowerCase()),
       giftBooks: (affiliateConfig.giftBooks || []).map((b) => ({
         classId: b.classId,
         priceIndex: b.priceIndex || 0,

--- a/src/util/api/plus/schemas.ts
+++ b/src/util/api/plus/schemas.ts
@@ -92,6 +92,7 @@ const AffiliateCustomVoiceSchema = z.object({
 export const AffiliateConfigSchema = z.object({
   active: z.boolean(),
   affiliateClassIds: z.array(z.string()),
+  affiliatePublisherWallets: z.array(z.string()).optional(),
   giftBooks: z.array(AffiliateGiftBookSchema).optional(),
   giftOnTrial: z.boolean(),
   customVoices: z.array(AffiliateCustomVoiceSchema),
@@ -104,6 +105,7 @@ export const PlusAffiliateResponseSchema = z.discriminatedUnion('active', [
   }),
   AffiliateConfigSchema.omit({ active: true }).extend({
     active: z.literal(true),
+    affiliatePublisherWallets: z.array(z.string()),
     giftBooks: z.array(AffiliateGiftBookSchema),
     isPlusDiscountAllowed: z.boolean(),
   }),


### PR DESCRIPTION
Return affiliatePublisherWallets from /plus/affiliate/:likerId so a publisher can grant their TTS voices to every book they list, not only books in affiliateClassIds. The field is optional in the stored config for backward compatibility and normalized to lowercase on the wire.