### PR TITLE
[TAS-5898] ✨ Validate response schemas across remaining endpoints

### DIFF
--- a/src/routes/arweave/index.ts
+++ b/src/routes/arweave/index.ts
@@ -27,6 +27,9 @@ import {
   ArweaveSignPaymentBodySchema,
   ArweaveSignPaymentResponseSchema,
   ArweaveTxHashParamsSchema,
+  ArweavePublicKeyResponseSchema,
+  ArweaveLinkResponseSchema,
+  ArweaveAccessTokenResponseSchema,
 } from '../../util/api/arweave/schemas';
 import { jwtAuth, jwtOptionalAuth } from '../../middleware/jwt';
 import { validateBody, validateParams } from '../../middleware/validate';
@@ -40,7 +43,7 @@ router.get(
   async (req, res, next) => {
     try {
       const publicKey = await getPublicKey();
-      res.json({ publicKey: publicKey.toString('base64') });
+      sendValidatedJSON(res, ArweavePublicKeyResponseSchema, { publicKey: publicKey.toString('base64') });
     } catch (error) {
       next(error);
     }
@@ -277,7 +280,7 @@ router.get(
         link.searchParams.set('key', key);
       }
       if (req.accepts('application/json')) {
-        res.json({
+        sendValidatedJSON(res, ArweaveLinkResponseSchema, {
           arweaveId,
           txHash,
           key,
@@ -306,7 +309,7 @@ router.post(
       if (req.user.wallet !== ownerWallet) throw new ValidationError('NOT_OWNER', 403);
       if (status !== 'complete') throw new ValidationError('TX_NOT_COMPLETE', 409);
       const accessToken = await rotateArweaveTxAccessToken(txHash);
-      res.json({ accessToken });
+      sendValidatedJSON(res, ArweaveAccessTokenResponseSchema, { accessToken });
     } catch (error) {
       next(error);
     }

--- a/src/routes/likernft/book/purchase.ts
+++ b/src/routes/likernft/book/purchase.ts
@@ -61,6 +61,7 @@ import {
   BookFreeClaimResponseSchema,
   BookOrdersResponseSchema,
   BookPurchaseMessagesResponseSchema,
+  BookClaimResponseSchema,
 } from '../../../util/api/likernft/book/schemas';
 
 const router = Router();
@@ -671,7 +672,7 @@ router.post(
         req,
       );
 
-      res.json({ nftId });
+      sendValidatedJSON(res, BookClaimResponseSchema, { nftId });
     } catch (err) {
       next(err);
     }

--- a/src/routes/likernft/book/store.ts
+++ b/src/routes/likernft/book/store.ts
@@ -35,6 +35,7 @@ import {
   BookSearchQuerySchema,
   BookListQuerySchema,
   BookCatalogMetaQuerySchema,
+  BookCatalogMetaResponseSchema,
   BookListResponseSchema,
   BookListModeratedResponseSchema,
   BookSearchResponseSchema,
@@ -136,7 +137,7 @@ router.get('/catalog/meta', validateQuery(BookCatalogMetaQuerySchema), async (re
       res.send(formatMetaProductCatalogCSV(items));
       return;
     }
-    res.json({ items });
+    sendValidatedJSON(res, BookCatalogMetaResponseSchema, { items });
   } catch (err) {
     next(err);
   }

--- a/src/routes/likernft/book/user.ts
+++ b/src/routes/likernft/book/user.ts
@@ -27,6 +27,8 @@ import {
   BookUserPayoutsListResponseSchema,
   BookUserPayoutResponseSchema,
   BookUserCommissionsResponseSchema,
+  BookUserConnectRefreshResponseSchema,
+  BookPurchaseCommissionFilteredSchema,
   type BookUserConnectStatusResponse,
   type StripeConnectSite,
 } from '../../../util/api/likernft/book/schemas';
@@ -135,7 +137,7 @@ router.post(
         stripeConnectAccountId,
       });
 
-      res.json({ url: loginLink.url });
+      sendValidatedJSON(res, StripeConnectNewResponseSchema, { url: loginLink.url });
     } catch (err) {
       next(err);
     }
@@ -254,7 +256,9 @@ router.post(
         email,
       });
 
-      res.json({ isReady: isStripeConnectReady });
+      sendValidatedJSON(res, BookUserConnectRefreshResponseSchema, {
+        isReady: isStripeConnectReady,
+      });
     } catch (err) {
       next(err);
     }
@@ -421,9 +425,13 @@ router.get(
         throw new ValidationError('COMMISSION_NOT_FOUND', 404);
       }
       const commissionData = commissionDoc.data() as BookPurchaseCommission;
-      res.json(filterBookPurchaseCommission(commissionData, {
-        includeBuyerEmail: commissionData.ownerWallet === wallet,
-      }));
+      sendValidatedJSON(
+        res,
+        BookPurchaseCommissionFilteredSchema,
+        filterBookPurchaseCommission(commissionData, {
+          includeBuyerEmail: commissionData.ownerWallet === wallet,
+        }),
+      );
     } catch (err) {
       next(err);
     }

--- a/src/routes/likernft/history.ts
+++ b/src/routes/likernft/history.ts
@@ -7,7 +7,9 @@ import { validateQuery } from '../../middleware/validate';
 import {
   LikernftClassQuerySchema,
   LikernftHistoryQuerySchema,
+  LikernftHistoryListResponseSchema,
 } from '../../util/api/likernft/schemas';
+import { sendValidatedJSON } from '../../util/ValidationHelper';
 import { COSMOS_LCD_INDEXER_ENDPOINT } from '../../../config/config';
 import { ONE_DAY_IN_S } from '../../constant';
 
@@ -35,7 +37,7 @@ router.get(
       const query = await queryObj.orderBy('timestamp', 'desc').get();
       list = query.docs.map((d) => ({ txHash: d.id, ...(d.data() || {}) }));
       res.set('Cache-Control', `public, max-age=${6}, s-maxage=${6}, stale-while-revalidate=${ONE_DAY_IN_S}, stale-if-error=${ONE_DAY_IN_S}`);
-      res.json({
+      sendValidatedJSON(res, LikernftHistoryListResponseSchema, {
         list,
       });
     } catch (err) {
@@ -84,7 +86,7 @@ router.get(
           timestamp,
         };
       }).sort((a, b) => b.timestamp - a.timestamp);
-      res.json({
+      sendValidatedJSON(res, LikernftHistoryListResponseSchema, {
         list,
       });
     } catch (err) {

--- a/src/routes/likernft/list.ts
+++ b/src/routes/likernft/list.ts
@@ -1,6 +1,8 @@
 import { Router } from 'express';
 import { ONE_DAY_IN_S } from '../../constant';
 import { likeNFTCollection } from '../../util/firebase';
+import { sendValidatedJSON } from '../../util/ValidationHelper';
+import { LikernftFreeListResponseSchema } from '../../util/api/likernft/schemas';
 
 const router = Router();
 
@@ -18,7 +20,7 @@ router.get(
         .filter((d) => !d.collectExpiryAt || d.collectExpiryAt > Date.now())
         .map((d) => d.classId);
       res.set('Cache-Control', `public, max-age=${60}, s-maxage=${60}, stale-while-revalidate=${ONE_DAY_IN_S}, stale-if-error=${ONE_DAY_IN_S}`);
-      res.json({
+      sendValidatedJSON(res, LikernftFreeListResponseSchema, {
         list,
       });
     } catch (err) {

--- a/src/routes/likernft/metadata.ts
+++ b/src/routes/likernft/metadata.ts
@@ -4,7 +4,7 @@ import {
   ONE_DAY_IN_S, API_EXTERNAL_HOSTNAME, WRITING_NFT_COLLECTION_ID, API_HOSTNAME,
 } from '../../constant';
 import { iscnInfoCollection } from '../../util/firebase';
-import { filterLikeNFTMetadata } from '../../util/ValidationHelper';
+import { filterLikeNFTMetadata, sendValidatedJSON } from '../../util/ValidationHelper';
 import { getISCNPrefixByClassId } from '../../util/api/likernft';
 import {
   getClassMetadata,
@@ -20,6 +20,7 @@ import {
   LikernftClassQuerySchema,
   LikernftClassIdParamsSchema,
   LikernftImageQuerySchema,
+  LikeNFTMetadataResponseSchema,
 } from '../../util/api/likernft/schemas';
 import { ValidationError } from '../../util/ValidationError';
 import { sleep } from '../../util/misc';
@@ -42,7 +43,7 @@ router.get(
         metadata,
       } = await getClassMetadata({ classId, iscnPrefix });
       res.set('Cache-Control', `public, max-age=${60}, s-maxage=${60}, stale-while-revalidate=${ONE_DAY_IN_S}, stale-if-error=${ONE_DAY_IN_S}`);
-      res.json(filterLikeNFTMetadata({
+      sendValidatedJSON(res, LikeNFTMetadataResponseSchema, filterLikeNFTMetadata({
         iscnId: iscnPrefix,
         iscnOwner,
         iscnStakeholders: iscnData.stakeholders,

--- a/src/routes/likernft/mint.ts
+++ b/src/routes/likernft/mint.ts
@@ -1,10 +1,10 @@
 import { Router } from 'express';
 
-import { filterLikeNFTISCNData } from '../../util/ValidationHelper';
+import { filterLikeNFTISCNData, sendValidatedJSON } from '../../util/ValidationHelper';
 import { getISCNDocByClassId } from '../../util/api/likernft';
 import { fetchISCNPrefixAndClassId } from '../../middleware/likernft';
 import { validateQuery } from '../../middleware/validate';
-import { LikernftClassQuerySchema } from '../../util/api/likernft/schemas';
+import { LikernftClassQuerySchema, LikeNFTISCNDataResponseSchema } from '../../util/api/likernft/schemas';
 
 const router = Router();
 
@@ -23,7 +23,11 @@ router.get(
       }
       const iscnPrefix = decodeURIComponent(doc.id);
       const data = doc.data();
-      res.json(filterLikeNFTISCNData({ ...data, iscnId: iscnPrefix }));
+      sendValidatedJSON(
+        res,
+        LikeNFTISCNDataResponseSchema,
+        filterLikeNFTISCNData({ ...data, iscnId: iscnPrefix }),
+      );
     } catch (err) {
       next(err);
     }

--- a/src/routes/likernft/user.ts
+++ b/src/routes/likernft/user.ts
@@ -4,7 +4,8 @@ import { getUserStat } from '../../util/api/likernft/user';
 import { ValidationError } from '../../util/ValidationError';
 import { ONE_DAY_IN_S } from '../../constant';
 import { validateParams } from '../../middleware/validate';
-import { LikernftUserStatsParamsSchema } from '../../util/api/likernft/schemas';
+import { LikernftUserStatsParamsSchema, LikernftUserStatResponseSchema } from '../../util/api/likernft/schemas';
+import { sendValidatedJSON } from '../../util/ValidationHelper';
 
 const router = Router();
 
@@ -18,7 +19,7 @@ router.get(
 
       const userStat = await getUserStat(wallet);
       res.set('Cache-Control', `public, max-age=60, s-maxage=60, stale-while-revalidate=${ONE_DAY_IN_S}, stale-if-error=${ONE_DAY_IN_S}`);
-      res.json(userStat);
+      sendValidatedJSON(res, LikernftUserStatResponseSchema, userStat);
     } catch (err) {
       next(err);
     }

--- a/src/routes/oembed/index.ts
+++ b/src/routes/oembed/index.ts
@@ -10,7 +10,8 @@ import {
   userCollection as dbRef,
 } from '../../util/firebase';
 import { validateQuery } from '../../middleware/validate';
-import { OembedQuerySchema } from '../../util/api/oembed/schemas';
+import { OembedQuerySchema, OembedResponseSchema } from '../../util/api/oembed/schemas';
+import { sendValidatedJSON } from '../../util/ValidationHelper';
 
 const allowedSubdomains = ['www.', 'rinkeby.', 'button.', 'button.rinkeby.', 'widget.'];
 const domainRegexp = /^((?:[a-z0-9]+\.)+)?like\.co$/;
@@ -228,7 +229,7 @@ router.get('/', validateQuery(OembedQuerySchema), async (req, res, next) => {
           };
           switch (format) {
             case 'json':
-              res.json(oEmbedResponse);
+              sendValidatedJSON(res, OembedResponseSchema, oEmbedResponse);
               break;
             case 'xml': {
               res.set('Content-Type', 'text/xml');

--- a/src/routes/plus/revenuecat.ts
+++ b/src/routes/plus/revenuecat.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, type RequestHandler } from 'express';
 
 import { jwtAuth } from '../../middleware/jwt';
 import {
@@ -8,7 +8,8 @@ import {
 import { processRevenueCatEvent } from '../../util/api/plus/revenuecat';
 import type { RevenueCatEvent } from '../../util/api/plus/revenuecat';
 import { constantTimeEqual } from '../../util/misc';
-import { RevenueCatConfigResponseSchema } from '../../util/api/plus/schemas';
+import { validateBody } from '../../middleware/validate';
+import { RevenueCatConfigResponseSchema, RevenueCatWebhookBodySchema } from '../../util/api/plus/schemas';
 import { sendValidatedJSON } from '../../util/ValidationHelper';
 
 const router = Router();
@@ -20,12 +21,18 @@ function isAuthorized(header?: string): boolean {
   return constantTimeEqual(header, REVENUECAT_WEBHOOK_AUTHORIZATION);
 }
 
-router.post('/webhook', async (req, res, next) => {
+// Shared-secret check is the trust boundary, so it runs before Zod body validation:
+// unauthorized callers get 401 without us attempting to validate or process the event.
+const revenueCatWebhookAuth: RequestHandler = (req, res, next) => {
+  if (!isAuthorized(req.headers.authorization)) {
+    res.sendStatus(401);
+    return;
+  }
+  next();
+};
+
+router.post('/webhook', revenueCatWebhookAuth, validateBody(RevenueCatWebhookBodySchema), async (req, res, next) => {
   try {
-    if (!isAuthorized(req.headers.authorization)) {
-      res.sendStatus(401);
-      return;
-    }
     const { event } = (req.body || {}) as { event?: RevenueCatEvent };
     if (event) {
       await processRevenueCatEvent(event, req);

--- a/src/routes/tx/history.ts
+++ b/src/routes/tx/history.ts
@@ -14,11 +14,13 @@ import {
   TxHistoryUserParamsSchema,
   TxHistoryAddrParamsSchema,
   TxHistoryQuerySchema,
+  TxHistoryListResponseSchema,
 } from '../../util/api/tx/schemas';
 import { ValidationError } from '../../util/ValidationError';
 import {
   filterTxData,
   checkAddressValid,
+  sendValidatedJSON,
 } from '../../util/ValidationHelper';
 
 const router = Router();
@@ -68,7 +70,7 @@ router.get('/history/user/:id', jwtAuth('read'), validateParams(TxHistoryUserPar
     });
     results.sort((a: any, b: any) => (b.ts - a.ts));
     results.splice(count);
-    res.json(results);
+    sendValidatedJSON(res, TxHistoryListResponseSchema, results);
   } catch (err) {
     next(err);
   }
@@ -133,7 +135,7 @@ router.get('/history/addr/:addr', jwtAuth('read'), validateParams(TxHistoryAddrP
     });
     results.sort((a: any, b: any) => (b.ts - a.ts));
     results.splice(count);
-    res.json(results);
+    sendValidatedJSON(res, TxHistoryListResponseSchema, results);
   } catch (err) {
     next(err);
   }

--- a/src/routes/tx/tx.ts
+++ b/src/routes/tx/tx.ts
@@ -2,13 +2,14 @@ import { Router } from 'express';
 import type { DocumentSnapshot } from '@google-cloud/firestore';
 import { txCollection as txLogRef, userCollection } from '../../util/firebase';
 import { filterMultipleTxData } from '../../util/api/tx';
-import { filterTxData } from '../../util/ValidationHelper';
+import { filterTxData, sendValidatedJSON } from '../../util/ValidationHelper';
 import { jwtOptionalAuth } from '../../middleware/jwt';
 import { validateParams, validateQuery, validateBody } from '../../middleware/validate';
 import {
   TxIdParamsSchema,
   TxIdQuerySchema,
   TxMetadataBodySchema,
+  TxDataResponseSchema,
 } from '../../util/api/tx/schemas';
 import {
   TX_METADATA_TYPES,
@@ -35,7 +36,7 @@ router.get('/id/:id', validateParams(TxIdParamsSchema), validateQuery(TxIdQueryS
       const payload = data.toIds
         ? filterMultipleTxData(data, { to: { addresses: address ? [address] : null } })
         : data;
-      res.json(filterTxData(payload));
+      sendValidatedJSON(res, TxDataResponseSchema, filterTxData(payload));
       return;
     }
     res.sendStatus(404);

--- a/src/routes/users/getInfo.ts
+++ b/src/routes/users/getInfo.ts
@@ -4,9 +4,10 @@ import {
 } from '../../util/firebase';
 import { jwtAuth } from '../../middleware/jwt';
 import { validateParams } from '../../middleware/validate';
-import { UsersIdParamsSchema } from '../../util/api/users/schemas';
+import { UsersIdParamsSchema, UserDataFilteredResponseSchema } from '../../util/api/users/schemas';
 import {
   filterUserData,
+  sendValidatedJSON,
 } from '../../util/ValidationHelper';
 import {
   getUserWithCivicLikerProperties,
@@ -30,7 +31,7 @@ router.get('/self', jwtAuth('read'), async (req, res, next) => {
         console.log(`Locked user: ${username}`);
         throw new Error('USER_LOCKED');
       }
-      res.json(filterUserData(payload));
+      sendValidatedJSON(res, UserDataFilteredResponseSchema, filterUserData(payload));
       await dbRef.doc(username).collection('session').doc(req.user.jti).set({
         lastAccessedUserAgent: req.headers['user-agent'] || 'unknown',
         lastAccessedIP: req.headers['x-real-ip'] || req.ip,
@@ -60,7 +61,7 @@ router.get('/id/:id', jwtAuth('read'), validateParams(UsersIdParamsSchema), asyn
         res.sendStatus(404);
         return;
       }
-      res.json(filterUserData(payload));
+      sendValidatedJSON(res, UserDataFilteredResponseSchema, filterUserData(payload));
     } else {
       res.sendStatus(404);
     }

--- a/src/routes/users/getPublicInfo.ts
+++ b/src/routes/users/getPublicInfo.ts
@@ -4,6 +4,7 @@ import sharp from 'sharp';
 import { ValidationError } from '../../util/ValidationError';
 import {
   filterUserDataMin,
+  sendValidatedJSON,
 } from '../../util/ValidationHelper';
 import {
   getUserWithCivicLikerProperties,
@@ -12,7 +13,7 @@ import {
 } from '../../util/api/users/getPublicInfo';
 import { ONE_DAY_IN_S, AVATAR_DEFAULT_PATH, DEFAULT_AVATAR_SIZE } from '../../constant';
 import { validateParams } from '../../middleware/validate';
-import { UsersAddrParamsSchema, UsersIdParamsSchema } from '../../util/api/users/schemas';
+import { UsersAddrParamsSchema, UsersIdParamsSchema, UserDataMinResponseSchema } from '../../util/api/users/schemas';
 
 const router = Router();
 
@@ -30,7 +31,7 @@ router.get('/id/:id/min', validateParams(UsersIdParamsSchema), async (req, res, 
       return;
     }
     res.set('Cache-Control', `public, max-age=30, stale-while-revalidate=${ONE_DAY_IN_S}`);
-    res.json(filterUserDataMin(payload, types));
+    sendValidatedJSON(res, UserDataMinResponseSchema, filterUserDataMin(payload, types));
   } catch (err) {
     next(err);
   }
@@ -101,7 +102,7 @@ router.get('/addr/:addr/min', validateParams(UsersAddrParamsSchema), async (req,
       return;
     }
     res.set('Cache-Control', `public, max-age=30, stale-while-revalidate=${ONE_DAY_IN_S}`);
-    res.json(filterUserDataMin(payload, types));
+    sendValidatedJSON(res, UserDataMinResponseSchema, filterUserDataMin(payload, types));
   } catch (err) {
     next(err);
   }

--- a/src/routes/wallet/index.ts
+++ b/src/routes/wallet/index.ts
@@ -22,6 +22,8 @@ import {
   WalletLikeWalletParamsSchema,
   WalletAuthorizeResponseSchema,
   WalletEvmMigrateResponseSchema,
+  WalletEvmMigrateBookResponseSchema,
+  WalletEvmMigrateUserResponseSchema,
 } from '../../util/api/wallet/schemas';
 import { validateBody, validateParams } from '../../middleware/validate';
 import publisher from '../../util/gcloudPub';
@@ -129,7 +131,7 @@ router.post('/evm/migrate/book', validateBody(WalletEvmMigrateBookBodySchema), a
       migratedClassIds,
       error,
     });
-    res.json({
+    sendValidatedJSON(res, WalletEvmMigrateBookResponseSchema, {
       migratedClassIds,
       error,
     });
@@ -150,7 +152,10 @@ router.get('/evm/migrate/user/addr/:likeWallet', validateParams(WalletLikeWallet
     ]);
     // This endpoint is unauthenticated; filter to the public-safe field set
     // so email, phone and Stripe ids never leak. Mirrors /users/addr/:addr/min.
-    res.json({ likerIdInfo: likerIdInfo ? filterUserDataMin(likerIdInfo) : null, evmWallet });
+    sendValidatedJSON(res, WalletEvmMigrateUserResponseSchema, {
+      likerIdInfo: likerIdInfo ? filterUserDataMin(likerIdInfo) : null,
+      evmWallet,
+    });
   } catch (err) {
     next(err);
   }

--- a/src/util/api/arweave/schemas.ts
+++ b/src/util/api/arweave/schemas.ts
@@ -49,3 +49,18 @@ export const ArweaveRegisterResponseSchema = z.object({
   accessToken: z.string(),
   isRequireAuth: z.boolean(),
 });
+
+export const ArweavePublicKeyResponseSchema = z.object({
+  publicKey: z.string(),
+});
+
+export const ArweaveLinkResponseSchema = z.object({
+  arweaveId: z.string().optional(),
+  txHash: z.string().optional(),
+  key: z.string().optional(),
+  link: z.string(),
+});
+
+export const ArweaveAccessTokenResponseSchema = z.object({
+  accessToken: z.string(),
+});

--- a/src/util/api/likernft/book/schemas.ts
+++ b/src/util/api/likernft/book/schemas.ts
@@ -511,6 +511,37 @@ export const BookUserCommissionsResponseSchema = z.object({
   commissions: z.array(BookPurchaseCommissionFilteredSchema),
 });
 
+// Stripe Connect onboarding-refresh returns only the readiness flag.
+export const BookUserConnectRefreshResponseSchema = z.object({
+  isReady: z.boolean(),
+});
+
+// claimNFTBook returns the claimed NFT id (absent when nothing was auto-minted).
+export const BookClaimResponseSchema = z.object({
+  nftId: z.string().optional(),
+});
+
+// Mirrors MetaCatalogItem (src/util/api/likernft/book/metaCatalog.ts); Meta feed
+// field names are snake_case per spec.
+export const BookCatalogMetaResponseSchema = z.object({
+  items: z.array(z.object({
+    id: z.string(),
+    title: z.string(),
+    description: z.string(),
+    availability: z.enum(['in stock', 'out of stock']),
+    condition: z.literal('new'),
+    price: z.string(),
+    link: z.string(),
+    image_link: z.string(),
+    brand: z.string(),
+    item_group_id: z.string(),
+    google_product_category: z.string(),
+    fb_product_category: z.string(),
+    gtin: z.string().optional(),
+    custom_label_0: z.string().optional(),
+  })),
+});
+
 const StripePayoutSummarySchema = z.object({
   amount: z.number(),
   currency: z.string(),

--- a/src/util/api/likernft/schemas.ts
+++ b/src/util/api/likernft/schemas.ts
@@ -27,3 +27,54 @@ export const LikernftImageQuerySchema = z.object({
 export const LikernftUserStatsParamsSchema = z.object({
   wallet: z.string().min(1),
 });
+
+// Mirrors filterLikeNFTISCNData's fixed output (src/util/ValidationHelper.ts).
+export const LikeNFTISCNDataResponseSchema = z.object({
+  iscnId: z.string(),
+  classId: z.string(),
+  nextNewNFTId: z.number().optional(),
+  totalCount: z.number().optional(),
+  currentPrice: z.number().optional(),
+  basePrice: z.number().optional(),
+  soldCount: z.number().optional(),
+  classUri: z.string().optional(),
+  creatorWallet: z.string().optional(),
+  ownerWallet: z.string().optional(),
+});
+
+export const LikernftFreeListResponseSchema = z.object({
+  list: z.array(z.string()),
+});
+
+// getUserStat folds chain-indexer counts (created/collector) with Firestore-derived
+// values; keep the raw indexer fields lenient since the LCD may return numeric strings.
+export const LikernftUserStatResponseSchema = z.object({
+  collectedClassCount: z.number(),
+  collectedCount: z.number(),
+  collectedValue: z.number(),
+  createdClassCount: z.union([z.number(), z.string()]),
+  createdCollectorCount: z.union([z.number(), z.string()]),
+  createdTotalSales: z.number(),
+});
+
+// Mirrors filterLikeNFTMetadata; .passthrough() because it spreads arbitrary
+// remaining metadata keys (`[key: string]: any`) alongside the OpenSea fields.
+export const LikeNFTMetadataResponseSchema = z.object({
+  image: z.string().optional(),
+  external_url: z.string().optional(),
+  description: z.string().optional(),
+  name: z.string().optional(),
+  background_color: z.string().optional(),
+  animation_url: z.string().optional(),
+  youtube_url: z.string().optional(),
+  iscn_id: z.string().optional(),
+  iscn_owner: z.string().optional(),
+  iscn_record_timestamp: z.number().optional(),
+  iscn_stakeholders: z.any(),
+}).passthrough();
+
+// /history and /events return heterogeneous Firestore / chain documents, so the
+// envelope is validated but list items stay permissive to avoid brittle drift.
+export const LikernftHistoryListResponseSchema = z.object({
+  list: z.array(z.record(z.string(), z.unknown())),
+});

--- a/src/util/api/oembed/schemas.ts
+++ b/src/util/api/oembed/schemas.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import { z } from 'zod';
 
 // Fields stay .optional() because the handler throws specific errors
@@ -7,4 +6,13 @@ import { z } from 'zod';
 export const OembedQuerySchema = z.object({
   url: z.string().optional(),
   format: z.string().optional(),
+}).passthrough();
+
+// The handler spreads arbitrary per-type oEmbed fields (title, html, width,
+// thumbnail_url, ...) onto the base envelope, so keep the extras via .passthrough().
+export const OembedResponseSchema = z.object({
+  type: z.string(),
+  version: z.string(),
+  provider_name: z.string(),
+  provider_url: z.string(),
 }).passthrough();

--- a/src/util/api/plus/schemas.ts
+++ b/src/util/api/plus/schemas.ts
@@ -140,6 +140,47 @@ export const RevenueCatConfigResponseSchema = z.object({
   entitlementId: z.string(),
 });
 
+// RevenueCat webhook body. Deliberately lenient: the request is authorized by the
+// shared-secret header (the real trust boundary), and a 400 here can drop a real
+// event. `event` itself is optional (the handler no-ops when it's missing); when
+// present, only `event.type` is required and everything else is .nullish() with
+// .passthrough(). Two checks against the official docs (verified against
+// revenuecat.com/docs/.../event-types-and-fields):
+//   - period_type/environment/store are plain strings, not enums — RevenueCat ships
+//     values our TS interface omits (e.g. period_type PREPAID), and an enum would
+//     reject those valid deliveries.
+//   - product_id/price/price_in_purchased_currency/currency are explicitly nullable
+//     in the docs, so every scalar is .nullish() (accepts null AND missing).
+export const RevenueCatWebhookBodySchema = z.object({
+  event: z.object({
+    type: z.string(),
+    id: z.string().nullish(),
+    app_user_id: z.string().nullish(),
+    aliases: z.array(z.string()).nullish(),
+    original_app_user_id: z.string().nullish(),
+    product_id: z.string().nullish(),
+    entitlement_id: z.string().nullish(),
+    entitlement_ids: z.array(z.string()).nullish(),
+    period_type: z.string().nullish(),
+    purchased_at_ms: z.number().nullish(),
+    expiration_at_ms: z.number().nullish(),
+    store: z.string().nullish(),
+    environment: z.string().nullish(),
+    price: z.number().nullish(),
+    price_in_purchased_currency: z.number().nullish(),
+    currency: z.string().nullish(),
+    original_transaction_id: z.string().nullish(),
+    cancel_reason: z.string().nullish(),
+    expiration_reason: z.string().nullish(),
+    transferred_from: z.array(z.string()).nullish(),
+    transferred_to: z.array(z.string()).nullish(),
+    subscriber_attributes: z.record(z.string(), z.object({
+      value: z.string().nullish(),
+      updated_at_ms: z.number().nullish(),
+    }).passthrough()).nullish(),
+  }).passthrough().optional(),
+}).passthrough();
+
 // Internal Plus reading-usage ingest (POST /plus/reading/usage), called
 // server-to-server by 3ook.com. Durations are already paced (anti-fraud)
 // upstream; cap each at 4h — the reader's per-session ceiling — as a sanity bound.

--- a/src/util/api/tx/schemas.ts
+++ b/src/util/api/tx/schemas.ts
@@ -29,3 +29,37 @@ export const TxIdQuerySchema = z.object({
 export const TxMetadataBodySchema = z.object({
   metadata: z.record(z.string(), z.unknown()).optional(),
 }).passthrough();
+
+// Mirrors filterTxData's output. For multi-recipient txs (filterMultipleTxData)
+// to/toId become arrays and amount is wrapped into Coin objects via LIKEToAmount,
+// so keep those unions; status/ts optional for legacy rows.
+const CoinSchema = z.object({
+  denom: z.string(),
+  amount: z.union([z.string(), z.number()]),
+});
+const TxAmountSchema = z.union([
+  z.string(),
+  z.number(),
+  CoinSchema,
+  z.array(z.union([z.string(), z.number(), CoinSchema])),
+]);
+
+export const TxDataResponseSchema = z.object({
+  from: z.string().optional(),
+  fromId: z.string().optional(),
+  to: z.union([z.string(), z.array(z.string())]).optional(),
+  toId: z.union([z.string(), z.array(z.string())]).optional(),
+  value: TxAmountSchema.optional(),
+  amount: TxAmountSchema.optional(),
+  status: z.string().optional(),
+  type: z.string().optional(),
+  remarks: z.string().optional(),
+  httpReferrer: z.string().optional(),
+  completeTs: z.number().optional(),
+  ts: z.number().optional(),
+  txHash: z.string().optional(),
+});
+
+export const TxHistoryListResponseSchema = z.array(
+  TxDataResponseSchema.extend({ id: z.string() }),
+);

--- a/src/util/api/wallet/schemas.ts
+++ b/src/util/api/wallet/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { UserDataMinResponseSchema } from '../users/schemas';
 
 export const WalletAuthorizeBodySchema = z.object({
   wallet: z.string().optional(),
@@ -57,4 +58,16 @@ export const WalletEvmMigrateResponseSchema = z.object({
   migrateBookOwnerError: z.string().nullable(),
   migrateLikerIdError: z.string().nullable(),
   migrateLikerLandError: z.unknown().nullable(),
+});
+
+export const WalletEvmMigrateBookResponseSchema = z.object({
+  migratedClassIds: z.array(z.string()).optional(),
+  error: z.string().nullable().optional(),
+});
+
+// Unauthenticated endpoint: likerIdInfo is the public-safe filterUserDataMin set
+// (or null when no user); evmWallet may be null/undefined when unmigrated.
+export const WalletEvmMigrateUserResponseSchema = z.object({
+  likerIdInfo: UserDataMinResponseSchema.nullable(),
+  evmWallet: z.string().nullable().optional(),
 });

--- a/test/middleware/validate.test.ts
+++ b/test/middleware/validate.test.ts
@@ -1,0 +1,63 @@
+import {
+  describe, it, expect, vi,
+} from 'vitest';
+import { z } from 'zod';
+import { validateBody, validateQuery, validateParams } from '../../src/middleware/validate';
+import { ValidationError } from '../../src/util/ValidationError';
+
+describe('validateBody', () => {
+  const schema = z.object({ name: z.string(), age: z.number() });
+
+  it('replaces req.body with the parsed data and calls next with no error', () => {
+    const req: any = { body: { name: 'ada', age: 36 } };
+    const next = vi.fn();
+    validateBody(schema)(req, {} as any, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith();
+    expect(req.body).toEqual({ name: 'ada', age: 36 });
+  });
+
+  it('forwards a 400 ValidationError with target and issues on mismatch', () => {
+    const req: any = { body: { name: 'ada', age: 'old' } };
+    const next = vi.fn();
+    validateBody(schema)(req, {} as any, next);
+    const err = next.mock.calls[0][0];
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.status).toBe(400);
+    expect(err.payload.target).toBe('body');
+    expect(err.payload.issues).toHaveLength(1);
+    expect(err.payload.issues[0].path).toEqual(['age']);
+  });
+});
+
+describe('validateQuery', () => {
+  // Coerce so query strings (always strings off the wire) reach handlers typed.
+  const schema = z.object({ limit: z.coerce.number() });
+
+  it('shadows the getter-only req.query without throwing (Express 5 contract)', () => {
+    // Express 5 exposes req.query as a getter-only property; a plain assignment
+    // throws, so the middleware must redefine it. Reproduce that shape here.
+    const req: any = { params: {} };
+    Object.defineProperty(req, 'query', {
+      get: () => ({ limit: '10' }),
+      configurable: true,
+    });
+    const next = vi.fn();
+    expect(() => validateQuery(schema)(req, {} as any, next)).not.toThrow();
+    expect(next).toHaveBeenCalledWith();
+    expect(req.query).toEqual({ limit: 10 });
+  });
+});
+
+describe('validateParams', () => {
+  const schema = z.object({ id: z.string() });
+
+  it('forwards a ValidationError tagged with the params target on mismatch', () => {
+    const req: any = { params: {} };
+    const next = vi.fn();
+    validateParams(schema)(req, {} as any, next);
+    const err = next.mock.calls[0][0];
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.payload.target).toBe('params');
+  });
+});

--- a/test/unit/validation-helper.test.ts
+++ b/test/unit/validation-helper.test.ts
@@ -1,0 +1,58 @@
+import {
+  describe, it, expect, vi, afterEach,
+} from 'vitest';
+import { z } from 'zod';
+import type { Response } from 'express';
+import { sendValidatedJSON } from '../../src/util/ValidationHelper';
+import { TEST_MODE } from '../../src/constant';
+
+function mockRes() {
+  const res: any = {};
+  res.json = vi.fn(() => res);
+  return res as Response & { json: ReturnType<typeof vi.fn> };
+}
+
+const schema = z.object({ id: z.string(), count: z.number() });
+
+describe('sendValidatedJSON', () => {
+  it('keeps response-schema enforcement active under the test runner (TEST_MODE on)', () => {
+    // Guard the safety mechanism itself: if TEST_MODE ever reads false here, the
+    // safeParse below is skipped and every response-schema mismatch ships silently.
+    expect(TEST_MODE).toBeTruthy();
+  });
+
+  it('sends data that matches the schema', () => {
+    const res = mockRes();
+    const data = { id: 'abc', count: 3 };
+    sendValidatedJSON(res, schema, data);
+    expect(res.json).toHaveBeenCalledWith(data);
+  });
+
+  it('throws RESPONSE_SCHEMA_MISMATCH and does not send when data violates the schema', () => {
+    const res = mockRes();
+    expect(() => sendValidatedJSON(res, schema, { id: 'abc', count: 'nope' } as any))
+      .toThrow(/RESPONSE_SCHEMA_MISMATCH/);
+    expect(res.json).not.toHaveBeenCalled();
+  });
+});
+
+describe('sendValidatedJSON in production (TEST_MODE off)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('passes mismatched data through without throwing (no runtime parse in prod)', async () => {
+    // Re-import with a production-like env so the re-evaluated TEST_MODE is false.
+    // This locks the deliberate passthrough: legacy datastore values must never
+    // 500 a live response, and this is NOT a confidentiality boundary.
+    vi.resetModules();
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('CI', '');
+    const { sendValidatedJSON: prodSend } = await import('../../src/util/ValidationHelper');
+    const res = mockRes();
+    const bad = { id: 'abc', count: 'nope' };
+    expect(() => prodSend(res, schema, bad as any)).not.toThrow();
+    expect(res.json).toHaveBeenCalledWith(bad);
+  });
+});


### PR DESCRIPTION
Route the last raw res.json handlers (users, likernft, tx, arweave, oembed, wallet, book) through sendValidatedJSON so response shapes are checked in TEST_MODE. Add a lenient .passthrough() body schema for the RevenueCat webhook (nullish + string-not-enum so a valid delivery is never 400'd) with the shared-secret check lifted ahead of validation.

Cover the validation mechanism itself with unit tests for sendValidatedJSON (throws on mismatch in TEST_MODE, passthrough in prod) and the request-side validate middleware.