### PR TITLE
♻️ Always parse sendValidatedJSON responses, drop TEST_MODE gate

### DIFF
--- a/src/util/ValidationHelper.ts
+++ b/src/util/ValidationHelper.ts
@@ -4,7 +4,6 @@ import type { z } from 'zod';
 import {
   MIN_USER_ID_LENGTH,
   MAX_USER_ID_LENGTH,
-  TEST_MODE,
 } from '../constant';
 import type { UserCivicLikerProperties } from '../types/user';
 import type {
@@ -37,23 +36,22 @@ import type {
 
 /**
  * Send `data` as a JSON response, type-checked at compile time against `schema`
- * (`data` must satisfy `z.infer<typeof schema>`). In dev/CI (`TEST_MODE`) it
- * also runs a `safeParse` so response-schema drift fails fast; deployed
- * production never parses, so legacy datastore values can't 500 a live
- * response. Pairs with the request-side validators in `middleware/validate.ts`.
+ * (`data` must satisfy `z.infer<typeof schema>`) and parsed at runtime: the
+ * parsed result is sent, so undeclared keys are stripped (except on
+ * `.passthrough()` schemas, which keep them). A mismatch throws
+ * `RESPONSE_SCHEMA_MISMATCH`, surfacing schema drift as an error in prod and
+ * dev/CI alike. Pairs with the request-side validators in `middleware/validate.ts`.
  */
 export function sendValidatedJSON<S extends z.ZodTypeAny>(
   res: Response,
   schema: S,
   data: z.infer<S>,
 ): void {
-  if (TEST_MODE) {
-    const result = schema.safeParse(data);
-    if (!result.success) {
-      throw new Error(`RESPONSE_SCHEMA_MISMATCH: ${JSON.stringify(result.error.issues)}`);
-    }
+  const result = schema.safeParse(data);
+  if (!result.success) {
+    throw new Error(`RESPONSE_SCHEMA_MISMATCH: ${JSON.stringify(result.error.issues)}`);
   }
-  res.json(data);
+  res.json(result.data);
 }
 
 export function checkAddressValid(addr: string): boolean {

--- a/test/unit/validation-helper.test.ts
+++ b/test/unit/validation-helper.test.ts
@@ -4,7 +4,6 @@ import {
 import { z } from 'zod';
 import type { Response } from 'express';
 import { sendValidatedJSON } from '../../src/util/ValidationHelper';
-import { TEST_MODE } from '../../src/constant';
 
 function mockRes() {
   const res: any = {};
@@ -15,16 +14,24 @@ function mockRes() {
 const schema = z.object({ id: z.string(), count: z.number() });
 
 describe('sendValidatedJSON', () => {
-  it('keeps response-schema enforcement active under the test runner (TEST_MODE on)', () => {
-    // Guard the safety mechanism itself: if TEST_MODE ever reads false here, the
-    // safeParse below is skipped and every response-schema mismatch ships silently.
-    expect(TEST_MODE).toBeTruthy();
-  });
-
   it('sends data that matches the schema', () => {
     const res = mockRes();
     const data = { id: 'abc', count: 3 };
     sendValidatedJSON(res, schema, data);
+    expect(res.json).toHaveBeenCalledWith(data);
+  });
+
+  it('strips undeclared keys from the response', () => {
+    const res = mockRes();
+    sendValidatedJSON(res, schema, { id: 'abc', count: 3, secret: 'leak' } as any);
+    expect(res.json).toHaveBeenCalledWith({ id: 'abc', count: 3 });
+  });
+
+  it('keeps undeclared keys on .passthrough() schemas', () => {
+    const res = mockRes();
+    const passthrough = schema.passthrough();
+    const data = { id: 'abc', count: 3, extra: 'kept' };
+    sendValidatedJSON(res, passthrough, data);
     expect(res.json).toHaveBeenCalledWith(data);
   });
 
@@ -36,23 +43,23 @@ describe('sendValidatedJSON', () => {
   });
 });
 
-describe('sendValidatedJSON in production (TEST_MODE off)', () => {
+describe('sendValidatedJSON in production', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.resetModules();
   });
 
-  it('passes mismatched data through without throwing (no runtime parse in prod)', async () => {
-    // Re-import with a production-like env so the re-evaluated TEST_MODE is false.
-    // This locks the deliberate passthrough: legacy datastore values must never
-    // 500 a live response, and this is NOT a confidentiality boundary.
+  it('enforces the schema in prod too (parses unconditionally, throws on mismatch)', async () => {
+    // Re-import with a production-like env to confirm enforcement no longer hinges
+    // on TEST_MODE: a response-schema mismatch throws RESPONSE_SCHEMA_MISMATCH in
+    // prod, surfacing drift instead of shipping malformed data silently.
     vi.resetModules();
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('CI', '');
     const { sendValidatedJSON: prodSend } = await import('../../src/util/ValidationHelper');
     const res = mockRes();
-    const bad = { id: 'abc', count: 'nope' };
-    expect(() => prodSend(res, schema, bad as any)).not.toThrow();
-    expect(res.json).toHaveBeenCalledWith(bad);
+    expect(() => prodSend(res, schema, { id: 'abc', count: 'nope' } as any))
+      .toThrow(/RESPONSE_SCHEMA_MISMATCH/);
+    expect(res.json).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
The runtime safeParse was gated behind TEST_MODE, so prod sent raw data unchecked. Parse unconditionally and send result.data instead: schema drift now surfaces as RESPONSE_SCHEMA_MISMATCH in prod too, and undeclared keys are stripped (except on .passthrough() schemas).