### PR TITLE
✨ Record non-library reading usage + idempotent ingest

### DIFF
--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -55,31 +55,48 @@ router.use('/revenuecat', revenueCatRouter);
 // revenue share. Recorded into a per-(book, day) ledger with a per-reader grain.
 router.post('/reading/usage', plusReadingServiceAuth, validateBody(PlusReadingUsageBodySchema), async (req, res, next) => {
   try {
-    const {
-      readerWallet,
-      classId,
-      readingTimeMs,
-      ttsTimeMs,
-      occurredAt,
-    } = req.body;
+    // Accept either a single (legacy flat) entry or a batch under `entries`.
+    const entries = Array.isArray(req.body.entries) ? req.body.entries : [req.body];
 
-    // Nothing to record, but ack so the forwarder doesn't retry.
-    if (readingTimeMs <= 0 && ttsTimeMs <= 0) {
-      sendValidatedJSON(res, PlusReadingUsageResponseSchema, {
-        success: true,
-        dayId: getUsageDayId(occurredAt ?? Date.now()),
+    const results: Array<{ dayId: string; applied: boolean }> = [];
+    for (const entry of entries) {
+      const {
+        id,
+        readerWallet,
+        classId,
+        readingTimeMs,
+        ttsTimeMs,
+        nonLibraryReadingTimeMs,
+        nonLibraryTtsTimeMs,
+        occurredAt,
+      } = entry;
+
+      // Nothing to record, but report a dayId so the forwarder treats it as acked.
+      if (readingTimeMs <= 0 && ttsTimeMs <= 0
+        && nonLibraryReadingTimeMs <= 0 && nonLibraryTtsTimeMs <= 0) {
+        results.push({ dayId: getUsageDayId(occurredAt ?? Date.now()), applied: false });
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
+      const { dayId, applied } = await recordPlusReadingUsage({
+        id,
+        readerWallet,
+        classId,
+        readingTimeMs,
+        ttsTimeMs,
+        nonLibraryReadingTimeMs,
+        nonLibraryTtsTimeMs,
+        occurredAt,
       });
-      return;
+      results.push({ dayId, applied });
     }
 
-    const { dayId } = await recordPlusReadingUsage({
-      readerWallet,
-      classId,
-      readingTimeMs,
-      ttsTimeMs,
-      occurredAt,
+    sendValidatedJSON(res, PlusReadingUsageResponseSchema, {
+      success: true,
+      dayId: results[0].dayId,
+      results,
     });
-    sendValidatedJSON(res, PlusReadingUsageResponseSchema, { success: true, dayId });
   } catch (err) {
     next(err);
   }

--- a/src/util/api/plus/revenueShare.ts
+++ b/src/util/api/plus/revenueShare.ts
@@ -1,7 +1,7 @@
 import { checksumAddress } from 'viem';
 import { ONE_DAY_IN_MS } from '../../../constant';
 import {
-  FieldValue, db, likeNFTBookCollection, userCollection,
+  FieldValue, Timestamp, db, likeNFTBookCollection, userCollection,
 } from '../../firebase';
 import { ValidationError } from '../../ValidationError';
 import type { PlusReadingAccrualData } from '../../../types/user';
@@ -75,6 +75,14 @@ export function getDayStartMs(timestampMs: number): number {
   return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
 }
 
+// How long a dedup receipt is kept. Retries of a dropped forward arrive within
+// seconds; days of margin covers a stuck queue. A Firestore TTL policy on
+// `plusUsageReceipts.expireAt` purges them so they don't grow unbounded.
+const USAGE_RECEIPT_TTL_MS = 7 * ONE_DAY_IN_MS;
+// gRPC ALREADY_EXISTS: a batched create() of a doc that already exists rejects
+// commit with this code — how the idempotency gate detects a duplicate delivery.
+const GRPC_ALREADY_EXISTS = 6;
+
 /**
  * Records already-paced (anti-fraud) Plus reading/TTS usage into the day-bucketed
  * ledger funding the reading-library revenue share — a trusted write. Dual-writes the
@@ -85,20 +93,33 @@ export function getDayStartMs(timestampMs: number): number {
  * `classId` (a contract address) is lowercased and `readerWallet` is EIP-55 checksummed
  * per repo convention, so casing variants don't split the same book/reader across docs and
  * reader keys match `likeNFTBookUserCollection`/`userCollection` (both checksummed).
+ * An `id` makes the write idempotent (see the receipt in the batch below).
  */
 export async function recordPlusReadingUsage({
+  id,
   readerWallet,
   classId,
   readingTimeMs,
   ttsTimeMs,
+  nonLibraryReadingTimeMs = 0,
+  nonLibraryTtsTimeMs = 0,
   occurredAt,
 }: {
+  // Idempotency key. When present, a repeat delivery (e.g. a retried forward after
+  // a lost response) is detected and skipped, so the non-idempotent increments below
+  // can't double-count. Absent → no dedup.
+  id?: string;
   readerWallet: string;
   classId: string;
   readingTimeMs: number;
   ttsTimeMs: number;
+  // Non-rev-share engagement (owned/non-Plus reads): rolled up per book+day for
+  // publisher stats, but never written to the per-reader grain and never read by
+  // settlement, so payouts stay library-only.
+  nonLibraryReadingTimeMs?: number;
+  nonLibraryTtsTimeMs?: number;
   occurredAt?: number;
-}): Promise<{ dayId: string }> {
+}): Promise<{ dayId: string; applied: boolean }> {
   const ts = occurredAt ?? Date.now();
   const dayId = getUsageDayId(ts);
   const dayMs = getDayStartMs(ts);
@@ -119,12 +140,42 @@ export async function recordPlusReadingUsage({
   };
 
   const batch = db.batch();
+  // Idempotency gate: claim the key with create() in the SAME batch as the increments,
+  // so the whole write is atomic — a duplicate id fails commit with ALREADY_EXISTS and
+  // nothing is applied (no double-count, no claim-without-increment window). Receipts hang
+  // off the (always-present) book doc, not the day rollup, so the first delta of a day still
+  // dedups.
+  if (id) {
+    batch.create(bookDocRef.collection('plusUsageReceipts').doc(id), {
+      createdAt: FieldValue.serverTimestamp(),
+      // Base the TTL on ingest time, not `ts` (which may be a historical `occurredAt`),
+      // so a backfilled delivery still gets the full retry-dedup window.
+      expireAt: Timestamp.fromMillis(Date.now() + USAGE_RECEIPT_TTL_MS),
+    });
+  }
   // `dayMs` (UTC start-of-day) lets settlement filter rollups by range without parsing ids.
-  batch.set(dayDocRef, { ...usageIncrement, dayMs }, { merge: true });
-  batch.set(readerDocRef, usageIncrement, { merge: true });
-  await batch.commit();
+  // The day rollup also carries the non-library engagement totals (settlement ignores them).
+  batch.set(dayDocRef, {
+    ...usageIncrement,
+    nonLibraryReadingTimeMs: FieldValue.increment(nonLibraryReadingTimeMs),
+    nonLibraryTtsTimeMs: FieldValue.increment(nonLibraryTtsTimeMs),
+    dayMs,
+  }, { merge: true });
+  // Per-reader grain is rev-share audit only — skip it for pure non-library
+  // engagement so non-Plus readers don't each spawn a reader doc.
+  if (readingTimeMs > 0 || ttsTimeMs > 0) {
+    batch.set(readerDocRef, usageIncrement, { merge: true });
+  }
 
-  return { dayId };
+  try {
+    await batch.commit();
+  } catch (err) {
+    // Duplicate id — the delta was already recorded, so this is a no-op retry.
+    if ((err as { code?: number }).code === GRPC_ALREADY_EXISTS) return { dayId, applied: false };
+    throw err;
+  }
+
+  return { dayId, applied: true };
 }
 
 /**

--- a/src/util/api/plus/schemas.ts
+++ b/src/util/api/plus/schemas.ts
@@ -186,18 +186,45 @@ export const RevenueCatWebhookBodySchema = z.object({
 // upstream; cap each at 4h — the reader's per-session ceiling — as a sanity bound.
 const MAX_USAGE_DELTA_MS = 4 * 60 * 60 * 1000;
 const UsageDurationSchema = z.number().int().min(0).max(MAX_USAGE_DELTA_MS);
+// Cap a batched forward so one request can't fan out into an unbounded write set.
+const MAX_USAGE_BATCH = 100;
 
-export const PlusReadingUsageBodySchema = z.object({
+const PlusReadingUsageEntrySchema = z.object({
+  // Idempotency key: the ledger increments are non-idempotent, so the API dedups
+  // retries of the same delta (see recordPlusReadingUsage) — that's what lets the
+  // forwarder retry a dropped request without double-counting. Optional: a forwarder
+  // that omits it simply gets no dedup (and must not enable retry).
+  // Reject `/` so a bad id can't become an invalid Firestore doc path (a 500 instead
+  // of a clean 400) when used as `.doc(id)`.
+  id: z.string().min(1).max(200).regex(/^[^/]+$/, 'INVALID_ID')
+    .optional(),
   readerWallet: z.string().regex(EVM_ADDRESS_REGEX, 'INVALID_READER_WALLET'),
   classId: z.string().regex(EVM_ADDRESS_REGEX, 'INVALID_CLASS_ID'),
+  // Rev-share-eligible (paid Plus, borrowed) durations that fund the payout pool.
   readingTimeMs: UsageDurationSchema,
   ttsTimeMs: UsageDurationSchema,
+  // Non-rev-share engagement (owned copies, trial/non-Plus reads). Recorded for
+  // publisher stats only; settlement never reads these. Default 0 so an older
+  // forwarder that omits them keeps working.
+  nonLibraryReadingTimeMs: UsageDurationSchema.default(0),
+  nonLibraryTtsTimeMs: UsageDurationSchema.default(0),
   occurredAt: z.number().int().positive().optional(),
 });
 
+// Accept a single entry (legacy flat body) or a batch. Backward compatible: an old
+// forwarder's flat body still validates as one entry; the `entries` form lets a
+// future coalescer flush several deltas in one request.
+export const PlusReadingUsageBodySchema = z.union([
+  PlusReadingUsageEntrySchema,
+  z.object({ entries: z.array(PlusReadingUsageEntrySchema).min(1).max(MAX_USAGE_BATCH) }),
+]);
+
 export const PlusReadingUsageResponseSchema = z.object({
   success: z.literal(true),
+  // Legacy convenience: the first entry's dayId. Batch callers should read `results`.
   dayId: z.string(),
+  // Per-entry outcome; `applied: false` means a no-op or a deduped retry.
+  results: z.array(z.object({ dayId: z.string(), applied: z.boolean() })),
 });
 
 // A settlement/report period: a whole month (`YYYY-MM`) or a single day (`YYYY-MM-DD`).
@@ -300,6 +327,8 @@ const PlusReadingStatsEntrySchema = z.object({
   periodId: z.string(),
   readingTimeMs: z.number(),
   ttsTimeMs: z.number(),
+  nonLibraryReadingTimeMs: z.number(),
+  nonLibraryTtsTimeMs: z.number(),
 });
 
 export const PlusReadingStatsResponseSchema = z.object({
@@ -307,6 +336,8 @@ export const PlusReadingStatsResponseSchema = z.object({
   summary: z.object({
     totalReadingTimeMs: z.number(),
     totalTTSTimeMs: z.number(),
+    totalNonLibraryReadingTimeMs: z.number(),
+    totalNonLibraryTTSTimeMs: z.number(),
     bookCount: z.number(),
     periodCount: z.number(),
   }),

--- a/src/util/api/plus/stats.ts
+++ b/src/util/api/plus/stats.ts
@@ -10,6 +10,10 @@ export interface PlusReadingStatsEntry {
   periodId: string;
   readingTimeMs: number;
   ttsTimeMs: number;
+  // Non-rev-share engagement (owned/non-Plus reads); reported alongside the
+  // library figures so publishers see total, not just payout-eligible, usage.
+  nonLibraryReadingTimeMs: number;
+  nonLibraryTtsTimeMs: number;
 }
 
 export interface PlusReadingStats {
@@ -17,6 +21,8 @@ export interface PlusReadingStats {
   summary: {
     totalReadingTimeMs: number;
     totalTTSTimeMs: number;
+    totalNonLibraryReadingTimeMs: number;
+    totalNonLibraryTTSTimeMs: number;
     bookCount: number;
     periodCount: number;
   };
@@ -33,9 +39,16 @@ export function summarizePlusReadingStats(
     (acc, e) => {
       acc.totalReadingTimeMs += e.readingTimeMs;
       acc.totalTTSTimeMs += e.ttsTimeMs;
+      acc.totalNonLibraryReadingTimeMs += e.nonLibraryReadingTimeMs;
+      acc.totalNonLibraryTTSTimeMs += e.nonLibraryTtsTimeMs;
       return acc;
     },
-    { totalReadingTimeMs: 0, totalTTSTimeMs: 0 },
+    {
+      totalReadingTimeMs: 0,
+      totalTTSTimeMs: 0,
+      totalNonLibraryReadingTimeMs: 0,
+      totalNonLibraryTTSTimeMs: 0,
+    },
   );
   return {
     ...totals,
@@ -96,10 +109,17 @@ export async function getPlusReadingStatsForWallet(
       const bucket = periodId || doc.id.slice(0, 7);
       const entry = byPeriod.get(bucket)
         || {
-          classId, periodId: bucket, readingTimeMs: 0, ttsTimeMs: 0,
+          classId,
+          periodId: bucket,
+          readingTimeMs: 0,
+          ttsTimeMs: 0,
+          nonLibraryReadingTimeMs: 0,
+          nonLibraryTtsTimeMs: 0,
         };
       entry.readingTimeMs += Number(data.readingTimeMs) || 0;
       entry.ttsTimeMs += Number(data.ttsTimeMs) || 0;
+      entry.nonLibraryReadingTimeMs += Number(data.nonLibraryReadingTimeMs) || 0;
+      entry.nonLibraryTtsTimeMs += Number(data.nonLibraryTtsTimeMs) || 0;
       byPeriod.set(bucket, entry);
     });
     return [...byPeriod.values()];
@@ -107,7 +127,8 @@ export async function getPlusReadingStatsForWallet(
 
   const stats = perBook
     .flat()
-    .filter((e) => e.readingTimeMs > 0 || e.ttsTimeMs > 0)
+    .filter((e) => e.readingTimeMs > 0 || e.ttsTimeMs > 0
+      || e.nonLibraryReadingTimeMs > 0 || e.nonLibraryTtsTimeMs > 0)
     .sort((a, b) => (a.periodId === b.periodId
       ? a.classId.localeCompare(b.classId)
       : b.periodId.localeCompare(a.periodId)));

--- a/test/api/plus-reading-usage.test.ts
+++ b/test/api/plus-reading-usage.test.ts
@@ -44,7 +44,11 @@ describe('POST /plus/reading/usage', () => {
       occurredAt: Date.UTC(2026, 2, 10, 8), // 2026-03-10
     }, AUTH_HEADER);
     expect(res.status).toBe(200);
-    expect(res.data).toEqual({ success: true, dayId: '2026-03-10' });
+    expect(res.data).toEqual({
+      success: true,
+      dayId: '2026-03-10',
+      results: [{ dayId: '2026-03-10', applied: true }],
+    });
 
     const doc = await likeNFTBookCollection
       .doc(lowerClassId)
@@ -57,6 +61,39 @@ describe('POST /plus/reading/usage', () => {
     expect(data.ttsTimeMs).toBe(4200);
     // Start-of-day ms stamped so settlement can filter rollups by range.
     expect(data.dayMs).toBe(Date.UTC(2026, 2, 10));
+  });
+
+  it('records non-library engagement on the day rollup but not the per-reader grain', async () => {
+    const classId = '0xbcdef22222222222222222222222222222222222';
+    await likeNFTBookCollection.doc(classId)
+      .set({ classId, ownerWallet: OWNER } as any);
+
+    // Owned/non-Plus read: only the non-library fields are populated.
+    const res = await post({
+      readerWallet: READER,
+      classId,
+      readingTimeMs: 0,
+      ttsTimeMs: 0,
+      nonLibraryReadingTimeMs: 900,
+      nonLibraryTtsTimeMs: 300,
+      occurredAt: Date.UTC(2026, 2, 11, 8), // 2026-03-11
+    }, AUTH_HEADER);
+    expect(res.status).toBe(200);
+    expect(res.data).toEqual({
+      success: true,
+      dayId: '2026-03-11',
+      results: [{ dayId: '2026-03-11', applied: true }],
+    });
+
+    const dayDocRef = likeNFTBookCollection.doc(classId).collection('plusUsage').doc('2026-03-11');
+    const day = (await dayDocRef.get()).data() as any;
+    expect(day.nonLibraryReadingTimeMs).toBe(900);
+    expect(day.nonLibraryTtsTimeMs).toBe(300);
+    expect(day.readingTimeMs).toBe(0);
+    expect(day.ttsTimeMs).toBe(0);
+    // No rev-share-eligible time → no per-reader audit doc spawned at all.
+    const readers = await dayDocRef.collection('readers').get();
+    expect(readers.size).toBe(0);
   });
 
   it('rejects usage for a class id with no book doc', async () => {
@@ -80,6 +117,59 @@ describe('POST /plus/reading/usage', () => {
       occurredAt: Date.UTC(2026, 4, 1), // 2026-05-01
     }, AUTH_HEADER);
     expect(res.status).toBe(200);
-    expect(res.data).toEqual({ success: true, dayId: '2026-05-01' });
+    expect(res.data).toEqual({
+      success: true,
+      dayId: '2026-05-01',
+      results: [{ dayId: '2026-05-01', applied: false }],
+    });
+  });
+
+  it('dedups a retried delta by idempotency id (no double-count)', async () => {
+    const classId = mockEVMAddress(0x55);
+    await likeNFTBookCollection.doc(classId).set({ classId, ownerWallet: OWNER } as any);
+    const occurredAt = Date.UTC(2026, 2, 10, 8);
+    const entry = (id: string, readingTimeMs: number) => ({
+      id, readerWallet: READER, classId, readingTimeMs, ttsTimeMs: 0, occurredAt,
+    });
+    // Re-resolve the ref each read; the stub snapshots a doc at ref-creation time.
+    const readDayReading = async () => (await likeNFTBookCollection
+      .doc(classId).collection('plusUsage').doc('2026-03-10')
+      .get()).data()?.readingTimeMs;
+
+    const first = await post(entry('key-1', 1000), AUTH_HEADER);
+    expect(first.data.results).toEqual([{ dayId: '2026-03-10', applied: true }]);
+    expect(await readDayReading()).toBe(1000);
+
+    // Same id, different value: deduped, so the rollup must NOT change (stub increment
+    // is identity, so a non-deduped re-write would overwrite to 5000).
+    const dup = await post(entry('key-1', 5000), AUTH_HEADER);
+    expect(dup.data.results).toEqual([{ dayId: '2026-03-10', applied: false }]);
+    expect(await readDayReading()).toBe(1000);
+
+    // A fresh id applies again.
+    const fresh = await post(entry('key-2', 5000), AUTH_HEADER);
+    expect(fresh.data.results).toEqual([{ dayId: '2026-03-10', applied: true }]);
+    expect(await readDayReading()).toBe(5000);
+  });
+
+  it('records a batch of entries in one request', async () => {
+    const classId = mockEVMAddress(0x66);
+    await likeNFTBookCollection.doc(classId).set({ classId, ownerWallet: OWNER } as any);
+
+    const res = await post({
+      entries: [
+        {
+          id: 'b-1', readerWallet: READER, classId, readingTimeMs: 100, ttsTimeMs: 0, occurredAt: Date.UTC(2026, 2, 10),
+        },
+        {
+          id: 'b-2', readerWallet: READER, classId, readingTimeMs: 0, ttsTimeMs: 0, nonLibraryReadingTimeMs: 200, occurredAt: Date.UTC(2026, 2, 11),
+        },
+      ],
+    }, AUTH_HEADER);
+    expect(res.status).toBe(200);
+    expect(res.data.results).toEqual([
+      { dayId: '2026-03-10', applied: true },
+      { dayId: '2026-03-11', applied: true },
+    ]);
   });
 });

--- a/test/api/plus-settle.test.ts
+++ b/test/api/plus-settle.test.ts
@@ -91,6 +91,26 @@ describe('POST /plus/admin/reading/settle — range allocation', () => {
     });
   });
 
+  it('ignores non-library engagement when pricing payouts', async () => {
+    await likeNFTBookCollection.doc(CLASS_ID)
+      .set({ classId: CLASS_ID, ownerWallet: mockEVMAddress(0x66) } as any, { merge: true });
+    // Library reading min(100), but huge non-library totals that settlement must not price.
+    await likeNFTBookCollection.doc(CLASS_ID).collection('plusUsage').doc('2026-03-05')
+      .set({
+        readingTimeMs: min(100),
+        ttsTimeMs: 0,
+        nonLibraryReadingTimeMs: min(9999),
+        nonLibraryTtsTimeMs: min(9999),
+        dayMs: Date.UTC(2026, 2, 5),
+      } as any);
+
+    const res = await post({ periodId: '2026-03', dryRun: true, mode: 'static' }, AUTH_HEADER);
+    expect(res.status).toBe(200);
+    expect(res.data.totalReadingTimeMs).toBe(min(100));
+    // static $0.01/min × 100 library min = 100 cents; non-library is inert.
+    expect(res.data.books[0]).toMatchObject({ classId: CLASS_ID, amountCents: 100 });
+  });
+
   it('a single-day settle reads only that day', async () => {
     await seedUsage(CLASS_ID, '2026-03-05', Date.UTC(2026, 2, 5), min(60));
     await seedUsage(CLASS_ID, '2026-03-20', Date.UTC(2026, 2, 20), min(40));

--- a/test/unit/plus-reading-stats.test.ts
+++ b/test/unit/plus-reading-stats.test.ts
@@ -11,17 +11,19 @@ describe('summarizePlusReadingStats', () => {
   it('sums durations and counts distinct books and periods', () => {
     expect(summarizePlusReadingStats([
       {
-        classId: '0xa', periodId: '2026-03', readingTimeMs: 100, ttsTimeMs: 50,
+        classId: '0xa', periodId: '2026-03', readingTimeMs: 100, ttsTimeMs: 50, nonLibraryReadingTimeMs: 5, nonLibraryTtsTimeMs: 2,
       },
       {
-        classId: '0xb', periodId: '2026-03', readingTimeMs: 200, ttsTimeMs: 0,
+        classId: '0xb', periodId: '2026-03', readingTimeMs: 200, ttsTimeMs: 0, nonLibraryReadingTimeMs: 0, nonLibraryTtsTimeMs: 0,
       },
       {
-        classId: '0xa', periodId: '2026-02', readingTimeMs: 30, ttsTimeMs: 10,
+        classId: '0xa', periodId: '2026-02', readingTimeMs: 30, ttsTimeMs: 10, nonLibraryReadingTimeMs: 1, nonLibraryTtsTimeMs: 3,
       },
     ])).toEqual({
       totalReadingTimeMs: 330,
       totalTTSTimeMs: 60,
+      totalNonLibraryReadingTimeMs: 6,
+      totalNonLibraryTTSTimeMs: 5,
       bookCount: 2,
       periodCount: 2,
     });
@@ -31,6 +33,8 @@ describe('summarizePlusReadingStats', () => {
     expect(summarizePlusReadingStats([])).toEqual({
       totalReadingTimeMs: 0,
       totalTTSTimeMs: 0,
+      totalNonLibraryReadingTimeMs: 0,
+      totalNonLibraryTTSTimeMs: 0,
       bookCount: 0,
       periodCount: 0,
     });
@@ -41,9 +45,19 @@ describe('getPlusReadingStatsForWallet', () => {
   // Usage is bucketed daily (`YYYY-MM-DD` + dayMs); the endpoint rolls days up to their month
   // by default. Book A's two March days sum to 6000/1000 — the same totals the monthly view
   // reports. Reseeded per test (the firebase stub clears these collections before each test).
-  async function day(classId, dayId, dayMs, readingTimeMs, ttsTimeMs) {
+  async function day(
+    classId,
+    dayId,
+    dayMs,
+    readingTimeMs,
+    ttsTimeMs,
+    nonLibraryReadingTimeMs = 0,
+    nonLibraryTtsTimeMs = 0,
+  ) {
     await likeNFTBookCollection.doc(classId).collection('plusUsage').doc(dayId)
-      .set({ readingTimeMs, ttsTimeMs, dayMs } as any);
+      .set({
+        readingTimeMs, ttsTimeMs, dayMs, nonLibraryReadingTimeMs, nonLibraryTtsTimeMs,
+      } as any);
   }
   // Pin "now" so the default trailing window (DEFAULT_STATS_WINDOW_MONTHS) always spans the
   // seeded 2026-02/03 usage; otherwise the no-period tests would flap once wall-clock time
@@ -53,7 +67,7 @@ describe('getPlusReadingStatsForWallet', () => {
     vi.setSystemTime(new Date(Date.UTC(2026, 2, 25)));
     // Book A (owned) — March across two days + one February day.
     await likeNFTBookCollection.doc('0xaaa').set({ ownerWallet: OWNER, classId: '0xaaa' } as any);
-    await day('0xaaa', '2026-03-05', Date.UTC(2026, 2, 5), 4000, 600);
+    await day('0xaaa', '2026-03-05', Date.UTC(2026, 2, 5), 4000, 600, 1000, 200);
     await day('0xaaa', '2026-03-20', Date.UTC(2026, 2, 20), 2000, 400);
     await day('0xaaa', '2026-02-10', Date.UTC(2026, 1, 10), 3000, 0);
     // Book B (owned) — one March day.
@@ -76,11 +90,15 @@ describe('getPlusReadingStatsForWallet', () => {
       '2026-03/0xbbb',
       '2026-02/0xaaa',
     ]);
-    // Book A's two March days summed into one month entry.
-    expect(stats[0]).toMatchObject({ readingTimeMs: 6000, ttsTimeMs: 1000 });
+    // Book A's two March days summed into one month entry (non-library from the first day).
+    expect(stats[0]).toMatchObject({
+      readingTimeMs: 6000, ttsTimeMs: 1000, nonLibraryReadingTimeMs: 1000, nonLibraryTtsTimeMs: 200,
+    });
     expect(summary).toEqual({
       totalReadingTimeMs: 11000,
       totalTTSTimeMs: 1500,
+      totalNonLibraryReadingTimeMs: 1000,
+      totalNonLibraryTTSTimeMs: 200,
       bookCount: 2,
       periodCount: 2,
     });
@@ -101,7 +119,12 @@ describe('getPlusReadingStatsForWallet', () => {
   it('reads a single day when given a YYYY-MM-DD period', async () => {
     const { stats, summary } = await getPlusReadingStatsForWallet(OWNER, { periodId: '2026-03-05' });
     expect(stats).toEqual([{
-      classId: '0xaaa', periodId: '2026-03-05', readingTimeMs: 4000, ttsTimeMs: 600,
+      classId: '0xaaa',
+      periodId: '2026-03-05',
+      readingTimeMs: 4000,
+      ttsTimeMs: 600,
+      nonLibraryReadingTimeMs: 1000,
+      nonLibraryTtsTimeMs: 200,
     }]);
     expect(summary).toMatchObject({
       totalReadingTimeMs: 4000,
@@ -132,8 +155,32 @@ describe('getPlusReadingStatsForWallet', () => {
     expect(summary).toEqual({
       totalReadingTimeMs: 0,
       totalTTSTimeMs: 0,
+      totalNonLibraryReadingTimeMs: 0,
+      totalNonLibraryTTSTimeMs: 0,
       bookCount: 0,
       periodCount: 0,
+    });
+  });
+
+  it('surfaces a book whose only usage is non-library (zero rev-share time)', async () => {
+    await likeNFTBookCollection.doc('0xeee').set({ ownerWallet: OWNER, classId: '0xeee' } as any);
+    await day('0xeee', '2026-03-12', Date.UTC(2026, 2, 12), 0, 0, 5000, 1500);
+
+    const { stats, summary } = await getPlusReadingStatsForWallet(OWNER, { classId: '0xeee' });
+    expect(stats).toEqual([{
+      classId: '0xeee',
+      periodId: '2026-03',
+      readingTimeMs: 0,
+      ttsTimeMs: 0,
+      nonLibraryReadingTimeMs: 5000,
+      nonLibraryTtsTimeMs: 1500,
+    }]);
+    expect(summary).toMatchObject({
+      totalReadingTimeMs: 0,
+      totalTTSTimeMs: 0,
+      totalNonLibraryReadingTimeMs: 5000,
+      totalNonLibraryTTSTimeMs: 1500,
+      bookCount: 1,
     });
   });
 });


### PR DESCRIPTION
Publishers can now see non-library (owned / non-Plus) reading & TTS time alongside the rev-share-eligible library figures: the usage ledger records nonLibrary* fields on the day rollup and the stats endpoint returns them. Settlement still reads only the library fields, so payouts are unchanged.

The ingest endpoint now dedups by a per-entry idempotency `id` (an in-batch receipt create, atomic with the increments) and accepts a batched `entries` body, so the forwarder's retries are safe against the non-idempotent ledger.

Requires a Firestore TTL policy on plusUsageReceipts.expireAt. Deploy this BEFORE the 3ook.com forwarder that enables retry — a retry-enabled client against a non-deduping API would double-count.