### PR TITLE
🐛 Fix response schema types for author and iscn timestamp

### DIFF
--- a/src/types/nft.d.ts
+++ b/src/types/nft.d.ts
@@ -26,7 +26,7 @@ export interface LikeNFTMetadata {
   iscnOwner?: string;
   iscnStakeholders?: any;
   iscnId?: string;
-  iscnRecordTimestamp?: number;
+  iscnRecordTimestamp?: string;
   [key: string]: any;
 }
 
@@ -41,7 +41,7 @@ export interface LikeNFTMetadataFiltered {
   youtube_url?: string;
   iscn_id?: string;
   iscn_owner?: string;
-  iscn_record_timestamp?: number;
+  iscn_record_timestamp?: string;
   iscn_stakeholders?: any;
   /* eslint-enable camelcase */
   [key: string]: any;

--- a/src/util/api/likernft/book/schemas.ts
+++ b/src/util/api/likernft/book/schemas.ts
@@ -352,7 +352,14 @@ export const NFTBookListingInfoFilteredSchema = z.object({
   reviewURL: z.string().optional(),
   keywords: z.array(z.string()).optional(),
   thumbnailUrl: z.string().optional(),
-  author: z.string().optional(),
+  author: z.union([
+    z.string(),
+    z.object({
+      name: z.string().optional(),
+      description: z.string().optional(),
+      url: z.string().optional(),
+    }).passthrough(),
+  ]).optional(),
   usageInfo: z.string().optional(),
   isbn: z.string().optional(),
   genre: z.string().optional(),

--- a/src/util/api/likernft/schemas.ts
+++ b/src/util/api/likernft/schemas.ts
@@ -69,7 +69,7 @@ export const LikeNFTMetadataResponseSchema = z.object({
   youtube_url: z.string().optional(),
   iscn_id: z.string().optional(),
   iscn_owner: z.string().optional(),
-  iscn_record_timestamp: z.number().optional(),
+  iscn_record_timestamp: z.string().optional(),
   iscn_stakeholders: z.any(),
 }).passthrough();
 


### PR DESCRIPTION
Both fields 500'd via RESPONSE_SCHEMA_MISMATCH on real data: author is stored verbatim from ISCN metadata as string or { name, ... } object, and iscn_record_timestamp is an ISO string, not a number. Widen the schemas to match and narrow the source types in lockstep.