### PR TITLE
🐛 Allow null txHash in book purchase response schema

### DIFF
--- a/src/util/api/likernft/book/schemas.ts
+++ b/src/util/api/likernft/book/schemas.ts
@@ -402,7 +402,7 @@ export const BookPurchaseDataFilteredSchema = z.object({
   priceIndex: z.number().int().optional(),
   priceName: z.string().optional(),
   coupon: z.string().optional(),
-  txHash: z.string().optional(),
+  txHash: z.string().nullish(),
   message: z.string().optional(),
   from: z.string().optional(),
   giftInfo: BookGiftInfoSchema.optional(),


### PR DESCRIPTION
Purchase/transaction docs store txHash as null until the on-chain tx is sent, so the messages endpoint 500'd via RESPONSE_SCHEMA_MISMATCH. Widen txHash to .nullish() to match the established pattern and the real data.