### PR TITLE
🐛 Allow 'signed' value for enableSignatureImage in book schema

### DIFF
--- a/src/routes/likernft/book/store.ts
+++ b/src/routes/likernft/book/store.ts
@@ -456,7 +456,7 @@ router.post(['/:classId/price/:priceIndex', '/class/:classId/price/:priceIndex']
     prices.push(newPrice);
 
     const enableCustomMessagePage = docEnableCustomMessagePage
-      || enableSignatureImage
+      || !!enableSignatureImage
       || !!signedMessageText
       || prices.some((p) => !p.isAutoDeliver);
     await updateNftBookInfo(
@@ -558,7 +558,7 @@ router.put(['/:classId/price/:priceIndex', '/class/:classId/price/:priceIndex'],
 
     prices[priceIndex] = newPriceInfo;
     const enableCustomMessagePage = docEnableCustomMessagePage
-      || enableSignatureImage
+      || !!enableSignatureImage
       || !!signedMessageText
       || prices.some((p) => !p.isAutoDeliver);
     await updateNftBookInfo(

--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -142,7 +142,7 @@ export interface NFTBookListingInfo {
   enableCustomMessagePage?: boolean;
   tableOfContents?: any;
   signedMessageText?: string;
-  enableSignatureImage?: boolean;
+  enableSignatureImage?: boolean | 'signed';
   recommendedClassIds?: string[];
   inLanguage?: string;
   name?: string;

--- a/src/util/api/likernft/book/index.ts
+++ b/src/util/api/likernft/book/index.ts
@@ -507,7 +507,7 @@ export async function updateNftBookInfo(classId: string, {
   hideAudio?: boolean;
   hideUpsell?: boolean;
   enableCustomMessagePage?: boolean;
-  enableSignatureImage?: boolean;
+  enableSignatureImage?: boolean | 'signed';
   signedMessageText?: string;
   tableOfContents?: string;
   isAdultOnly?: boolean;

--- a/src/util/api/likernft/book/schemas.ts
+++ b/src/util/api/likernft/book/schemas.ts
@@ -338,7 +338,7 @@ export const NFTBookListingInfoFilteredSchema = z.object({
   enableCustomMessagePage: z.boolean().optional(),
   tableOfContents: z.unknown().optional(),
   signedMessageText: z.string().optional(),
-  enableSignatureImage: z.boolean().optional(),
+  enableSignatureImage: z.union([z.boolean(), z.literal('signed')]).optional(),
   recommendedClassIds: z.array(z.string()).optional(),
   inLanguage: z.string().optional(),
   name: z.string().optional(),


### PR DESCRIPTION
enableSignatureImage is a tri-state (boolean or 'signed' for sign-only books, per ebook-cors), so the book-info response 500'd on the 'signed' string. Widen the schema and source types, and coerce it to boolean where it feeds enableCustomMessagePage.