### PR TITLE
✨ Exclude free books from Plus reading revenue share

### DIFF
--- a/src/util/api/plus/revenueShare.ts
+++ b/src/util/api/plus/revenueShare.ts
@@ -93,6 +93,9 @@ const GRPC_ALREADY_EXISTS = 6;
  * `classId` (a contract address) is lowercased and `readerWallet` is EIP-55 checksummed
  * per repo convention, so casing variants don't split the same book/reader across docs and
  * reader keys match `likeNFTBookUserCollection`/`userCollection` (both checksummed).
+ * Reads of a free book (`minPriceInDecimal === 0`) are recorded as non-library
+ * engagement (publisher stats only): the pool funds paid library reading, so a free
+ * book draws no payout. Settlement ignores the non-library fields, so this keeps it out.
  * An `id` makes the write idempotent (see the receipt in the batch below).
  */
 export async function recordPlusReadingUsage({
@@ -130,12 +133,20 @@ export async function recordPlusReadingUsage({
   const bookDoc = await bookDocRef.get();
   if (!bookDoc.exists) throw new ValidationError('CLASS_ID_NOT_FOUND', 404);
 
+  // Free books aren't rev-share eligible, so fold their reads into the non-library
+  // buckets — recorded for stats but ignored by settlement (`minPriceInDecimal === 0`).
+  const isFreeBook = bookDoc.data()?.minPriceInDecimal === 0;
+  const libraryReadingTimeMs = isFreeBook ? 0 : readingTimeMs;
+  const libraryTtsTimeMs = isFreeBook ? 0 : ttsTimeMs;
+  const statsNonLibraryReadingTimeMs = nonLibraryReadingTimeMs + (isFreeBook ? readingTimeMs : 0);
+  const statsNonLibraryTtsTimeMs = nonLibraryTtsTimeMs + (isFreeBook ? ttsTimeMs : 0);
+
   const dayDocRef = bookDocRef.collection('plusUsage').doc(dayId);
   const readerDocRef = dayDocRef.collection('readers').doc(normalizedReaderWallet);
 
   const usageIncrement = {
-    readingTimeMs: FieldValue.increment(readingTimeMs),
-    ttsTimeMs: FieldValue.increment(ttsTimeMs),
+    readingTimeMs: FieldValue.increment(libraryReadingTimeMs),
+    ttsTimeMs: FieldValue.increment(libraryTtsTimeMs),
     updatedAt: FieldValue.serverTimestamp(),
   };
 
@@ -157,13 +168,13 @@ export async function recordPlusReadingUsage({
   // The day rollup also carries the non-library engagement totals (settlement ignores them).
   batch.set(dayDocRef, {
     ...usageIncrement,
-    nonLibraryReadingTimeMs: FieldValue.increment(nonLibraryReadingTimeMs),
-    nonLibraryTtsTimeMs: FieldValue.increment(nonLibraryTtsTimeMs),
+    nonLibraryReadingTimeMs: FieldValue.increment(statsNonLibraryReadingTimeMs),
+    nonLibraryTtsTimeMs: FieldValue.increment(statsNonLibraryTtsTimeMs),
     dayMs,
   }, { merge: true });
   // Per-reader grain is rev-share audit only — skip it for pure non-library
-  // engagement so non-Plus readers don't each spawn a reader doc.
-  if (readingTimeMs > 0 || ttsTimeMs > 0) {
+  // engagement (including free-book reads) so non-payout reads don't spawn reader docs.
+  if (libraryReadingTimeMs > 0 || libraryTtsTimeMs > 0) {
     batch.set(readerDocRef, usageIncrement, { merge: true });
   }
 

--- a/test/api/plus-reading-usage.test.ts
+++ b/test/api/plus-reading-usage.test.ts
@@ -96,6 +96,34 @@ describe('POST /plus/reading/usage', () => {
     expect(readers.size).toBe(0);
   });
 
+  it('reclassifies free-book reads as non-library engagement (no payout)', async () => {
+    const classId = '0xcdef033333333333333333333333333333333333';
+    // Free book: minPriceInDecimal === 0 → reads fund no rev-share pool.
+    await likeNFTBookCollection.doc(classId)
+      .set({ classId, ownerWallet: OWNER, minPriceInDecimal: 0 } as any);
+
+    const res = await post({
+      readerWallet: READER,
+      classId,
+      readingTimeMs: 1500,
+      ttsTimeMs: 4200,
+      occurredAt: Date.UTC(2026, 2, 12, 8), // 2026-03-12
+    }, AUTH_HEADER);
+    expect(res.status).toBe(200);
+    expect(res.data.results).toEqual([{ dayId: '2026-03-12', applied: true }]);
+
+    const dayDocRef = likeNFTBookCollection.doc(classId).collection('plusUsage').doc('2026-03-12');
+    const day = (await dayDocRef.get()).data() as any;
+    // Library time settlement totals stay 0; engagement is parked under non-library.
+    expect(day.readingTimeMs).toBe(0);
+    expect(day.ttsTimeMs).toBe(0);
+    expect(day.nonLibraryReadingTimeMs).toBe(1500);
+    expect(day.nonLibraryTtsTimeMs).toBe(4200);
+    // No rev-share-eligible time → no per-reader audit doc.
+    const readers = await dayDocRef.collection('readers').get();
+    expect(readers.size).toBe(0);
+  });
+
   it('rejects usage for a class id with no book doc', async () => {
     const orphanClassId = mockEVMAddress(0x44);
     const res = await post({


### PR DESCRIPTION
Free books fund no payout, so reclassify their reads as non-library engagement (publisher stats only) at ingest. Settlement already ignores the non-library fields, keeping free books out of the pool without a second exclusion path. Detected via the denormalized minPriceInDecimal === 0.