### PR TITLE
🐛 Make ownerWallet optional in commission response schema

### DIFF
--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -78,7 +78,7 @@ export type PlusGiftCartDataFiltered = z.infer<typeof PlusGiftCartStatusResponse
 
 export interface BookPurchaseCommission {
   type: string;
-  ownerWallet: string;
+  ownerWallet?: string;
   classId?: string;
   priceIndex?: number;
   collectionId?: string;

--- a/src/util/api/likernft/book/schemas.ts
+++ b/src/util/api/likernft/book/schemas.ts
@@ -416,7 +416,8 @@ export const BookPurchaseDataFilteredSchema = z.object({
 
 export const BookPurchaseCommissionFilteredSchema = z.object({
   type: z.string(),
-  ownerWallet: z.string(),
+  // Legacy commission docs predate the ownerWallet field.
+  ownerWallet: z.string().optional(),
   classId: z.string().optional(),
   priceIndex: z.number().int().optional(),
   collectionId: z.string().optional(),


### PR DESCRIPTION
Legacy commission docs predate the ownerWallet field, causing RESPONSE_SCHEMA_MISMATCH 500s on /book/user/commissions/list. Widen the zod schema and BookPurchaseCommission type in lockstep.