### PR TITLE
🐛 Tolerate legacy partial entries in affiliate config response

### DIFF
--- a/src/util/api/likernft/book/cart.ts
+++ b/src/util/api/likernft/book/cart.ts
@@ -517,10 +517,12 @@ export async function processNFTBookCart(
           promoOwnerDisplayName = ownerLikerInfo.displayName;
           const ownerAffiliateConfig = ownerInfo?.bookUserInfo?.affiliateConfig;
           if (ownerAffiliateConfig?.active && ownerAffiliateConfig.customVoices?.length) {
-            promoOwnerVoices = ownerAffiliateConfig.customVoices.map((v) => ({
-              name: v.name,
-              language: v.language,
-            }));
+            promoOwnerVoices = ownerAffiliateConfig.customVoices
+              .filter((v): v is typeof v & { name: string } => !!v.name)
+              .map((v) => ({
+                name: v.name,
+                language: v.language,
+              }));
           }
         }
       }

--- a/src/util/api/plus/schemas.ts
+++ b/src/util/api/plus/schemas.ts
@@ -76,17 +76,20 @@ export const PlusPortalResponseSchema = z.object({
   url: z.string().url(),
 });
 
+// Fields are optional to tolerate legacy/partial affiliate records: entries
+// saved before these were required must still pass response validation rather
+// than 500 the whole endpoint. Consumers filter out entries they can't use.
 const AffiliateGiftBookSchema = z.object({
-  classId: z.string(),
+  classId: z.string().optional(),
   priceIndex: z.number().int().min(0),
 });
 
 const AffiliateCustomVoiceSchema = z.object({
-  id: z.string(),
-  name: z.string(),
+  id: z.string().optional(),
+  name: z.string().optional(),
   language: z.string().optional(),
   avatarUrl: z.string().optional(),
-  providerVoiceId: z.string(),
+  providerVoiceId: z.string().optional(),
 });
 
 export const AffiliateConfigSchema = z.object({


### PR DESCRIPTION
## Problem

`GET /plus/affiliate/:likerId` was 500ing with `RESPONSE_SCHEMA_MISMATCH` on real data:

```
RESPONSE_SCHEMA_MISMATCH: [{"code":"invalid_type","expected":"string","received":"undefined","path":["giftBooks",1,"classId"],"message":"Required"}]
```

Legacy/partial affiliate records in Firestore can hold gift books without a `classId`, or custom voices missing required string fields (`id`, `name`, `providerVoiceId`). The response schema required those fields, so a **single** malformed entry failed validation in `sendValidatedJSON` and took down the entire endpoint — not just the bad entry.

## Fix

Support the legacy data instead of dropping it: make those fields `.optional()` in `AffiliateGiftBookSchema` / `AffiliateCustomVoiceSchema` so partial entries pass response validation and are forwarded as-is.

- `priceIndex` stays required — the response builder always coerces it with `|| 0`, so the validated response always has a number.
- These schemas are `z.infer` sources for `AffiliateConfig` / `AffiliateGiftBook` / `AffiliateCustomVoice`, so the inferred types widen in lockstep. The only internal consumer that needed adjusting is the promo-voice mapping in `cart.ts`, which now filters out voices with no `name`.

## Consumer compatibility

The `3ook-com` BFF already tolerates partial upstream data — it types `customVoices` as `Partial<AffiliateCustomVoice>[]` and runtime-filters both arrays (`isValidCustomVoice`; `classId` presence for gift books). It keeps what it can render and ignores the rest, so forwarding legacy entries is safe end-to-end.

## Changes

- `src/util/api/plus/schemas.ts` — widen affiliate gift-book / custom-voice fields to optional
- `src/util/api/likernft/book/cart.ts` — guard promo-voice mapping against the now-optional `name`