### PR TITLE
✅ Guard response schemas against legacy book data shapes

### DIFF
--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -3,6 +3,7 @@
 import type { z } from 'zod';
 import type {
   BookContributorSchema,
+  BookSignatureImageSchema,
   BookFreeClaimResponseSchema,
   BookGiftInfoSchema,
   BookPurchaseCommissionFilteredSchema,
@@ -20,6 +21,8 @@ import type {
 export type BookGiftInfo = z.infer<typeof BookGiftInfoSchema>;
 
 export type BookContributor = z.infer<typeof BookContributorSchema>;
+
+export type BookSignatureImage = z.infer<typeof BookSignatureImageSchema>;
 
 export interface BookPurchaseData {
   id?: string;
@@ -145,7 +148,7 @@ export interface NFTBookListingInfo {
   enableCustomMessagePage?: boolean;
   tableOfContents?: any;
   signedMessageText?: string;
-  enableSignatureImage?: boolean | 'signed';
+  enableSignatureImage?: BookSignatureImage;
   recommendedClassIds?: string[];
   inLanguage?: string;
   name?: string;

--- a/src/util/api/likernft/book/index.ts
+++ b/src/util/api/likernft/book/index.ts
@@ -27,7 +27,9 @@ import { getBook3NFTClassPageURL } from '../../../liker-land';
 import { updateAirtablePublicationRecord } from '../../../airtable';
 import { checkIsTrustedPublisher } from './user';
 import { cacheBookFilesFromNFTClassMetadata } from './cache';
-import type { BookContributor, NFTBookListingInfo, NFTBookPrice } from '../../../../types/book';
+import type {
+  BookContributor, BookSignatureImage, NFTBookListingInfo, NFTBookPrice,
+} from '../../../../types/book';
 import { getBookPriceRangeByCurrency, getStripeCurrencyOptionsFromNFTBookPrice } from '../../../pricing';
 
 export function getNameFromMetadata(value: unknown): string {
@@ -507,7 +509,7 @@ export async function updateNftBookInfo(classId: string, {
   hideAudio?: boolean;
   hideUpsell?: boolean;
   enableCustomMessagePage?: boolean;
-  enableSignatureImage?: boolean | 'signed';
+  enableSignatureImage?: BookSignatureImage;
   signedMessageText?: string;
   tableOfContents?: string;
   isAdultOnly?: boolean;

--- a/src/util/api/likernft/book/schemas.ts
+++ b/src/util/api/likernft/book/schemas.ts
@@ -329,6 +329,11 @@ export const BookContributorSchema = z.union([
   }).passthrough(),
 ]);
 
+// `true` once a signature image is attached; the literal 'signed' marks docs whose
+// signature was applied without an uploaded image. Shared so the response schema and
+// the NFTBookListingInfo source type can't drift apart.
+export const BookSignatureImageSchema = z.union([z.boolean(), z.literal('signed')]);
+
 export const NFTBookListingInfoFilteredSchema = z.object({
   id: z.string(),
   classId: z.string(),
@@ -348,7 +353,7 @@ export const NFTBookListingInfoFilteredSchema = z.object({
   enableCustomMessagePage: z.boolean().optional(),
   tableOfContents: z.unknown().optional(),
   signedMessageText: z.string().optional(),
-  enableSignatureImage: z.union([z.boolean(), z.literal('signed')]).optional(),
+  enableSignatureImage: BookSignatureImageSchema.optional(),
   recommendedClassIds: z.array(z.string()).optional(),
   inLanguage: z.string().optional(),
   name: z.string().optional(),

--- a/test/unit/response-schemas.test.ts
+++ b/test/unit/response-schemas.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import type { ZodTypeAny } from 'zod';
+
+import {
+  filterNFTBookListingInfo,
+  filterBookPurchaseData,
+  filterBookPurchaseCommission,
+  filterLikeNFTMetadata,
+  filterLikeNFTISCNData,
+} from '../../src/util/ValidationHelper';
+import {
+  BookContributorSchema,
+  NFTBookListingInfoFilteredSchema,
+  BookPurchaseDataFilteredSchema,
+  BookPurchaseCommissionFilteredSchema,
+} from '../../src/util/api/likernft/book/schemas';
+import {
+  LikeNFTMetadataResponseSchema,
+  LikeNFTISCNDataResponseSchema,
+} from '../../src/util/api/likernft/schemas';
+import {
+  AffiliateConfigSchema,
+  PlusAffiliateResponseSchema,
+} from '../../src/util/api/plus/schemas';
+
+// Regression guard for the recurring "response schema stricter than real data" 500s.
+// Each case reproduces a legacy/partial Firestore shape that 500'd a live endpoint
+// (see the matching 🐛 fix commit) and asserts the schema now accepts it. Where a
+// filter function sits in front of the schema, we run the real filter→schema path so
+// the test fails if either side drifts back to being too strict.
+
+// Firestore Timestamp stand-in: the filters call `.toMillis()`.
+const ts = (millis: number) => ({ toMillis: () => millis });
+
+function expectParses(schema: ZodTypeAny, data: unknown) {
+  const result = schema.safeParse(data);
+  // Assert on the issues so a failure prints what was rejected, not a bare `false`.
+  expect(result.error?.issues ?? []).toEqual([]);
+}
+
+describe('Response schema ↔ legacy data alignment', () => {
+  describe('BookContributorSchema (author/publisher: legacy string vs newer object)', () => {
+    it('accepts a legacy plain-string contributor', () => {
+      expectParses(BookContributorSchema, 'Some Author Name');
+    });
+    it('accepts a newer object contributor with extra keys', () => {
+      expectParses(BookContributorSchema, { name: 'Author', url: 'https://x', extra: 1 });
+    });
+  });
+
+  describe('NFTBookListingInfoFilteredSchema (filter→schema)', () => {
+    it('accepts a legacy doc: string author, object publisher, signed signature, no approval flags', () => {
+      const legacyDoc: any = {
+        classId: 'class-legacy',
+        ownerWallet: '0xowner',
+        // author stored verbatim from ISCN metadata as a plain string (commit d8bf8115)
+        author: 'Legacy Author String',
+        // publisher as object (commit 8ebf307f)
+        publisher: { name: 'Legacy Publisher', url: 'https://pub' },
+        // enableSignatureImage can be the literal 'signed' (commit acc088fc)
+        enableSignatureImage: 'signed',
+        timestamp: ts(1700000000000),
+        // approval flags absent on old books — filter defaults them to true
+      };
+      expectParses(NFTBookListingInfoFilteredSchema, filterNFTBookListingInfo(legacyDoc, true));
+    });
+  });
+
+  describe('BookPurchaseDataFilteredSchema (filter→schema)', () => {
+    it('accepts a purchase doc with null txHash and no timestamp', () => {
+      // null txHash (commit 0769894f); quantity defaulted by the filter
+      const doc: any = { id: 'p1', classId: 'class-1', txHash: null };
+      expectParses(BookPurchaseDataFilteredSchema, filterBookPurchaseData(doc));
+    });
+  });
+
+  describe('BookPurchaseCommissionFilteredSchema (filter→schema)', () => {
+    it('accepts a legacy commission doc missing ownerWallet', () => {
+      // ownerWallet predates legacy commission docs (commit 4d34d746)
+      const doc: any = {
+        type: 'royalty',
+        paymentId: 'pay-1',
+        amountTotal: 1000,
+        amount: 300,
+        currency: 'usd',
+        timestamp: ts(1700000000000),
+      };
+      expectParses(BookPurchaseCommissionFilteredSchema, filterBookPurchaseCommission(doc));
+    });
+  });
+
+  describe('LikeNFTMetadataResponseSchema (filter→schema)', () => {
+    it('accepts ISO-string iscn_record_timestamp and passes through extra keys', () => {
+      // iscn_record_timestamp is an ISO string, not a number (commit d8bf8115)
+      const meta: any = {
+        name: 'NFT',
+        iscnId: 'iscn://x',
+        iscnRecordTimestamp: '2024-01-01T00:00:00Z',
+        customKey: 'kept by passthrough',
+      };
+      expectParses(LikeNFTMetadataResponseSchema, filterLikeNFTMetadata(meta));
+    });
+  });
+
+  describe('LikeNFTISCNDataResponseSchema (filter→schema)', () => {
+    it('accepts a minimal ISCN doc with only required fields', () => {
+      const doc: any = { iscnId: 'iscn://x', classId: 'class-1' };
+      expectParses(LikeNFTISCNDataResponseSchema, filterLikeNFTISCNData(doc));
+    });
+  });
+
+  describe('AffiliateConfig / PlusAffiliateResponseSchema (inline-built)', () => {
+    it('tolerates a gift book without classId and a custom voice missing fields', () => {
+      // legacy partial affiliate entries (commit 117c4731)
+      const config = {
+        active: true as const,
+        affiliateClassIds: [],
+        affiliatePublisherWallets: [],
+        giftBooks: [{ priceIndex: 0 }], // no classId
+        giftOnTrial: false,
+        customVoices: [{}], // missing every optional field
+      };
+      expectParses(AffiliateConfigSchema, config);
+      expectParses(PlusAffiliateResponseSchema, { ...config, isPlusDiscountAllowed: true });
+    });
+
+    it('still accepts the inactive-affiliate variant of the discriminated union', () => {
+      expectParses(PlusAffiliateResponseSchema, { active: false, isPlusDiscountAllowed: false });
+    });
+  });
+});


### PR DESCRIPTION
Add a regression test that runs the legacy/partial Firestore shapes from the recent run of schema fixes (string author, object publisher, 'signed' signature, null txHash, missing ownerWallet, ISO iscn timestamp, partial affiliate entries) through the real filter→schema path, so a future over-strict schema fails a test instead of 500ing in prod.

Also single-source the enableSignatureImage union as BookSignatureImageSchema, mirroring BookContributorSchema, so the response schema and the NFTBookListingInfo source type can no longer drift apart.