### PR TITLE
✨ Prefer author for Meta catalog brand, add author/publisher labels

### DIFF
--- a/src/util/api/likernft/book/metaCatalog.ts
+++ b/src/util/api/likernft/book/metaCatalog.ts
@@ -11,10 +11,10 @@ import type { NFTBookListingInfo, NFTBookPrice } from '../../../../types/book';
 
 const META_CATALOG_LOCALE = 'en';
 // Per Meta's catalog spec, `brand` should be the product's real brand, not the
-// storefront name. For books the brand convention is the publisher/imprint, so
-// prefer publisher, fall back to author (self-published), then `3ook.com` as a
-// last resort. Category mirrors `product:category` in liker-land-v3's
-// use-structured-data.ts.
+// storefront name. On an independent-author storefront the author is the
+// strongest brand signal, so prefer author, fall back to publisher/imprint,
+// then `3ook.com` as a last resort. Category mirrors `product:category` in
+// liker-land-v3's use-structured-data.ts.
 const META_CATALOG_FALLBACK_BRAND = '3ook.com';
 const META_CATALOG_GOOGLE_PRODUCT_CATEGORY = 'Media > Books > E-Books';
 // `fb_product_category` uses Meta's own product taxonomy (distinct from Google's
@@ -41,6 +41,8 @@ export interface MetaCatalogItem {
   fb_product_category: string;
   gtin?: string;
   custom_label_0?: string;
+  custom_label_1?: string;
+  custom_label_2?: string;
 }
 /* eslint-enable camelcase */
 
@@ -65,6 +67,8 @@ const META_CATALOG_CSV_COLUMNS: Array<keyof MetaCatalogItem> = [
   'item_group_id',
   'gtin',
   'custom_label_0',
+  'custom_label_1',
+  'custom_label_2',
 ];
 /* eslint-enable camelcase */
 
@@ -99,7 +103,7 @@ function buildItem(
   const inStock = price.isAutoDeliver || price.stock === undefined || price.stock > 0;
   const author = getAuthorNameFromMetadata(book.author);
   const publisher = getPublisherNameFromMetadata(book.publisher);
-  const brand = publisher || author || META_CATALOG_FALLBACK_BRAND;
+  const brand = author || publisher || META_CATALOG_FALLBACK_BRAND;
 
   const item: MetaCatalogItem = {
     id: buildItemId(classId, priceIndex),
@@ -117,6 +121,10 @@ function buildItem(
   };
   // Mirrors `product:custom_label_0` in liker-land-v3 (owner wallet address).
   if (book.ownerWallet) item.custom_label_0 = book.ownerWallet;
+  // Expose author/publisher as their own labels (separate from `brand`) so both
+  // stay filterable in Commerce Manager regardless of which won the brand slot.
+  if (author) item.custom_label_1 = author;
+  if (publisher) item.custom_label_2 = publisher;
   // `book.isbn` holds an ISBN, and only ISBN-13 (13 digits) is a valid GTIN.
   // Normalize to bare digits and drop hyphenated/ISBN-10/malformed values
   // rather than risk Meta feed validation errors.
@@ -153,7 +161,8 @@ export async function getMetaProductCatalogItems(): Promise<MetaCatalogItem[]> {
 }
 
 // Defang spreadsheet formula injection (CWE-1236): publisher-supplied fields
-// (title/description/brand) could start with a formula trigger. Meta ingests
+// (title/description/brand/author/publisher) could start with a formula trigger.
+// Meta ingests
 // the value as-is, but an admin opening the downloaded feed in Excel/Sheets
 // would otherwise evaluate it. Prefix a single quote per OWASP, before the
 // RFC 4180 quoting below so quoted cells are defanged too.

--- a/src/util/api/likernft/book/schemas.ts
+++ b/src/util/api/likernft/book/schemas.ts
@@ -554,6 +554,8 @@ export const BookCatalogMetaResponseSchema = z.object({
     fb_product_category: z.string(),
     gtin: z.string().optional(),
     custom_label_0: z.string().optional(),
+    custom_label_1: z.string().optional(),
+    custom_label_2: z.string().optional(),
   })),
 });
 

--- a/test/unit/meta-catalog.test.ts
+++ b/test/unit/meta-catalog.test.ts
@@ -81,7 +81,7 @@ describe('getMetaProductCatalogItems', () => {
     expect(item.link).toContain('/store/class-a');
   });
 
-  it('falls back brand to publisher, then 3ook.com, and drops invalid GTINs', async () => {
+  it('uses author when present; otherwise falls back brand to publisher, then 3ook.com, and drops invalid GTINs', async () => {
     setBooks([
       {
         id: 'class-f',

--- a/test/unit/meta-catalog.test.ts
+++ b/test/unit/meta-catalog.test.ts
@@ -67,18 +67,21 @@ describe('getMetaProductCatalogItems', () => {
     expect(item.availability).toBe('in stock');
     expect(item.condition).toBe('new');
     expect(item.price).toBe('15.00 USD');
-    // publisher wins over author for `brand`
-    expect(item.brand).toBe('Penguin');
+    // author wins over publisher for `brand`
+    expect(item.brand).toBe('Jane Doe');
     expect(item.item_group_id).toBe('class-a');
     expect(item.google_product_category).toBe('Media > Books > E-Books');
     expect(item.fb_product_category).toBe('Media > Books');
     // hyphenated ISBN-13 normalized to a 13-digit GTIN
     expect(item.gtin).toBe('9783161484100');
     expect(item.custom_label_0).toBe('0xabc');
+    // author and publisher emitted as their own labels regardless of brand
+    expect(item.custom_label_1).toBe('Jane Doe');
+    expect(item.custom_label_2).toBe('Penguin');
     expect(item.link).toContain('/store/class-a');
   });
 
-  it('falls back brand to author, then 3ook.com, and drops invalid GTINs', async () => {
+  it('falls back brand to publisher, then 3ook.com, and drops invalid GTINs', async () => {
     setBooks([
       {
         id: 'class-f',
@@ -90,6 +93,16 @@ describe('getMetaProductCatalogItems', () => {
         ownerWallet: '0xfff',
         description: 'short',
         prices: [{ priceInDecimal: 999, stock: 0, isAutoDeliver: false }],
+      },
+      {
+        id: 'class-p',
+        classId: 'class-p',
+        name: 'Imprint Work',
+        image: 'https://img.example/p.jpg',
+        publisher: 'Penguin', // no author → publisher
+        ownerWallet: '0xppp',
+        description: 'desc',
+        prices: [{ priceInDecimal: 700, stock: 2 }],
       },
       {
         id: 'class-i',
@@ -110,6 +123,10 @@ describe('getMetaProductCatalogItems', () => {
     expect(solo?.availability).toBe('out of stock');
     expect(solo?.price).toBe('9.99 USD');
     expect(solo?.title).toBe('Solo Work');
+
+    const imprint = items.find((i) => i.id === 'class-p-0');
+    expect(imprint?.brand).toBe('Penguin');
+    expect(imprint?.custom_label_2).toBe('Penguin');
 
     const anon = items.find((i) => i.id === 'class-i-0');
     expect(anon?.brand).toBe('3ook.com');
@@ -171,19 +188,22 @@ describe('formatMetaProductCatalogCSV', () => {
     price: '15.00 USD',
     link: 'https://3ook.com/store/class-a?priceIndex=0',
     image_link: 'https://img.example/a.jpg',
-    brand: 'Penguin',
+    brand: 'Jane Doe',
     item_group_id: 'class-a',
     google_product_category: 'Media > Books > E-Books',
     fb_product_category: 'Media > Books',
     gtin: '9783161484100',
     custom_label_0: '0xabc',
+    custom_label_1: 'Jane Doe',
+    custom_label_2: 'Penguin',
   };
 
   it('emits the template header in column order', () => {
     const [header] = formatMetaProductCatalogCSV([]).split('\n');
     expect(header).toBe(
       'id,title,description,availability,condition,price,link,image_link,brand,'
-      + 'google_product_category,fb_product_category,item_group_id,gtin,custom_label_0',
+      + 'google_product_category,fb_product_category,item_group_id,gtin,'
+      + 'custom_label_0,custom_label_1,custom_label_2',
     );
   });
 
@@ -191,8 +211,8 @@ describe('formatMetaProductCatalogCSV', () => {
     const [, row] = formatMetaProductCatalogCSV([baseItem]).split('\n');
     expect(row).toBe(
       'class-a-0,The Great Book,Full description,in stock,new,15.00 USD,'
-      + 'https://3ook.com/store/class-a?priceIndex=0,https://img.example/a.jpg,Penguin,'
-      + 'Media > Books > E-Books,Media > Books,class-a,9783161484100,0xabc',
+      + 'https://3ook.com/store/class-a?priceIndex=0,https://img.example/a.jpg,Jane Doe,'
+      + 'Media > Books > E-Books,Media > Books,class-a,9783161484100,0xabc,Jane Doe,Penguin',
     );
   });
 
@@ -222,8 +242,10 @@ describe('formatMetaProductCatalogCSV', () => {
     const withoutOptional: MetaCatalogItem = { ...baseItem };
     delete withoutOptional.gtin;
     delete withoutOptional.custom_label_0;
+    delete withoutOptional.custom_label_1;
+    delete withoutOptional.custom_label_2;
     const [, row] = formatMetaProductCatalogCSV([withoutOptional]).split('\n');
-    // trailing gtin and custom_label_0 columns are empty
-    expect(row.endsWith('class-a,,')).toBe(true);
+    // trailing gtin and custom_label_0/1/2 columns are empty
+    expect(row.endsWith('class-a,,,,')).toBe(true);
   });
 });


### PR DESCRIPTION
Flip `brand` to prefer author over publisher (stronger signal on an independent-author storefront), and emit author/publisher as custom_label_1/2 so neither is lost to the fallback. Add both fields to BookCatalogMetaResponseSchema so the JSON feed doesn't strip them.