### PR TITLE
✨ Add OpenAI product catalog feed for book listings

### DIFF
--- a/src/routes/likernft/book/store.ts
+++ b/src/routes/likernft/book/store.ts
@@ -34,8 +34,10 @@ import {
   BookClassIdPriceIndexParamsSchema,
   BookSearchQuerySchema,
   BookListQuerySchema,
-  BookCatalogMetaQuerySchema,
+  BookCatalogQuerySchema,
   BookCatalogMetaResponseSchema,
+  BookCatalogOpenAIResponseSchema,
+  BookCatalogOpenAIFeedResponseSchema,
   BookListResponseSchema,
   BookListModeratedResponseSchema,
   BookSearchResponseSchema,
@@ -88,6 +90,11 @@ import {
 } from '../../../util/pricing';
 import { cacheBookFilesFromNFTClassMetadata } from '../../../util/api/likernft/book/cache';
 import { getMetaProductCatalogItems, formatMetaProductCatalogCSV } from '../../../util/api/likernft/book/metaCatalog';
+import {
+  getOpenAIProductCatalogItems,
+  getOpenAIFeedItems,
+  formatOpenAIFeedCSV,
+} from '../../../util/api/likernft/book/openaiCatalog';
 import { normalizeClassIdParam } from '../../../middleware/likernft';
 
 const router = Router();
@@ -127,7 +134,7 @@ router.get('/search', validateQuery(BookSearchQuerySchema), async (req, res, nex
   }
 });
 
-router.get('/catalog/meta', validateQuery(BookCatalogMetaQuerySchema), async (req, res, next) => {
+router.get('/catalog/meta', validateQuery(BookCatalogQuerySchema), async (req, res, next) => {
   try {
     const items = await getMetaProductCatalogItems();
     res.set('Cache-Control', `public, max-age=${ONE_HOUR_IN_S}, s-maxage=${ONE_HOUR_IN_S}, stale-while-revalidate=${ONE_DAY_IN_S}, stale-if-error=${ONE_DAY_IN_S}`);
@@ -138,6 +145,30 @@ router.get('/catalog/meta', validateQuery(BookCatalogMetaQuerySchema), async (re
       return;
     }
     sendValidatedJSON(res, BookCatalogMetaResponseSchema, { items });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Search-only OpenAI catalog. `format` selects the representation, mirroring
+// the Meta route: default → flat file-upload feed (JSON), `csv` → that feed as
+// CSV, `api` → the nested API model (Product → Variant) JSON.
+router.get('/catalog/openai', validateQuery(BookCatalogQuerySchema), async (req, res, next) => {
+  try {
+    res.set('Cache-Control', `public, max-age=${ONE_HOUR_IN_S}, s-maxage=${ONE_HOUR_IN_S}, stale-while-revalidate=${ONE_DAY_IN_S}, stale-if-error=${ONE_DAY_IN_S}`);
+    if (req.query.format === 'api') {
+      const products = await getOpenAIProductCatalogItems();
+      sendValidatedJSON(res, BookCatalogOpenAIResponseSchema, { products });
+      return;
+    }
+    const items = await getOpenAIFeedItems();
+    if (req.query.format === 'csv') {
+      res.type('text/csv; charset=utf-8');
+      res.set('Content-Disposition', 'attachment; filename="openai-catalog.csv"');
+      res.send(formatOpenAIFeedCSV(items));
+      return;
+    }
+    sendValidatedJSON(res, BookCatalogOpenAIFeedResponseSchema, { products: items });
   } catch (err) {
     next(err);
   }

--- a/src/routes/likernft/book/store.ts
+++ b/src/routes/likernft/book/store.ts
@@ -38,6 +38,7 @@ import {
   BookCatalogMetaResponseSchema,
   BookCatalogOpenAIResponseSchema,
   BookCatalogOpenAIFeedResponseSchema,
+  BookCatalogStripeResponseSchema,
   BookListResponseSchema,
   BookListModeratedResponseSchema,
   BookSearchResponseSchema,
@@ -95,6 +96,7 @@ import {
   getOpenAIFeedItems,
   formatOpenAIFeedCSV,
 } from '../../../util/api/likernft/book/openaiCatalog';
+import { getStripeFeedItems, formatStripeFeedCSV } from '../../../util/api/likernft/book/stripeCatalog';
 import { normalizeClassIdParam } from '../../../middleware/likernft';
 
 const router = Router();
@@ -169,6 +171,25 @@ router.get('/catalog/openai', validateQuery(BookCatalogQuerySchema), async (req,
       return;
     }
     sendValidatedJSON(res, BookCatalogOpenAIFeedResponseSchema, { products: items });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Stripe Agentic Commerce product feed (Google-Shopping field dialect, uploaded
+// via Stripe's product_catalog import API). Mirrors the Meta route: default
+// JSON, `csv` returns the upload file.
+router.get('/catalog/stripe', validateQuery(BookCatalogQuerySchema), async (req, res, next) => {
+  try {
+    const items = await getStripeFeedItems();
+    res.set('Cache-Control', `public, max-age=${ONE_HOUR_IN_S}, s-maxage=${ONE_HOUR_IN_S}, stale-while-revalidate=${ONE_DAY_IN_S}, stale-if-error=${ONE_DAY_IN_S}`);
+    if (req.query.format === 'csv') {
+      res.type('text/csv; charset=utf-8');
+      res.set('Content-Disposition', 'attachment; filename="stripe-catalog.csv"');
+      res.send(formatStripeFeedCSV(items));
+      return;
+    }
+    sendValidatedJSON(res, BookCatalogStripeResponseSchema, { products: items });
   } catch (err) {
     next(err);
   }

--- a/src/util/api/likernft/book/catalogCSV.ts
+++ b/src/util/api/likernft/book/catalogCSV.ts
@@ -1,0 +1,28 @@
+// Shared CSV serialization for product-catalog feeds (Meta, OpenAI file-upload).
+// Centralizes the security-sensitive escaping so it can't drift between feeds.
+
+// Defang spreadsheet formula injection (CWE-1236): publisher-supplied fields
+// (title/description/brand) could start with a formula trigger. The platform
+// ingests the value as-is, but an admin opening the downloaded feed in
+// Excel/Sheets would otherwise evaluate it. Prefix a single quote per OWASP,
+// before the RFC 4180 quoting below so quoted cells are defanged too. Allow for
+// leading whitespace before the trigger, since spreadsheet apps trim it before
+// evaluating (so " =1+1" is still treated as a formula).
+// RFC 4180: wrap a field in double quotes when it contains a comma, quote, or
+// line break, and escape embedded quotes by doubling them. Book descriptions
+// routinely contain all three, so this keeps columns from shifting.
+export function escapeCSVField(value: string | undefined): string {
+  if (!value) return '';
+  const defanged = /^\s*[=+\-@]/.test(value) ? `'${value}` : value;
+  return /[",\r\n]/.test(defanged) ? `"${defanged.replace(/"/g, '""')}"` : defanged;
+}
+
+// Emit a header row in column order followed by one row per item. Items are
+// expected to hold string (or undefined) values; absent columns render empty.
+export function buildCatalogCSV<T>(columns: Array<keyof T>, items: T[]): string {
+  const header = columns.join(',');
+  const rows = items.map((item) => columns
+    .map((col) => escapeCSVField(item[col] as unknown as string | undefined))
+    .join(','));
+  return `${header}\n${rows.join('\n')}`;
+}

--- a/src/util/api/likernft/book/catalogSource.ts
+++ b/src/util/api/likernft/book/catalogSource.ts
@@ -1,0 +1,88 @@
+import {
+  listLatestNFTBookInfo,
+  getLocalizedTextWithFallback,
+  getAuthorNameFromMetadata,
+  getPublisherNameFromMetadata,
+} from './index';
+import type { NFTBookListingInfo, NFTBookPrice } from '../../../../types/book';
+
+// Shared building blocks for product-catalog feeds (Meta, OpenAI). Each feed
+// maps the same eligible books into its own schema, so keeping the fetch,
+// filter, and per-variant helpers here stops the eligibility, stock, GTIN,
+// price and brand rules from drifting apart between feeds.
+const CATALOG_LOCALE = 'en';
+const CATALOG_FALLBACK_BRAND = '3ook.com';
+
+// Per the catalog specs, `brand` should be the product's real brand, not the
+// storefront name. On an independent-author storefront the author is the
+// strongest brand signal, so prefer author, fall back to publisher/imprint,
+// then 3ook.com. Returns author/publisher too so feeds can also expose them
+// as their own labels.
+export function resolveCatalogBrand(book: NFTBookListingInfo): {
+  author: string;
+  publisher: string;
+  brand: string;
+} {
+  const author = getAuthorNameFromMetadata(book.author);
+  const publisher = getPublisherNameFromMetadata(book.publisher);
+  return { author, publisher, brand: author || publisher || CATALOG_FALLBACK_BRAND };
+}
+
+// `price.stock` is a remaining counter (decremented at sale time in
+// purchase.ts), not a total. Mirrors the sold-out check in cart.ts and
+// ValidationHelper.ts (which express it as the inverse, isOutOfStock).
+export function isBookPriceInStock(price: NFTBookPrice): boolean {
+  return price.isAutoDeliver || price.stock === undefined || price.stock > 0;
+}
+
+export function getCatalogVariantTitle(baseTitle: string, price: NFTBookPrice): string {
+  const priceName = price.name
+    ? getLocalizedTextWithFallback(price.name, CATALOG_LOCALE)
+    : '';
+  return priceName ? `${baseTitle} - ${priceName}` : baseTitle;
+}
+
+// priceInDecimal is USD minor units (cents); feeds that want a display string
+// use "<amount> USD" (the API model uses the raw integer instead).
+export function formatCatalogPriceUSD(price: NFTBookPrice): string {
+  return `${(price.priceInDecimal / 100).toFixed(2)} USD`;
+}
+
+// `book.isbn` holds an ISBN; only ISBN-13 (13 digits) is a valid GTIN. Strip
+// hyphens and drop ISBN-10/malformed values rather than risk feed rejection.
+export function normalizeISBNToGTIN(isbn?: string): string | undefined {
+  if (!isbn) return undefined;
+  const gtin = isbn.replace(/\D/g, '');
+  return gtin.length === 13 ? gtin : undefined;
+}
+
+// Meta limits a single catalog feed to 200k products and OpenAI similarly
+// bounds feed size; books listings are nowhere near that today, but cap
+// defensively to keep the response bounded.
+export const CATALOG_MAX_BOOKS = 5000;
+
+export interface CatalogBook {
+  book: NFTBookListingInfo;
+  classId: string;
+}
+
+export async function listCatalogEligibleBooks(): Promise<CatalogBook[]> {
+  const books = await listLatestNFTBookInfo({
+    chain: 'base',
+    limit: CATALOG_MAX_BOOKS,
+  });
+  const result: CatalogBook[] = [];
+  books.forEach((book) => {
+    const data = book as NFTBookListingInfo;
+    // `isApprovedForAds === false` is an explicit admin denial; `undefined` means legacy/unset
+    // and defaults to approved (see ValidationHelper.ts), so we filter only on the explicit false.
+    if (
+      data.isHidden
+      || data.redirectClassId
+      || data.isAdultOnly
+      || data.isApprovedForAds === false
+    ) return;
+    result.push({ book: data, classId: data.classId || book.id });
+  });
+  return result;
+}

--- a/src/util/api/likernft/book/catalogSource.ts
+++ b/src/util/api/likernft/book/catalogSource.ts
@@ -1,3 +1,6 @@
+import { getBook3NFTClassPageURL } from '../../../liker-land';
+import { parseImageURLFromMetadata } from '../metadata';
+import { buildItemId } from '../../../analyticsEvents';
 import {
   listLatestNFTBookInfo,
   getLocalizedTextWithFallback,
@@ -85,4 +88,72 @@ export async function listCatalogEligibleBooks(): Promise<CatalogBook[]> {
     result.push({ book: data, classId: data.classId || book.id });
   });
   return result;
+}
+
+// A single sellable variant, normalized once so the flat feeds (Meta, OpenAI,
+// Stripe) are pure schema mappers and share one definition of which variants
+// are valid (listed, positively priced, on a book with a name and image).
+export interface CatalogVariant {
+  book: NFTBookListingInfo;
+  classId: string;
+  priceIndex: number;
+  price: NFTBookPrice;
+  id: string;
+  title: string;
+  baseTitle: string;
+  description: string;
+  link: string;
+  image: string;
+  brand: string;
+  author: string;
+  publisher: string;
+  inStock: boolean;
+  priceUSD: string;
+  hasVariations: boolean;
+  gtin?: string;
+}
+
+export async function listCatalogVariants(): Promise<CatalogVariant[]> {
+  const books = await listCatalogEligibleBooks();
+  const variants: CatalogVariant[] = [];
+  books.forEach(({ book, classId }) => {
+    const baseTitle = book.name;
+    if (!baseTitle) return;
+    const imageSource = book.image || book.thumbnailUrl;
+    if (!imageSource) return;
+    const image = parseImageURLFromMetadata(imageSource);
+    const { author, publisher, brand } = resolveCatalogBrand(book);
+    const description = book.descriptionFull || book.description || baseTitle;
+    const gtin = normalizeISBNToGTIN(book.isbn);
+    // Keep the original priceIndex (used for ids/URLs) while filtering to the
+    // sellable prices, so hasVariations reflects emitted variants, not raw count.
+    const eligiblePrices = (book.prices || [])
+      .map((price, priceIndex) => ({ price, priceIndex }))
+      .filter(({ price }) => !price.isUnlisted
+        && Number.isFinite(price.priceInDecimal)
+        && price.priceInDecimal > 0);
+    const hasVariations = eligiblePrices.length > 1;
+    eligiblePrices.forEach(({ price, priceIndex }) => {
+      variants.push({
+        book,
+        classId,
+        priceIndex,
+        price,
+        id: buildItemId(classId, priceIndex),
+        title: getCatalogVariantTitle(baseTitle, price),
+        baseTitle,
+        description,
+        link: getBook3NFTClassPageURL({ classId, priceIndex }),
+        image,
+        brand,
+        author,
+        publisher,
+        inStock: isBookPriceInStock(price),
+        priceUSD: formatCatalogPriceUSD(price),
+        hasVariations,
+        gtin,
+      });
+    });
+  });
+  return variants;
 }

--- a/src/util/api/likernft/book/metaCatalog.ts
+++ b/src/util/api/likernft/book/metaCatalog.ts
@@ -1,16 +1,6 @@
-import { getBook3NFTClassPageURL } from '../../../liker-land';
-import { parseImageURLFromMetadata } from '../metadata';
-import { buildItemId } from '../../../analyticsEvents';
-import {
-  listCatalogEligibleBooks,
-  isBookPriceInStock,
-  getCatalogVariantTitle,
-  formatCatalogPriceUSD,
-  normalizeISBNToGTIN,
-  resolveCatalogBrand,
-} from './catalogSource';
+import { listCatalogVariants } from './catalogSource';
+import type { CatalogVariant } from './catalogSource';
 import { buildCatalogCSV } from './catalogCSV';
-import type { NFTBookListingInfo, NFTBookPrice } from '../../../../types/book';
 // Category mirrors `product:category` in liker-land-v3's use-structured-data.ts.
 const META_CATALOG_GOOGLE_PRODUCT_CATEGORY = 'Media > Books > E-Books';
 // `fb_product_category` uses Meta's own product taxonomy (distinct from Google's
@@ -65,59 +55,34 @@ const META_CATALOG_CSV_COLUMNS: Array<keyof MetaCatalogItem> = [
 ];
 /* eslint-enable camelcase */
 
-function buildItem(
-  book: NFTBookListingInfo,
-  classId: string,
-  price: NFTBookPrice,
-  priceIndex: number,
-): MetaCatalogItem | null {
-  if (price.isUnlisted) return null;
-  if (!Number.isFinite(price.priceInDecimal) || price.priceInDecimal <= 0) return null;
-  const baseTitle = book.name;
-  if (!baseTitle) return null;
-  const imageSource = book.image || book.thumbnailUrl;
-  if (!imageSource) return null;
-  const image = parseImageURLFromMetadata(imageSource);
-
-  const description = book.descriptionFull || book.description || baseTitle;
-  const inStock = isBookPriceInStock(price);
-  const { author, publisher, brand } = resolveCatalogBrand(book);
-
+function buildItem(v: CatalogVariant): MetaCatalogItem {
   const item: MetaCatalogItem = {
-    id: buildItemId(classId, priceIndex),
-    title: getCatalogVariantTitle(baseTitle, price),
-    description,
-    availability: inStock ? 'in stock' : 'out of stock',
+    id: v.id,
+    title: v.title,
+    description: v.description,
+    availability: v.inStock ? 'in stock' : 'out of stock',
     condition: 'new',
-    price: formatCatalogPriceUSD(price),
-    link: getBook3NFTClassPageURL({ classId, priceIndex }),
-    image_link: image,
-    brand,
-    item_group_id: classId,
+    price: v.priceUSD,
+    link: v.link,
+    image_link: v.image,
+    brand: v.brand,
+    item_group_id: v.classId,
     google_product_category: META_CATALOG_GOOGLE_PRODUCT_CATEGORY,
     fb_product_category: META_CATALOG_FB_PRODUCT_CATEGORY,
   };
   // Mirrors `product:custom_label_0` in liker-land-v3 (owner wallet address).
-  if (book.ownerWallet) item.custom_label_0 = book.ownerWallet;
+  if (v.book.ownerWallet) item.custom_label_0 = v.book.ownerWallet;
   // Expose author/publisher as their own labels (separate from `brand`) so both
   // stay filterable in Commerce Manager regardless of which won the brand slot.
-  if (author) item.custom_label_1 = author;
-  if (publisher) item.custom_label_2 = publisher;
-  const gtin = normalizeISBNToGTIN(book.isbn);
-  if (gtin) item.gtin = gtin;
+  if (v.author) item.custom_label_1 = v.author;
+  if (v.publisher) item.custom_label_2 = v.publisher;
+  if (v.gtin) item.gtin = v.gtin;
   return item;
 }
 
 export async function getMetaProductCatalogItems(): Promise<MetaCatalogItem[]> {
-  const books = await listCatalogEligibleBooks();
-  const items: MetaCatalogItem[] = [];
-  books.forEach(({ book, classId }) => {
-    (book.prices || []).forEach((p, priceIndex) => {
-      const item = buildItem(book, classId, p, priceIndex);
-      if (item) items.push(item);
-    });
-  });
-  return items;
+  const variants = await listCatalogVariants();
+  return variants.map(buildItem);
 }
 
 export function formatMetaProductCatalogCSV(items: MetaCatalogItem[]): string {

--- a/src/util/api/likernft/book/metaCatalog.ts
+++ b/src/util/api/likernft/book/metaCatalog.ts
@@ -2,28 +2,21 @@ import { getBook3NFTClassPageURL } from '../../../liker-land';
 import { parseImageURLFromMetadata } from '../metadata';
 import { buildItemId } from '../../../analyticsEvents';
 import {
-  getAuthorNameFromMetadata,
-  getPublisherNameFromMetadata,
-  getLocalizedTextWithFallback,
-  listLatestNFTBookInfo,
-} from './index';
+  listCatalogEligibleBooks,
+  isBookPriceInStock,
+  getCatalogVariantTitle,
+  formatCatalogPriceUSD,
+  normalizeISBNToGTIN,
+  resolveCatalogBrand,
+} from './catalogSource';
+import { buildCatalogCSV } from './catalogCSV';
 import type { NFTBookListingInfo, NFTBookPrice } from '../../../../types/book';
-
-const META_CATALOG_LOCALE = 'en';
-// Per Meta's catalog spec, `brand` should be the product's real brand, not the
-// storefront name. On an independent-author storefront the author is the
-// strongest brand signal, so prefer author, fall back to publisher/imprint,
-// then `3ook.com` as a last resort. Category mirrors `product:category` in
-// liker-land-v3's use-structured-data.ts.
-const META_CATALOG_FALLBACK_BRAND = '3ook.com';
+// Category mirrors `product:category` in liker-land-v3's use-structured-data.ts.
 const META_CATALOG_GOOGLE_PRODUCT_CATEGORY = 'Media > Books > E-Books';
 // `fb_product_category` uses Meta's own product taxonomy (distinct from Google's
 // taxonomy above) and is a required column in Meta's official catalog CSV
 // template. Books map to "Media > Books".
 const META_CATALOG_FB_PRODUCT_CATEGORY = 'Media > Books';
-// Meta limits a single catalog feed to 200k products; books listings are
-// nowhere near that today, but cap defensively to keep the response bounded.
-const META_CATALOG_MAX_BOOKS = 5000;
 
 /* eslint-disable camelcase -- Meta product catalog field names must be snake_case per spec */
 export interface MetaCatalogItem {
@@ -72,12 +65,6 @@ const META_CATALOG_CSV_COLUMNS: Array<keyof MetaCatalogItem> = [
 ];
 /* eslint-enable camelcase */
 
-function formatPrice(price: NFTBookPrice): string {
-  // priceInDecimal is in USD minor units (cents) — matches the Stripe
-  // product created in createStripeProductFromNFTBookPrice.
-  return `${(price.priceInDecimal / 100).toFixed(2)} USD`;
-}
-
 function buildItem(
   book: NFTBookListingInfo,
   classId: string,
@@ -92,26 +79,17 @@ function buildItem(
   if (!imageSource) return null;
   const image = parseImageURLFromMetadata(imageSource);
 
-  const priceName = price.name
-    ? getLocalizedTextWithFallback(price.name, META_CATALOG_LOCALE)
-    : '';
-  const title = priceName ? `${baseTitle} - ${priceName}` : baseTitle;
   const description = book.descriptionFull || book.description || baseTitle;
-  // `price.stock` is a remaining counter (decremented at sale time in
-  // purchase.ts), not a total. Mirrors the canonical sold-out check in
-  // cart.ts and ValidationHelper.ts.
-  const inStock = price.isAutoDeliver || price.stock === undefined || price.stock > 0;
-  const author = getAuthorNameFromMetadata(book.author);
-  const publisher = getPublisherNameFromMetadata(book.publisher);
-  const brand = author || publisher || META_CATALOG_FALLBACK_BRAND;
+  const inStock = isBookPriceInStock(price);
+  const { author, publisher, brand } = resolveCatalogBrand(book);
 
   const item: MetaCatalogItem = {
     id: buildItemId(classId, priceIndex),
-    title,
+    title: getCatalogVariantTitle(baseTitle, price),
     description,
     availability: inStock ? 'in stock' : 'out of stock',
     condition: 'new',
-    price: formatPrice(price),
+    price: formatCatalogPriceUSD(price),
     link: getBook3NFTClassPageURL({ classId, priceIndex }),
     image_link: image,
     brand,
@@ -125,60 +103,23 @@ function buildItem(
   // stay filterable in Commerce Manager regardless of which won the brand slot.
   if (author) item.custom_label_1 = author;
   if (publisher) item.custom_label_2 = publisher;
-  // `book.isbn` holds an ISBN, and only ISBN-13 (13 digits) is a valid GTIN.
-  // Normalize to bare digits and drop hyphenated/ISBN-10/malformed values
-  // rather than risk Meta feed validation errors.
-  if (book.isbn) {
-    const gtin = book.isbn.replace(/\D/g, '');
-    if (gtin.length === 13) item.gtin = gtin;
-  }
+  const gtin = normalizeISBNToGTIN(book.isbn);
+  if (gtin) item.gtin = gtin;
   return item;
 }
 
 export async function getMetaProductCatalogItems(): Promise<MetaCatalogItem[]> {
-  const books = await listLatestNFTBookInfo({
-    chain: 'base',
-    limit: META_CATALOG_MAX_BOOKS,
-  });
+  const books = await listCatalogEligibleBooks();
   const items: MetaCatalogItem[] = [];
-  books.forEach((book) => {
-    const data = book as NFTBookListingInfo;
-    // `isApprovedForAds === false` is an explicit admin denial; `undefined` means legacy/unset
-    // and defaults to approved (see ValidationHelper.ts), so we filter only on the explicit false.
-    if (
-      data.isHidden
-      || data.redirectClassId
-      || data.isAdultOnly
-      || data.isApprovedForAds === false
-    ) return;
-    const classId = data.classId || book.id;
-    (data.prices || []).forEach((p, priceIndex) => {
-      const item = buildItem(data, classId, p, priceIndex);
+  books.forEach(({ book, classId }) => {
+    (book.prices || []).forEach((p, priceIndex) => {
+      const item = buildItem(book, classId, p, priceIndex);
       if (item) items.push(item);
     });
   });
   return items;
 }
 
-// Defang spreadsheet formula injection (CWE-1236): publisher-supplied fields
-// (title/description/brand/author/publisher) could start with a formula trigger.
-// Meta ingests
-// the value as-is, but an admin opening the downloaded feed in Excel/Sheets
-// would otherwise evaluate it. Prefix a single quote per OWASP, before the
-// RFC 4180 quoting below so quoted cells are defanged too.
-// RFC 4180: wrap a field in double quotes when it contains a comma, quote, or
-// line break, and escape embedded quotes by doubling them. Book descriptions
-// routinely contain all three, so this keeps columns from shifting.
-function escapeCSVField(value: string | undefined): string {
-  if (!value) return '';
-  const defanged = /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
-  return /[",\r\n]/.test(defanged) ? `"${defanged.replace(/"/g, '""')}"` : defanged;
-}
-
 export function formatMetaProductCatalogCSV(items: MetaCatalogItem[]): string {
-  const header = META_CATALOG_CSV_COLUMNS.join(',');
-  const rows = items.map((item) => META_CATALOG_CSV_COLUMNS
-    .map((col) => escapeCSVField(item[col]))
-    .join(','));
-  return `${header}\n${rows.join('\n')}`;
+  return buildCatalogCSV(META_CATALOG_CSV_COLUMNS, items);
 }

--- a/src/util/api/likernft/book/openaiCatalog.ts
+++ b/src/util/api/likernft/book/openaiCatalog.ts
@@ -1,0 +1,301 @@
+import { getBook3NFTClassPageURL, getBook3URL } from '../../../liker-land';
+import { parseImageURLFromMetadata } from '../metadata';
+import { buildItemId } from '../../../analyticsEvents';
+import {
+  listCatalogEligibleBooks,
+  isBookPriceInStock,
+  getCatalogVariantTitle,
+  formatCatalogPriceUSD,
+  normalizeISBNToGTIN,
+  resolveCatalogBrand,
+} from './catalogSource';
+import { buildCatalogCSV } from './catalogCSV';
+import type { NFTBookListingInfo, NFTBookPrice } from '../../../../types/book';
+
+// Search-only feed shaped for OpenAI's commerce *API* product schema
+// (https://developers.openai.com/commerce/specs/api/products): a nested
+// Product → Variant model, distinct from the flat Meta catalog. This module
+// only builds the payload; pushing it to OpenAI (POST /product_feeds + upsert)
+// is a separate integration. Checkout fields (seller, returns, policies) are
+// intentionally omitted — this feed is discovery-only.
+//
+// OpenAI's Category inner shape is not fully pinned down in the public spec;
+// `{ name }` with a `>`-separated path mirrors the file-upload taxonomy and is
+// the best-effort representation pending validation against the real ingester.
+const OPENAI_CATALOG_CATEGORY = 'Media > Books > E-Books';
+
+/* eslint-disable camelcase -- OpenAI product API field names are snake_case per spec */
+export interface OpenAIDescription {
+  plain: string;
+}
+
+export interface OpenAIMedia {
+  type: 'image';
+  url: string;
+}
+
+export interface OpenAIPrice {
+  // ISO 4217 minor units (cents) — matches NFTBookPrice.priceInDecimal directly,
+  // so unlike the Meta feed no "$X.XX USD" string formatting is needed.
+  amount: number;
+  currency: string;
+}
+
+export interface OpenAIAvailability {
+  available: boolean;
+  status: 'in_stock' | 'out_of_stock';
+}
+
+export interface OpenAIBarcode {
+  type: string;
+  value: string;
+}
+
+export interface OpenAICategory {
+  name: string;
+}
+
+export interface OpenAIVariant {
+  id: string;
+  title: string;
+  url: string;
+  price: OpenAIPrice;
+  availability: OpenAIAvailability;
+  condition: string[];
+  categories: OpenAICategory[];
+  media: OpenAIMedia[];
+  barcodes?: OpenAIBarcode[];
+}
+
+export interface OpenAIProduct {
+  id: string;
+  title: string;
+  description: OpenAIDescription;
+  url: string;
+  media: OpenAIMedia[];
+  variants: OpenAIVariant[];
+}
+/* eslint-enable camelcase */
+
+function buildVariant(
+  book: NFTBookListingInfo,
+  baseTitle: string,
+  classId: string,
+  price: NFTBookPrice,
+  priceIndex: number,
+  image: string,
+): OpenAIVariant | null {
+  if (price.isUnlisted) return null;
+  if (!Number.isFinite(price.priceInDecimal) || price.priceInDecimal <= 0) return null;
+
+  const inStock = isBookPriceInStock(price);
+  const variant: OpenAIVariant = {
+    id: buildItemId(classId, priceIndex),
+    title: getCatalogVariantTitle(baseTitle, price),
+    url: getBook3NFTClassPageURL({ classId, priceIndex }),
+    price: {
+      amount: price.priceInDecimal,
+      currency: 'USD',
+    },
+    availability: {
+      available: inStock,
+      status: inStock ? 'in_stock' : 'out_of_stock',
+    },
+    condition: ['new'],
+    categories: [{ name: OPENAI_CATALOG_CATEGORY }],
+    media: [{ type: 'image', url: image }],
+  };
+  const gtin = normalizeISBNToGTIN(book.isbn);
+  if (gtin) variant.barcodes = [{ type: 'gtin', value: gtin }];
+  return variant;
+}
+
+function buildProduct(
+  book: NFTBookListingInfo,
+  classId: string,
+): OpenAIProduct | null {
+  const baseTitle = book.name;
+  if (!baseTitle) return null;
+  const imageSource = book.image || book.thumbnailUrl;
+  if (!imageSource) return null;
+  const image = parseImageURLFromMetadata(imageSource);
+
+  const variants = (book.prices || [])
+    .map((p, priceIndex) => buildVariant(book, baseTitle, classId, p, priceIndex, image))
+    .filter((v): v is OpenAIVariant => v !== null);
+  if (!variants.length) return null;
+
+  return {
+    id: classId,
+    title: baseTitle,
+    description: { plain: book.descriptionFull || book.description || baseTitle },
+    url: getBook3NFTClassPageURL({ classId }),
+    media: [{ type: 'image', url: image }],
+    variants,
+  };
+}
+
+export async function getOpenAIProductCatalogItems(): Promise<OpenAIProduct[]> {
+  const books = await listCatalogEligibleBooks();
+  const products: OpenAIProduct[] = [];
+  books.forEach(({ book, classId }) => {
+    const product = buildProduct(book, classId);
+    if (product) products.push(product);
+  });
+  return products;
+}
+
+// ---------------------------------------------------------------------------
+// File-upload feed (flat schema)
+// ---------------------------------------------------------------------------
+// OpenAI's other ingestion path is a flat product feed file
+// (https://developers.openai.com/commerce/specs/file-upload/products), shaped
+// like the Meta catalog: one row per variant, snake_case columns, CSV or JSON.
+// Unlike the API model, this feed marks brand, seller_*, return_policy and geo
+// as Required even for a search-only listing, so they are always populated.
+const OPENAI_FEED_CATEGORY = 'Media > Books > E-Books';
+const OPENAI_FEED_SELLER_NAME = '3ook.com';
+const OPENAI_FEED_SELLER_URL = getBook3URL('');
+// `return_policy` is a Required URL even for search-only — the published
+// shipping/return/refund policy linked from the store footer.
+const OPENAI_FEED_RETURN_POLICY_URL = 'https://link.3ook.com/shipping-return-refund';
+// `store_country` is the seller-of-record's country (the operating entity, not
+// the HK team). Default 'US' matches the feed's USD pricing; switch to 'TW' if
+// the Stripe merchant of record for these books is the TW entity instead.
+const OPENAI_FEED_STORE_COUNTRY = 'US';
+// `target_countries` is Required per the file-upload spec, but it is
+// first-entry-used: pinning a country would narrow targeting to that market,
+// which contradicts selling these digital ebooks worldwide. So we leave it
+// empty (blank in CSV / omitted in JSON) to keep availability global. If OpenAI's ingester
+// rejects rows without it, set a value here (e.g. 'TW,HK,US') to populate it.
+const OPENAI_FEED_TARGET_COUNTRIES = '';
+
+/* eslint-disable camelcase -- OpenAI file-upload feed field names are snake_case per spec */
+export interface OpenAIFeedItem {
+  item_id: string;
+  title: string;
+  description: string;
+  url: string;
+  brand: string;
+  image_url: string;
+  price: string;
+  availability: 'in_stock' | 'out_of_stock';
+  condition: string;
+  product_category: string;
+  group_id: string;
+  listing_has_variations: string;
+  is_digital: string;
+  is_eligible_search: string;
+  is_eligible_checkout: string;
+  seller_name: string;
+  seller_url: string;
+  return_policy: string;
+  store_country: string;
+  target_countries?: string;
+  gtin?: string;
+}
+
+// Required columns first, then the optional/recommended ones. Boolean and list
+// fields are emitted as strings so the same item serializes to CSV or JSON.
+const OPENAI_FEED_CSV_COLUMNS: Array<keyof OpenAIFeedItem> = [
+  'item_id',
+  'title',
+  'description',
+  'url',
+  'brand',
+  'image_url',
+  'price',
+  'availability',
+  'is_eligible_search',
+  'is_eligible_checkout',
+  'seller_name',
+  'seller_url',
+  'return_policy',
+  'store_country',
+  'target_countries',
+  'condition',
+  'product_category',
+  'group_id',
+  'listing_has_variations',
+  'is_digital',
+  'gtin',
+];
+/* eslint-enable camelcase */
+
+function buildFeedItem(
+  book: NFTBookListingInfo,
+  baseTitle: string,
+  description: string,
+  brand: string,
+  image: string,
+  classId: string,
+  hasVariations: boolean,
+  price: NFTBookPrice,
+  priceIndex: number,
+): OpenAIFeedItem | null {
+  if (price.isUnlisted) return null;
+  if (!Number.isFinite(price.priceInDecimal) || price.priceInDecimal <= 0) return null;
+
+  const inStock = isBookPriceInStock(price);
+  const item: OpenAIFeedItem = {
+    item_id: buildItemId(classId, priceIndex),
+    title: getCatalogVariantTitle(baseTitle, price),
+    description,
+    url: getBook3NFTClassPageURL({ classId, priceIndex }),
+    brand,
+    image_url: image,
+    price: formatCatalogPriceUSD(price),
+    availability: inStock ? 'in_stock' : 'out_of_stock',
+    condition: 'new',
+    product_category: OPENAI_FEED_CATEGORY,
+    group_id: classId,
+    listing_has_variations: hasVariations ? 'true' : 'false',
+    is_digital: 'true',
+    is_eligible_search: 'true',
+    is_eligible_checkout: 'false',
+    seller_name: OPENAI_FEED_SELLER_NAME,
+    seller_url: OPENAI_FEED_SELLER_URL,
+    return_policy: OPENAI_FEED_RETURN_POLICY_URL,
+    store_country: OPENAI_FEED_STORE_COUNTRY,
+  };
+  // Omitted by default to keep availability global (see constant above).
+  if (OPENAI_FEED_TARGET_COUNTRIES) item.target_countries = OPENAI_FEED_TARGET_COUNTRIES;
+  const gtin = normalizeISBNToGTIN(book.isbn);
+  if (gtin) item.gtin = gtin;
+  return item;
+}
+
+export async function getOpenAIFeedItems(): Promise<OpenAIFeedItem[]> {
+  const books = await listCatalogEligibleBooks();
+  const items: OpenAIFeedItem[] = [];
+  books.forEach(({ book, classId }) => {
+    const baseTitle = book.name;
+    if (!baseTitle) return;
+    const imageSource = book.image || book.thumbnailUrl;
+    if (!imageSource) return;
+    const image = parseImageURLFromMetadata(imageSource);
+    const { brand } = resolveCatalogBrand(book);
+    const description = book.descriptionFull || book.description || baseTitle;
+    const prices = book.prices || [];
+    const hasVariations = prices.length > 1;
+    prices.forEach((p, priceIndex) => {
+      const item = buildFeedItem(
+        book,
+        baseTitle,
+        description,
+        brand,
+        image,
+        classId,
+        hasVariations,
+        p,
+        priceIndex,
+      );
+      if (item) items.push(item);
+    });
+  });
+  return items;
+}
+
+export function formatOpenAIFeedCSV(items: OpenAIFeedItem[]): string {
+  return buildCatalogCSV(OPENAI_FEED_CSV_COLUMNS, items);
+}

--- a/src/util/api/likernft/book/openaiCatalog.ts
+++ b/src/util/api/likernft/book/openaiCatalog.ts
@@ -3,12 +3,12 @@ import { parseImageURLFromMetadata } from '../metadata';
 import { buildItemId } from '../../../analyticsEvents';
 import {
   listCatalogEligibleBooks,
+  listCatalogVariants,
   isBookPriceInStock,
   getCatalogVariantTitle,
-  formatCatalogPriceUSD,
   normalizeISBNToGTIN,
-  resolveCatalogBrand,
 } from './catalogSource';
+import type { CatalogVariant } from './catalogSource';
 import { buildCatalogCSV } from './catalogCSV';
 import type { NFTBookListingInfo, NFTBookPrice } from '../../../../types/book';
 
@@ -222,34 +222,20 @@ const OPENAI_FEED_CSV_COLUMNS: Array<keyof OpenAIFeedItem> = [
 ];
 /* eslint-enable camelcase */
 
-function buildFeedItem(
-  book: NFTBookListingInfo,
-  baseTitle: string,
-  description: string,
-  brand: string,
-  image: string,
-  classId: string,
-  hasVariations: boolean,
-  price: NFTBookPrice,
-  priceIndex: number,
-): OpenAIFeedItem | null {
-  if (price.isUnlisted) return null;
-  if (!Number.isFinite(price.priceInDecimal) || price.priceInDecimal <= 0) return null;
-
-  const inStock = isBookPriceInStock(price);
+function buildFeedItem(v: CatalogVariant): OpenAIFeedItem {
   const item: OpenAIFeedItem = {
-    item_id: buildItemId(classId, priceIndex),
-    title: getCatalogVariantTitle(baseTitle, price),
-    description,
-    url: getBook3NFTClassPageURL({ classId, priceIndex }),
-    brand,
-    image_url: image,
-    price: formatCatalogPriceUSD(price),
-    availability: inStock ? 'in_stock' : 'out_of_stock',
+    item_id: v.id,
+    title: v.title,
+    description: v.description,
+    url: v.link,
+    brand: v.brand,
+    image_url: v.image,
+    price: v.priceUSD,
+    availability: v.inStock ? 'in_stock' : 'out_of_stock',
     condition: 'new',
     product_category: OPENAI_FEED_CATEGORY,
-    group_id: classId,
-    listing_has_variations: hasVariations ? 'true' : 'false',
+    group_id: v.classId,
+    listing_has_variations: v.hasVariations ? 'true' : 'false',
     is_digital: 'true',
     is_eligible_search: 'true',
     is_eligible_checkout: 'false',
@@ -260,40 +246,13 @@ function buildFeedItem(
   };
   // Omitted by default to keep availability global (see constant above).
   if (OPENAI_FEED_TARGET_COUNTRIES) item.target_countries = OPENAI_FEED_TARGET_COUNTRIES;
-  const gtin = normalizeISBNToGTIN(book.isbn);
-  if (gtin) item.gtin = gtin;
+  if (v.gtin) item.gtin = v.gtin;
   return item;
 }
 
 export async function getOpenAIFeedItems(): Promise<OpenAIFeedItem[]> {
-  const books = await listCatalogEligibleBooks();
-  const items: OpenAIFeedItem[] = [];
-  books.forEach(({ book, classId }) => {
-    const baseTitle = book.name;
-    if (!baseTitle) return;
-    const imageSource = book.image || book.thumbnailUrl;
-    if (!imageSource) return;
-    const image = parseImageURLFromMetadata(imageSource);
-    const { brand } = resolveCatalogBrand(book);
-    const description = book.descriptionFull || book.description || baseTitle;
-    const prices = book.prices || [];
-    const hasVariations = prices.length > 1;
-    prices.forEach((p, priceIndex) => {
-      const item = buildFeedItem(
-        book,
-        baseTitle,
-        description,
-        brand,
-        image,
-        classId,
-        hasVariations,
-        p,
-        priceIndex,
-      );
-      if (item) items.push(item);
-    });
-  });
-  return items;
+  const variants = await listCatalogVariants();
+  return variants.map(buildFeedItem);
 }
 
 export function formatOpenAIFeedCSV(items: OpenAIFeedItem[]): string {

--- a/src/util/api/likernft/book/schemas.ts
+++ b/src/util/api/likernft/book/schemas.ts
@@ -196,7 +196,8 @@ export const BookListQuerySchema = BookListPaginationQuerySchema.extend({
 });
 export type BookListQuery = z.infer<typeof BookListQuerySchema>;
 
-export const BookCatalogMetaQuerySchema = z.object({
+// Shared by the Meta and OpenAI catalog routes — both select output via `format`.
+export const BookCatalogQuerySchema = z.object({
   format: z.string().optional(),
 }).passthrough();
 
@@ -561,6 +562,70 @@ export const BookCatalogMetaResponseSchema = z.object({
     custom_label_0: z.string().optional(),
     custom_label_1: z.string().optional(),
     custom_label_2: z.string().optional(),
+  })),
+});
+
+// Mirrors the OpenAI commerce API product schema (Product → Variant) built in
+// src/util/api/likernft/book/openaiCatalog.ts. Field names are snake_case per spec.
+const OpenAICatalogMediaSchema = z.object({
+  type: z.literal('image'),
+  url: z.string(),
+});
+export const BookCatalogOpenAIResponseSchema = z.object({
+  products: z.array(z.object({
+    id: z.string(),
+    title: z.string(),
+    description: z.object({ plain: z.string() }),
+    url: z.string(),
+    media: z.array(OpenAICatalogMediaSchema),
+    variants: z.array(z.object({
+      id: z.string(),
+      title: z.string(),
+      url: z.string(),
+      price: z.object({
+        amount: z.number(),
+        currency: z.string(),
+      }),
+      availability: z.object({
+        available: z.boolean(),
+        status: z.enum(['in_stock', 'out_of_stock']),
+      }),
+      condition: z.array(z.string()),
+      categories: z.array(z.object({ name: z.string() })),
+      media: z.array(OpenAICatalogMediaSchema),
+      barcodes: z.array(z.object({
+        type: z.string(),
+        value: z.string(),
+      })).optional(),
+    })),
+  })),
+});
+
+// Mirrors OpenAIFeedItem (openaiCatalog.ts) — the flat file-upload feed. Boolean
+// and list fields are emitted as strings so one item serializes to CSV or JSON.
+export const BookCatalogOpenAIFeedResponseSchema = z.object({
+  products: z.array(z.object({
+    item_id: z.string(),
+    title: z.string(),
+    description: z.string(),
+    url: z.string(),
+    brand: z.string(),
+    image_url: z.string(),
+    price: z.string(),
+    availability: z.enum(['in_stock', 'out_of_stock']),
+    condition: z.string(),
+    product_category: z.string(),
+    group_id: z.string(),
+    listing_has_variations: z.string(),
+    is_digital: z.string(),
+    is_eligible_search: z.string(),
+    is_eligible_checkout: z.string(),
+    seller_name: z.string(),
+    seller_url: z.string(),
+    return_policy: z.string(),
+    store_country: z.string(),
+    target_countries: z.string().optional(),
+    gtin: z.string().optional(),
   })),
 });
 

--- a/src/util/api/likernft/book/schemas.ts
+++ b/src/util/api/likernft/book/schemas.ts
@@ -196,7 +196,7 @@ export const BookListQuerySchema = BookListPaginationQuerySchema.extend({
 });
 export type BookListQuery = z.infer<typeof BookListQuerySchema>;
 
-// Shared by the Meta and OpenAI catalog routes — both select output via `format`.
+// Shared by the Meta, OpenAI, and Stripe catalog routes — output is selected via `format`.
 export const BookCatalogQuerySchema = z.object({
   format: z.string().optional(),
 }).passthrough();
@@ -626,6 +626,30 @@ export const BookCatalogOpenAIFeedResponseSchema = z.object({
     store_country: z.string(),
     target_countries: z.string().optional(),
     gtin: z.string().optional(),
+  })),
+});
+
+// Mirrors StripeFeedItem (stripeCatalog.ts) — the Stripe Agentic Commerce feed.
+// Google-Shopping field dialect; boolean fields are strings so one item
+// serializes to CSV or JSON.
+export const BookCatalogStripeResponseSchema = z.object({
+  products: z.array(z.object({
+    id: z.string(),
+    title: z.string(),
+    description: z.string(),
+    link: z.string(),
+    image_link: z.string(),
+    price: z.string(),
+    availability: z.enum(['in_stock', 'out_of_stock']),
+    inventory_not_tracked: z.string(),
+    condition: z.string(),
+    brand: z.string(),
+    google_product_category: z.string(),
+    item_group_id: z.string(),
+    item_group_title: z.string(),
+    disable_checkout: z.string(),
+    gtin: z.string().optional(),
+    stripe_product_tax_code: z.string().optional(),
   })),
 });
 

--- a/src/util/api/likernft/book/stripeCatalog.ts
+++ b/src/util/api/likernft/book/stripeCatalog.ts
@@ -1,0 +1,93 @@
+import { listCatalogVariants } from './catalogSource';
+import type { CatalogVariant } from './catalogSource';
+import { buildCatalogCSV } from './catalogCSV';
+
+// Stripe Agentic Commerce product feed
+// (https://docs.stripe.com/agentic-commerce/product-feed): a flat CSV in the
+// Google-Shopping field dialect (id/link/image_link/item_group_id), uploaded via
+// POST /v2/commerce/product_catalog/imports. Same lineage as the Meta feed, so
+// it reuses the shared catalog source and helpers; only field names and the
+// digital-goods/checkout flags differ. This module only builds the payload;
+// uploading it to Stripe is a separate integration.
+const STRIPE_FEED_CATEGORY = 'Media > Books > E-Books';
+// Books are digital downloads: inventory isn't tracked and there is no shipping,
+// so `availability` alone conveys sold-out state.
+const STRIPE_FEED_INVENTORY_NOT_TRACKED = 'true';
+// Discovery-only until the seller is enabled for agentic checkout: `true` makes
+// agents link out to the product page instead of checking out in-agent. Flip to
+// 'false' once ACP checkout is approved.
+const STRIPE_FEED_DISABLE_CHECKOUT = 'true';
+// Set to a Stripe digital-goods product tax code (e.g. 'txcd_10503000') if the
+// account uses Stripe Tax; left blank otherwise (column present, value empty).
+const STRIPE_FEED_TAX_CODE = '';
+
+/* eslint-disable camelcase -- Stripe product feed column names are snake_case per spec */
+export interface StripeFeedItem {
+  id: string;
+  title: string;
+  description: string;
+  link: string;
+  image_link: string;
+  price: string;
+  availability: 'in_stock' | 'out_of_stock';
+  inventory_not_tracked: string;
+  condition: string;
+  brand: string;
+  google_product_category: string;
+  item_group_id: string;
+  item_group_title: string;
+  disable_checkout: string;
+  gtin?: string;
+  stripe_product_tax_code?: string;
+}
+
+const STRIPE_FEED_CSV_COLUMNS: Array<keyof StripeFeedItem> = [
+  'id',
+  'title',
+  'description',
+  'link',
+  'image_link',
+  'price',
+  'availability',
+  'inventory_not_tracked',
+  'condition',
+  'brand',
+  'gtin',
+  'google_product_category',
+  'item_group_id',
+  'item_group_title',
+  'disable_checkout',
+  'stripe_product_tax_code',
+];
+/* eslint-enable camelcase */
+
+function buildFeedItem(v: CatalogVariant): StripeFeedItem {
+  const item: StripeFeedItem = {
+    id: v.id,
+    title: v.title,
+    description: v.description,
+    link: v.link,
+    image_link: v.image,
+    price: v.priceUSD,
+    availability: v.inStock ? 'in_stock' : 'out_of_stock',
+    inventory_not_tracked: STRIPE_FEED_INVENTORY_NOT_TRACKED,
+    condition: 'new',
+    brand: v.brand,
+    google_product_category: STRIPE_FEED_CATEGORY,
+    item_group_id: v.classId,
+    item_group_title: v.baseTitle,
+    disable_checkout: STRIPE_FEED_DISABLE_CHECKOUT,
+  };
+  if (v.gtin) item.gtin = v.gtin;
+  if (STRIPE_FEED_TAX_CODE) item.stripe_product_tax_code = STRIPE_FEED_TAX_CODE;
+  return item;
+}
+
+export async function getStripeFeedItems(): Promise<StripeFeedItem[]> {
+  const variants = await listCatalogVariants();
+  return variants.map(buildFeedItem);
+}
+
+export function formatStripeFeedCSV(items: StripeFeedItem[]): string {
+  return buildCatalogCSV(STRIPE_FEED_CSV_COLUMNS, items);
+}

--- a/test/unit/openai-catalog.test.ts
+++ b/test/unit/openai-catalog.test.ts
@@ -1,0 +1,279 @@
+import {
+  describe, it, expect, beforeEach, vi,
+} from 'vitest';
+import {
+  getOpenAIProductCatalogItems,
+  getOpenAIFeedItems,
+  formatOpenAIFeedCSV,
+} from '../../src/util/api/likernft/book/openaiCatalog';
+import type { OpenAIFeedItem } from '../../src/util/api/likernft/book/openaiCatalog';
+import { listLatestNFTBookInfo } from '../../src/util/api/likernft/book/index';
+import type { NFTBookListingInfo } from '../../src/types/book';
+
+// Mock only the data fetch; keep the real pure helpers
+// (getLocalizedTextWithFallback) so the mapping logic is exercised end-to-end.
+vi.mock('../../src/util/api/likernft/book/index', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/util/api/likernft/book/index')>();
+  return {
+    ...actual,
+    listLatestNFTBookInfo: vi.fn(),
+  };
+});
+
+const mockedList = vi.mocked(listLatestNFTBookInfo);
+
+function setBooks(books: Array<Partial<NFTBookListingInfo>>) {
+  mockedList.mockResolvedValue(books as any);
+}
+
+async function expectProductIds(
+  books: Array<Partial<NFTBookListingInfo>>,
+  expectedIds: string[],
+) {
+  setBooks(books);
+  const products = await getOpenAIProductCatalogItems();
+  expect(products.map((p) => p.id)).toEqual(expectedIds);
+}
+
+describe('getOpenAIProductCatalogItems', () => {
+  beforeEach(() => {
+    mockedList.mockReset();
+  });
+
+  it('fetches Base book listings up to the catalog cap', async () => {
+    setBooks([]);
+    await getOpenAIProductCatalogItems();
+    expect(mockedList).toHaveBeenCalledWith({ chain: 'base', limit: 5000 });
+  });
+
+  it('maps a book into a nested Product with one Variant per price', async () => {
+    setBooks([{
+      id: 'class-a',
+      classId: 'class-a',
+      name: 'The Great Book',
+      image: 'https://img.example/a.jpg',
+      isbn: '978-3-16-148410-0', // ISBN-13 with hyphens
+      descriptionFull: 'Full description',
+      prices: [
+        { priceInDecimal: 1500, name: 'Hardcover', stock: 5 },
+        { priceInDecimal: 999, stock: 0, isAutoDeliver: false },
+      ],
+    }]);
+
+    const products = await getOpenAIProductCatalogItems();
+
+    expect(products).toHaveLength(1);
+    const [product] = products;
+    expect(product.id).toBe('class-a');
+    expect(product.title).toBe('The Great Book');
+    expect(product.description).toEqual({ plain: 'Full description' });
+    expect(product.url).toContain('/store/class-a');
+    expect(product.media).toEqual([{ type: 'image', url: 'https://img.example/a.jpg' }]);
+
+    expect(product.variants).toHaveLength(2);
+    const [first, second] = product.variants;
+    expect(first.id).toBe('class-a-0');
+    expect(first.title).toBe('The Great Book - Hardcover');
+    // price is ISO 4217 minor units, no string formatting
+    expect(first.price).toEqual({ amount: 1500, currency: 'USD' });
+    expect(first.availability).toEqual({ available: true, status: 'in_stock' });
+    expect(first.condition).toEqual(['new']);
+    expect(first.categories).toEqual([{ name: 'Media > Books > E-Books' }]);
+    // hyphenated ISBN-13 normalized to a 13-digit GTIN barcode
+    expect(first.barcodes).toEqual([{ type: 'gtin', value: '9783161484100' }]);
+
+    // second variant has no name and is out of stock
+    expect(second.id).toBe('class-a-1');
+    expect(second.title).toBe('The Great Book');
+    expect(second.availability).toEqual({ available: false, status: 'out_of_stock' });
+  });
+
+  it('falls back description to short description then title, and drops invalid GTINs', async () => {
+    setBooks([{
+      id: 'class-f',
+      classId: 'class-f',
+      name: 'Solo Work',
+      image: 'https://img.example/f.jpg',
+      isbn: '0-306-40615-2', // ISBN-10 → not a valid GTIN length
+      description: 'short',
+      prices: [{ priceInDecimal: 999, stock: 3 }],
+    }]);
+
+    const [product] = await getOpenAIProductCatalogItems();
+    expect(product.description).toEqual({ plain: 'short' });
+    expect(product.variants[0].barcodes).toBeUndefined();
+  });
+
+  it('skips hidden, redirected, adult, and ads-denied books', async () => {
+    await expectProductIds([
+      {
+        id: 'hidden', classId: 'hidden', name: 'Hidden', image: 'https://img/x.jpg', isHidden: true, prices: [{ priceInDecimal: 100 }],
+      },
+      {
+        id: 'redirect', classId: 'redirect', name: 'Redirect', image: 'https://img/x.jpg', redirectClassId: 'other', prices: [{ priceInDecimal: 100 }],
+      },
+      {
+        id: 'adult', classId: 'adult', name: 'Adult', image: 'https://img/x.jpg', isAdultOnly: true, prices: [{ priceInDecimal: 100 }],
+      },
+      {
+        id: 'denied', classId: 'denied', name: 'Denied', image: 'https://img/x.jpg', isApprovedForAds: false, prices: [{ priceInDecimal: 100 }],
+      },
+    ], []);
+  });
+
+  it('includes books where isApprovedForAds is unset (legacy default approved)', async () => {
+    await expectProductIds([{
+      id: 'legacy', classId: 'legacy', name: 'Legacy', image: 'https://img/l.jpg', prices: [{ priceInDecimal: 100 }],
+    }], ['legacy']);
+  });
+
+  it('drops unlisted and non-positive variants, and books with no valid variant', async () => {
+    await expectProductIds([
+      {
+        id: 'mixed',
+        classId: 'mixed',
+        name: 'Mixed Prices',
+        image: 'https://img/m.jpg',
+        prices: [
+          { priceInDecimal: 1000 }, // index 0 → kept
+          { priceInDecimal: 0 }, // index 1 → dropped (non-positive)
+          { priceInDecimal: 2000, isUnlisted: true }, // index 2 → dropped (unlisted)
+        ],
+      },
+      {
+        // all variants invalid → whole product dropped
+        id: 'empty', classId: 'empty', name: 'Empty', image: 'https://img/e.jpg', prices: [{ priceInDecimal: 0 }],
+      },
+      {
+        id: 'noimage', classId: 'noimage', name: 'No Image', prices: [{ priceInDecimal: 1000 }], // missing image → dropped
+      },
+    ], ['mixed']);
+    const products = await getOpenAIProductCatalogItems();
+    const mixed = products.find((p) => p.id === 'mixed');
+    expect(mixed?.variants.map((v) => v.id)).toEqual(['mixed-0']);
+  });
+});
+
+describe('getOpenAIFeedItems (flat file-upload feed)', () => {
+  beforeEach(() => {
+    mockedList.mockReset();
+  });
+
+  it('maps each price into a flat row with required search/seller/geo fields', async () => {
+    setBooks([{
+      id: 'class-a',
+      classId: 'class-a',
+      name: 'The Great Book',
+      image: 'https://img.example/a.jpg',
+      author: 'Jane Doe',
+      publisher: 'Penguin',
+      isbn: '978-3-16-148410-0',
+      descriptionFull: 'Full description',
+      prices: [
+        { priceInDecimal: 1500, name: 'Hardcover', stock: 5 },
+        { priceInDecimal: 999, stock: 0, isAutoDeliver: false },
+      ],
+    }]);
+
+    const items = await getOpenAIFeedItems();
+    expect(items).toHaveLength(2);
+    const [first] = items;
+    expect(first.item_id).toBe('class-a-0');
+    expect(first.title).toBe('The Great Book - Hardcover');
+    // flat feed uses a "<amount> <currency>" string, not minor units
+    expect(first.price).toBe('15.00 USD');
+    expect(first.availability).toBe('in_stock');
+    // author wins over publisher for brand (shared resolveCatalogBrand)
+    expect(first.brand).toBe('Jane Doe');
+    expect(first.gtin).toBe('9783161484100');
+    expect(first.group_id).toBe('class-a');
+    expect(first.listing_has_variations).toBe('true');
+    // required-for-search fields are always populated
+    expect(first.is_eligible_search).toBe('true');
+    expect(first.is_eligible_checkout).toBe('false');
+    expect(first.is_digital).toBe('true');
+    expect(first.seller_name).toBe('3ook.com');
+    expect(first.seller_url).toContain('3ook.com');
+    expect(first.return_policy).toBe('https://link.3ook.com/shipping-return-refund');
+    expect(first.store_country).toBe('US');
+    // target_countries is omitted by default to keep availability global
+    expect(first.target_countries).toBeUndefined();
+
+    expect(items[1].availability).toBe('out_of_stock');
+  });
+
+  it('marks single-price books as having no variations', async () => {
+    setBooks([{
+      id: 'solo', classId: 'solo', name: 'Solo', image: 'https://img/s.jpg', prices: [{ priceInDecimal: 500 }],
+    }]);
+    const [item] = await getOpenAIFeedItems();
+    expect(item.listing_has_variations).toBe('false');
+  });
+
+  it('applies the same eligibility and variant drop rules as the API model', async () => {
+    setBooks([
+      {
+        id: 'hidden', classId: 'hidden', name: 'Hidden', image: 'https://img/x.jpg', isHidden: true, prices: [{ priceInDecimal: 100 }],
+      },
+      {
+        id: 'noimage', classId: 'noimage', name: 'No Image', prices: [{ priceInDecimal: 100 }],
+      },
+      {
+        id: 'ok', classId: 'ok', name: 'OK', image: 'https://img/o.jpg', prices: [{ priceInDecimal: 100, isUnlisted: true }, { priceInDecimal: 200 }],
+      },
+    ]);
+    const items = await getOpenAIFeedItems();
+    expect(items.map((i) => i.item_id)).toEqual(['ok-1']);
+  });
+});
+
+describe('formatOpenAIFeedCSV', () => {
+  const baseItem: OpenAIFeedItem = {
+    item_id: 'class-a-0',
+    title: 'The Great Book',
+    description: 'Full description',
+    url: 'https://3ook.com/store/class-a',
+    brand: 'Penguin',
+    image_url: 'https://img.example/a.jpg',
+    price: '15.00 USD',
+    availability: 'in_stock',
+    condition: 'new',
+    product_category: 'Media > Books > E-Books',
+    group_id: 'class-a',
+    listing_has_variations: 'false',
+    is_digital: 'true',
+    is_eligible_search: 'true',
+    is_eligible_checkout: 'false',
+    seller_name: '3ook.com',
+    seller_url: 'https://3ook.com',
+    return_policy: 'https://link.3ook.com/shipping-return-refund',
+    store_country: 'US',
+    gtin: '9783161484100',
+  };
+
+  it('emits the header in column order', () => {
+    const [header] = formatOpenAIFeedCSV([]).split('\n');
+    expect(header).toBe(
+      'item_id,title,description,url,brand,image_url,price,availability,'
+      + 'is_eligible_search,is_eligible_checkout,seller_name,seller_url,return_policy,'
+      + 'store_country,target_countries,condition,product_category,group_id,'
+      + 'listing_has_variations,is_digital,gtin',
+    );
+  });
+
+  it('quotes fields with commas and defangs formula injection', () => {
+    const csv = formatOpenAIFeedCSV([{
+      ...baseItem,
+      product_category: 'Media > Books > E-Books',
+      title: '=HYPERLINK("http://evil")',
+    }]);
+    expect(csv).toContain('"\'=HYPERLINK(""http://evil"")"');
+  });
+
+  it('leaves an absent gtin blank in the trailing column', () => {
+    const withoutGtin: OpenAIFeedItem = { ...baseItem };
+    delete withoutGtin.gtin;
+    const [, row] = formatOpenAIFeedCSV([withoutGtin]).split('\n');
+    expect(row.endsWith(',')).toBe(true);
+  });
+});

--- a/test/unit/stripe-catalog.test.ts
+++ b/test/unit/stripe-catalog.test.ts
@@ -1,0 +1,146 @@
+import {
+  describe, it, expect, beforeEach, vi,
+} from 'vitest';
+import { getStripeFeedItems, formatStripeFeedCSV } from '../../src/util/api/likernft/book/stripeCatalog';
+import type { StripeFeedItem } from '../../src/util/api/likernft/book/stripeCatalog';
+import { listLatestNFTBookInfo } from '../../src/util/api/likernft/book/index';
+import type { NFTBookListingInfo } from '../../src/types/book';
+
+// Mock only the data fetch; keep the real pure helpers so the mapping logic is
+// exercised end-to-end.
+vi.mock('../../src/util/api/likernft/book/index', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/util/api/likernft/book/index')>();
+  return {
+    ...actual,
+    listLatestNFTBookInfo: vi.fn(),
+  };
+});
+
+const mockedList = vi.mocked(listLatestNFTBookInfo);
+
+function setBooks(books: Array<Partial<NFTBookListingInfo>>) {
+  mockedList.mockResolvedValue(books as any);
+}
+
+describe('getStripeFeedItems', () => {
+  beforeEach(() => {
+    mockedList.mockReset();
+  });
+
+  it('maps each price into a Stripe row with the Google-Shopping dialect', async () => {
+    setBooks([{
+      id: 'class-a',
+      classId: 'class-a',
+      name: 'The Great Book',
+      image: 'https://img.example/a.jpg',
+      author: 'Jane Doe',
+      publisher: 'Penguin',
+      isbn: '978-3-16-148410-0',
+      descriptionFull: 'Full description',
+      prices: [
+        { priceInDecimal: 1500, name: 'Hardcover', stock: 5 },
+        { priceInDecimal: 999, stock: 0, isAutoDeliver: false },
+      ],
+    }]);
+
+    const items = await getStripeFeedItems();
+    expect(items).toHaveLength(2);
+    const [first] = items;
+    expect(first.id).toBe('class-a-0');
+    expect(first.title).toBe('The Great Book - Hardcover');
+    expect(first.link).toContain('/store/class-a');
+    expect(first.image_link).toBe('https://img.example/a.jpg');
+    expect(first.price).toBe('15.00 USD');
+    // underscore enum, unlike the Meta feed's "in stock"
+    expect(first.availability).toBe('in_stock');
+    expect(first.condition).toBe('new');
+    // author wins over publisher for brand (shared resolveCatalogBrand)
+    expect(first.brand).toBe('Jane Doe');
+    expect(first.gtin).toBe('9783161484100');
+    expect(first.item_group_id).toBe('class-a');
+    expect(first.item_group_title).toBe('The Great Book');
+    // digital-goods + discovery-only flags
+    expect(first.inventory_not_tracked).toBe('true');
+    expect(first.disable_checkout).toBe('true');
+    // tax code omitted by default
+    expect(first.stripe_product_tax_code).toBeUndefined();
+
+    expect(items[1].availability).toBe('out_of_stock');
+  });
+
+  it('drops invalid GTINs (ISBN-10) and keeps the row', async () => {
+    setBooks([{
+      id: 'class-f',
+      classId: 'class-f',
+      name: 'Solo Work',
+      image: 'https://img.example/f.jpg',
+      isbn: '0-306-40615-2', // ISBN-10 → not a valid GTIN length
+      description: 'short',
+      prices: [{ priceInDecimal: 999, stock: 3 }],
+    }]);
+
+    const [item] = await getStripeFeedItems();
+    expect(item.gtin).toBeUndefined();
+    expect(item.brand).toBe('3ook.com'); // no author/publisher → fallback
+  });
+
+  it('applies the same eligibility and variant drop rules as the other feeds', async () => {
+    setBooks([
+      {
+        id: 'hidden', classId: 'hidden', name: 'Hidden', image: 'https://img/x.jpg', isHidden: true, prices: [{ priceInDecimal: 100 }],
+      },
+      {
+        id: 'noimage', classId: 'noimage', name: 'No Image', prices: [{ priceInDecimal: 100 }],
+      },
+      {
+        id: 'ok', classId: 'ok', name: 'OK', image: 'https://img/o.jpg', prices: [{ priceInDecimal: 100, isUnlisted: true }, { priceInDecimal: 200 }],
+      },
+    ]);
+    const items = await getStripeFeedItems();
+    expect(items.map((i) => i.id)).toEqual(['ok-1']);
+  });
+});
+
+describe('formatStripeFeedCSV', () => {
+  const baseItem: StripeFeedItem = {
+    id: 'class-a-0',
+    title: 'The Great Book',
+    description: 'Full description',
+    link: 'https://3ook.com/store/class-a',
+    image_link: 'https://img.example/a.jpg',
+    price: '15.00 USD',
+    availability: 'in_stock',
+    inventory_not_tracked: 'true',
+    condition: 'new',
+    brand: 'Jane Doe',
+    google_product_category: 'Media > Books > E-Books',
+    item_group_id: 'class-a',
+    item_group_title: 'The Great Book',
+    disable_checkout: 'true',
+    gtin: '9783161484100',
+  };
+
+  it('emits the header in column order', () => {
+    const [header] = formatStripeFeedCSV([]).split('\n');
+    expect(header).toBe(
+      'id,title,description,link,image_link,price,availability,inventory_not_tracked,'
+      + 'condition,brand,gtin,google_product_category,item_group_id,item_group_title,'
+      + 'disable_checkout,stripe_product_tax_code',
+    );
+  });
+
+  it('quotes fields with commas and defangs formula injection', () => {
+    const csv = formatStripeFeedCSV([{
+      ...baseItem,
+      title: '=HYPERLINK("http://evil")',
+    }]);
+    expect(csv).toContain('"\'=HYPERLINK(""http://evil"")"');
+    // category contains '>' but no comma/quote, so it is not quoted
+    expect(csv).toContain('Media > Books > E-Books');
+  });
+
+  it('leaves an absent tax code blank in the trailing column', () => {
+    const [, row] = formatStripeFeedCSV([baseItem]).split('\n');
+    expect(row.endsWith(',')).toBe(true);
+  });
+});


### PR DESCRIPTION
Expose GET /catalog/openai for ChatGPT commerce discovery, search-only. `format` selects the representation, mirroring the Meta route: default is the flat file-upload feed (JSON), `csv` downloads it, and `api` returns the nested API model (Product → Variant).

Share the fetch/filter, stock, GTIN, price and CSV-escaping rules between the Meta and OpenAI feeds (catalogSource/catalogCSV) so they can't drift. Checkout fields are omitted; store_country/return_policy are set, while target_countries is left empty to keep digital ebooks globally available.