### PR TITLE
🐛 Skip empty Image attachment in Airtable record create

### DIFF
--- a/src/util/airtable.ts
+++ b/src/util/airtable.ts
@@ -104,13 +104,16 @@ export async function createAirtablePublicationRecord({
       ID: id,
       Name: typeof name === 'string' ? name : name.zh,
       Description: typeof description === 'string' ? description : description.zh,
-      Image: [{ url: normalizedImageURL }],
-      'Image URL': normalizedImageURL,
       'Min Price': minPrice,
       'Max Price': maxPrice,
       'DRM-free': isDRMFree,
       'In Library': isPlusReadingEnabled,
     };
+
+    if (normalizedImageURL) {
+      fields.Image = [{ url: normalizedImageURL }];
+      fields['Image URL'] = normalizedImageURL;
+    }
 
     if (priceRangeByCurrency) {
       for (const [currency, range] of Object.entries(priceRangeByCurrency)) {


### PR DESCRIPTION
An empty image URL produced an `Image: [{ url: '' }]` attachment that Airtable rejected, failing the whole create. The error was swallowed by the catch, leaving the publication record silently missing and needing manual backfill. Guard the Image/Image URL fields on a non-empty URL, matching the existing guard in updateAirtablePublicationRecord.