### PR TITLE
[TAS-5398] ✨ Support changing login email for Magic and wallet users

### DIFF
--- a/src/routes/users/registerLogin.ts
+++ b/src/routes/users/registerLogin.ts
@@ -27,6 +27,7 @@ import { validateBody } from '../../middleware/validate';
 import {
   UsersUpdateAvatarBodySchema,
   UsersUpdateBodySchema,
+  UsersEmailCheckBodySchema,
   UsersRegisterBodySchema,
   UsersLoginBodySchema,
   UsersUpdateAvatarResponseSchema,
@@ -178,6 +179,7 @@ router.post(
       const { user } = req.user;
       const {
         email,
+        magicDIDToken,
         displayName,
         description,
         locale: inputLocale,
@@ -212,6 +214,7 @@ router.post(
         email: oldEmail,
         locale: oldLocale,
         authCoreUserId,
+        magicUserId,
       } = oldUserData;
 
       const updateObj: any = {
@@ -223,21 +226,39 @@ router.post(
 
       if (email) {
         if (authCoreUserId && oldEmail) throw new ValidationError('EMAIL_CANNOT_BE_CHANGED');
-        await userOrWalletByEmailQuery({ user }, email);
-        const {
-          normalizedEmail,
-          isEmailBlacklisted,
-          isEmailDuplicated,
-        } = await normalizeUserEmail(user, email);
-        if (normalizedEmail) {
-          updateObj.email = email;
-          updateObj.normalizedEmail = normalizedEmail;
-          updateObj.isEmailVerified = false;
-        } else {
-          throw new ValidationError('EMAIL_FORMAT_INCORRECT');
+        // Only re-run uniqueness/verification when the email actually changes, so
+        // resubmitting an unchanged email doesn't reset isEmailVerified for wallet users.
+        if (email.toLowerCase() !== (oldEmail || '').toLowerCase()) {
+          await userOrWalletByEmailQuery({ user }, email);
+          // Magic OTP-verifies email changes, so a DID token whose issuer matches the
+          // user's magicUserId lets us keep isEmailVerified; wallet users (no token)
+          // reset it. The issuer match stops a wallet user claiming verification.
+          let isEmailVerified = false;
+          if (magicDIDToken) {
+            const magicUserMetadata = await getMagicUserMetadataByDIDToken(magicDIDToken);
+            if (!magicUserId || magicUserMetadata.issuer !== magicUserId) {
+              throw new ValidationError('MAGIC_USER_MISMATCH');
+            }
+            if (!verifyEmailByMagicUserMetadata(email, magicUserMetadata)) {
+              throw new ValidationError('MAGIC_EMAIL_MISMATCH');
+            }
+            isEmailVerified = true;
+          }
+          const {
+            normalizedEmail,
+            isEmailBlacklisted,
+            isEmailDuplicated,
+          } = await normalizeUserEmail(user, email);
+          if (normalizedEmail) {
+            updateObj.email = email;
+            updateObj.normalizedEmail = normalizedEmail;
+            updateObj.isEmailVerified = isEmailVerified;
+          } else {
+            throw new ValidationError('EMAIL_FORMAT_INCORRECT');
+          }
+          if (isEmailBlacklisted !== undefined) updateObj.isEmailBlacklisted = isEmailBlacklisted;
+          if (isEmailDuplicated !== undefined) updateObj.isEmailDuplicated = isEmailDuplicated;
         }
-        if (isEmailBlacklisted !== undefined) updateObj.isEmailBlacklisted = isEmailBlacklisted;
-        if (isEmailDuplicated !== undefined) updateObj.isEmailDuplicated = isEmailDuplicated;
       }
 
       Object.keys(updateObj).forEach((key) => {
@@ -264,6 +285,24 @@ router.post(
         locale: locale || oldLocale,
         registerTime: timestamp,
       });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+router.post(
+  '/email/check',
+  jwtAuth('write:profile'),
+  validateBody(UsersEmailCheckBodySchema),
+  async (req, res, next) => {
+    try {
+      const { user } = req.user;
+      const { email } = req.body;
+      // Advisory pre-check before triggering a Magic email change: throws
+      // EMAIL_ALREADY_USED if another user holds the email (self is excluded).
+      await userOrWalletByEmailQuery({ user }, email);
+      res.sendStatus(200);
     } catch (err) {
       next(err);
     }

--- a/src/util/api/users/schemas.ts
+++ b/src/util/api/users/schemas.ts
@@ -32,10 +32,15 @@ export const UsersDeleteBodySchema = z.object({
 
 export const UsersUpdateBodySchema = z.object({
   email: z.string().email().optional(),
+  magicDIDToken: z.string().optional(),
   displayName: z.string().optional(),
   description: z.string().optional(),
   locale: z.string().optional(),
   isEmailEnabled: z.union([z.boolean(), z.string()]).optional(),
+});
+
+export const UsersEmailCheckBodySchema = z.object({
+  email: z.string().email(),
 });
 
 export const UsersUpdateAvatarBodySchema = z.object({

--- a/src/util/magic.ts
+++ b/src/util/magic.ts
@@ -38,7 +38,8 @@ export function verifyEmailByMagicUserMetadata(
   email: string,
   magicUserMetadata: MagicUserMetadata,
 ): boolean {
-  return !!magicUserMetadata.email && email === magicUserMetadata.email;
+  return !!email && !!magicUserMetadata.email
+    && email.toLowerCase() === magicUserMetadata.email.toLowerCase();
 }
 
 export async function verifyEmailByMagicDIDToken(

--- a/test/api/user.test.ts
+++ b/test/api/user.test.ts
@@ -1,5 +1,7 @@
 // eslint-disable-next-line import/no-unresolved
-import { describe, it, expect } from 'vitest';
+import {
+  describe, it, expect, vi,
+} from 'vitest';
 import FormData from 'form-data';
 import fs from 'fs';
 import { createHash } from 'crypto';
@@ -31,6 +33,8 @@ import {
   cosmosPrivateKeyNew,
 } from './data';
 import axiosist from './axiosist';
+import { userCollection, FieldValue } from '../../src/util/firebase';
+import { getMagicUserMetadataByDIDToken } from '../../src/util/magic';
 import {
   SUBSCRIPTION_GRACE_PERIOD,
 } from '../../src/constant';
@@ -40,9 +44,33 @@ import {
 
 import { jwtSign } from './jwt';
 
+// Override only the network call; keep verifyEmailByMagicUserMetadata real.
+vi.mock('../../src/util/magic', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/util/magic')>();
+  return {
+    ...actual,
+    getMagicUserMetadataByDIDToken: vi.fn(),
+  };
+});
+const mockGetMagicMetadata = vi.mocked(getMagicUserMetadataByDIDToken);
+
 function signERCProfile(signData, privateKey) {
   const privKey = Buffer.from(privateKey.substr(2), 'hex');
   return sigUtil.personalSign(privKey, { data: web3Utils.utf8ToHex(signData) });
+}
+
+// The stub re-seeds fixtures by reference, so an email write leaks into later
+// tests; restore every email-related field a test touches (deleting ones absent
+// in the snapshot) to keep the suite order-safe.
+async function restoreEmailFields(user: string, before: any) {
+  await userCollection.doc(user).update({
+    email: before.email ?? FieldValue.delete(),
+    magicUserId: before.magicUserId ?? FieldValue.delete(),
+    normalizedEmail: before.normalizedEmail ?? FieldValue.delete(),
+    isEmailVerified: before.isEmailVerified ?? FieldValue.delete(),
+    isEmailBlacklisted: before.isEmailBlacklisted ?? FieldValue.delete(),
+    isEmailDuplicated: before.isEmailDuplicated ?? FieldValue.delete(),
+  });
 }
 
 describe('USER tests', () => {
@@ -205,6 +233,163 @@ describe('USER tests', () => {
 
     expect(res.status).toBe(400);
     expect(res.data).toBe('EMAIL_CANNOT_BE_CHANGED');
+  });
+
+  it('USER: Edit user by JSON from Web. Case: change email for wallet user', async () => {
+    const user = testingUser2;
+    const token = jwtSign({ user });
+    const newEmail = 'changed-login-email@example.com';
+    const before = { ...(await userCollection.doc(user).get()).data() } as any;
+    try {
+      const res = await axiosist.post('/api/users/update', {
+        user,
+        email: newEmail,
+      }, {
+        headers: {
+          Cookie: `likecoin_auth=${token};`,
+        },
+      }).catch((err) => (err as any).response);
+
+      expect(res.status).toBe(200);
+      const data = (await userCollection.doc(user).get()).data() as any;
+      expect(data.email).toBe(newEmail);
+      expect(data.isEmailVerified).toBe(false);
+    } finally {
+      await restoreEmailFields(user, before);
+    }
+  });
+
+  it('USER: Edit user by JSON from Web. Case: magic DID token keeps email verified', async () => {
+    const user = testingUser2;
+    const token = jwtSign({ user });
+    const newEmail = 'magic-changed-email@example.com';
+    const magicUserId = 'did:ethr:0xMagicIssuer';
+    const before = { ...(await userCollection.doc(user).get()).data() } as any;
+    try {
+      await userCollection.doc(user).update({ magicUserId });
+      mockGetMagicMetadata.mockResolvedValue({ issuer: magicUserId, email: newEmail } as any);
+      const res = await axiosist.post('/api/users/update', {
+        user,
+        email: newEmail,
+        magicDIDToken: 'valid-token',
+      }, {
+        headers: {
+          Cookie: `likecoin_auth=${token};`,
+        },
+      }).catch((err) => (err as any).response);
+
+      expect(res.status).toBe(200);
+      const data = (await userCollection.doc(user).get()).data() as any;
+      expect(data.email).toBe(newEmail);
+      expect(data.isEmailVerified).toBe(true);
+    } finally {
+      await restoreEmailFields(user, before);
+    }
+  });
+
+  it('USER: Edit user by JSON from Web. Case: magic DID token issuer mismatch', async () => {
+    const user = testingUser2;
+    const token = jwtSign({ user });
+    const newEmail = 'magic-issuer-mismatch@example.com';
+    const before = { ...(await userCollection.doc(user).get()).data() } as any;
+    try {
+      await userCollection.doc(user).update({ magicUserId: 'did:ethr:0xOwnIssuer' });
+      mockGetMagicMetadata.mockResolvedValue({ issuer: 'did:ethr:0xOtherIssuer', email: newEmail } as any);
+      const res = await axiosist.post('/api/users/update', {
+        user,
+        email: newEmail,
+        magicDIDToken: 'valid-token',
+      }, {
+        headers: {
+          Cookie: `likecoin_auth=${token};`,
+        },
+      }).catch((err) => (err as any).response);
+
+      expect(res.status).toBe(400);
+      expect(res.data).toBe('MAGIC_USER_MISMATCH');
+    } finally {
+      await restoreEmailFields(user, before);
+    }
+  });
+
+  it('USER: Edit user by JSON from Web. Case: magic DID token for non-magic user rejected', async () => {
+    const user = testingUser2;
+    const token = jwtSign({ user });
+    const newEmail = 'magic-no-binding@example.com';
+    // testingUser2 has no magicUserId; a wallet user must not be able to mark an
+    // email verified by supplying any valid Magic token.
+    mockGetMagicMetadata.mockResolvedValue({ issuer: 'did:ethr:0xAnyIssuer', email: newEmail } as any);
+    const res = await axiosist.post('/api/users/update', {
+      user,
+      email: newEmail,
+      magicDIDToken: 'valid-token',
+    }, {
+      headers: {
+        Cookie: `likecoin_auth=${token};`,
+      },
+    }).catch((err) => (err as any).response);
+
+    expect(res.status).toBe(400);
+    expect(res.data).toBe('MAGIC_USER_MISMATCH');
+  });
+
+  it('USER: Edit user by JSON from Web. Case: email already used by another user', async () => {
+    const user = testingUser2;
+    const token = jwtSign({ user });
+    const res = await axiosist.post('/api/users/update', {
+      user,
+      email: testingEmail1,
+    }, {
+      headers: {
+        Cookie: `likecoin_auth=${token};`,
+      },
+    }).catch((err) => (err as any).response);
+
+    expect(res.status).toBe(400);
+    expect(res.data).toBe('EMAIL_ALREADY_USED');
+  });
+
+  it('USER: Email availability pre-check. Case: available', async () => {
+    const user = testingUser2;
+    const token = jwtSign({ user });
+    const res = await axiosist.post('/api/users/email/check', {
+      email: 'brand-new-unused-email@example.com',
+    }, {
+      headers: {
+        Cookie: `likecoin_auth=${token};`,
+      },
+    }).catch((err) => (err as any).response);
+
+    expect(res.status).toBe(200);
+  });
+
+  it('USER: Email availability pre-check. Case: already used', async () => {
+    const user = testingUser2;
+    const token = jwtSign({ user });
+    const res = await axiosist.post('/api/users/email/check', {
+      email: testingEmail1,
+    }, {
+      headers: {
+        Cookie: `likecoin_auth=${token};`,
+      },
+    }).catch((err) => (err as any).response);
+
+    expect(res.status).toBe(400);
+    expect(res.data).toBe('EMAIL_ALREADY_USED');
+  });
+
+  it('USER: Email availability pre-check. Case: own email is self-excluded', async () => {
+    const user = testingUser2;
+    const token = jwtSign({ user });
+    const res = await axiosist.post('/api/users/email/check', {
+      email: testingEmail2,
+    }, {
+      headers: {
+        Cookie: `likecoin_auth=${token};`,
+      },
+    }).catch((err) => (err as any).response);
+
+    expect(res.status).toBe(200);
   });
 
   it('USER: Edit user by JSON from Web. Case: Incorrect email format', async () => {


### PR DESCRIPTION
Add POST /users/email/check as an authenticated, self-excluding uniqueness pre-check so the client can confirm an email is free before triggering Magic's email change. Teach POST /users/update to accept a magicDIDToken: when present, verify the token's issuer matches the user's magicUserId and its email matches, then keep isEmailVerified true (Magic already OTP-verifies); wallet users still reset the flag.