### PR TITLE
🐛 Translate Magic SDK errors to 401 instead of 500

### DIFF
--- a/src/util/magic.ts
+++ b/src/util/magic.ts
@@ -1,6 +1,9 @@
-import { Magic, MagicUserMetadata } from '@magic-sdk/admin';
+import { Magic, MagicUserMetadata, SDKError } from '@magic-sdk/admin';
 
 import { MAGIC_SECRET_API_KEY } from '../../config/config';
+import { ValidationError } from './ValidationError';
+
+const MAGIC_TOKEN_VERIFICATION_FAILED = 'MAGIC_TOKEN_VERIFICATION_FAILED';
 
 let magicInstance: Magic;
 
@@ -13,7 +16,24 @@ export async function getMagic(): Promise<Magic> {
 
 export async function getMagicUserMetadataByDIDToken(didToken: string): Promise<MagicUserMetadata> {
   const magic = await getMagic();
-  return magic.users.getMetadataByToken(didToken);
+  try {
+    return await magic.users.getMetadataByToken(didToken);
+  } catch (err) {
+    // Magic SDK errors (expired/malformed token, or SERVICE_ERROR from the Magic
+    // API) are not ValidationErrors, so they would surface as an opaque 500 and
+    // the nested `data` cause would be lost. Log the cause for diagnosis, then
+    // translate to a clean 401. Fails closed: email stays unverified on failure.
+    if (err instanceof SDKError) {
+      // eslint-disable-next-line no-console
+      console.error(JSON.stringify({
+        message: MAGIC_TOKEN_VERIFICATION_FAILED,
+        code: err.code,
+        data: err.data,
+      }));
+      throw new ValidationError(MAGIC_TOKEN_VERIFICATION_FAILED, 401);
+    }
+    throw err;
+  }
 }
 
 export function verifyEmailByMagicUserMetadata(

--- a/src/util/magic.ts
+++ b/src/util/magic.ts
@@ -19,10 +19,8 @@ export async function getMagicUserMetadataByDIDToken(didToken: string): Promise<
   try {
     return await magic.users.getMetadataByToken(didToken);
   } catch (err) {
-    // Magic SDK errors (expired/malformed token, or SERVICE_ERROR from the Magic
-    // API) are not ValidationErrors, so they would surface as an opaque 500 and
-    // the nested `data` cause would be lost. Log the cause for diagnosis, then
-    // translate to a clean 401. Fails closed: email stays unverified on failure.
+    // Magic SDK errors aren't ValidationErrors, so they'd surface as 500s and lose `data`.
+    // Log the code/data for diagnosis and translate to a 401; verification fails closed.
     if (err instanceof SDKError) {
       // eslint-disable-next-line no-console
       console.error(JSON.stringify({


### PR DESCRIPTION
Magic DID-token failures (expired/malformed token, or SERVICE_ERROR from the Magic API) bubbled up as opaque 500s and lost the nested `data` cause. Catch SDKError in getMagicUserMetadataByDIDToken, log code+data for diagnosis, and rethrow as a 401 ValidationError. Fails closed: email stays unverified on any verification failure.