### PR TITLE
🚀 Cache NFT class owner and metadata chain reads

### DIFF
--- a/src/routes/likernft/book/store.ts
+++ b/src/routes/likernft/book/store.ts
@@ -736,9 +736,11 @@ router.post(['/:classId/new', '/class/:classId/new'], jwtAuth('write:nftbook'), 
 
     let ownerWallet = '';
 
+    // Bypass cache: a stale owner could let a prior owner pass the
+    // authorization check below for up to 10 min after a transfer.
     const [classData, classOwner] = await Promise.all([
-      getEVMNFTClassDataById(classId),
-      getEVMNFTClassOwner(classId),
+      getEVMNFTClassDataById(classId, { skipCache: true }),
+      getEVMNFTClassOwner(classId, { skipCache: true }),
     ]);
     const metadata = classData;
     ownerWallet = classOwner;

--- a/src/util/api/likernft/book/index.ts
+++ b/src/util/api/likernft/book/index.ts
@@ -116,10 +116,13 @@ export function getPreviewContentFromHasPart(
   return previewPart?.text;
 }
 
-export async function getNFTClassDataById(classId: string): Promise<NFTClassData | null> {
+export async function getNFTClassDataById(
+  classId: string,
+  { skipCache = false }: { skipCache?: boolean } = {},
+): Promise<NFTClassData | null> {
   if (isEVMClassId(classId)) {
     try {
-      return (await getEVMNftClassDataById(classId)) as NFTClassData;
+      return (await getEVMNftClassDataById(classId, { skipCache })) as NFTClassData;
     } catch (error) {
       return null;
     }
@@ -368,8 +371,10 @@ export async function getNftBookInfo(classId: string): Promise<NFTBookListingInf
 }
 
 export async function syncNFTBookInfoWithISCN(classId) {
+  // Bypass cache: this sync runs after the user updated on-chain metadata,
+  // so it must read fresh chain data to refresh the DB.
   const [classData, bookInfo] = await Promise.all([
-    getNFTClassDataById(classId),
+    getNFTClassDataById(classId, { skipCache: true }),
     getNftBookInfo(classId),
   ]);
   const metadata = {

--- a/src/util/evm/nft.ts
+++ b/src/util/evm/nft.ts
@@ -2,6 +2,7 @@
 import { readContract } from 'viem/actions';
 import { getAddress } from 'viem';
 import axios from 'axios';
+import LRU from 'lru-cache';
 import { getEVMClient, getEVMWalletAccount, getEVMWalletClient } from './client';
 import { LIKE_NFT_ABI, LIKE_NFT_CLASS_ABI, LIKE_NFT_CONTRACT_ADDRESS } from './LikeNFT';
 import { sendWriteContractWithNonce } from './tx';
@@ -102,12 +103,22 @@ export function isEVMClassId(classId) {
   return classId.startsWith('0x');
 }
 
-export async function getNFTClassOwner(classId) {
+const nftClassOwnerCache = new LRU({ max: 4096, ttl: 10 * 60 * 1000 }); // 10 min
+
+export async function getNFTClassOwner(classId, { skipCache = false }: {
+  skipCache?: boolean;
+} = {}) {
+  const address = getAddress(classId);
+  if (!skipCache) {
+    const cachedOwner = nftClassOwnerCache.get(address);
+    if (cachedOwner !== undefined) return cachedOwner as string;
+  }
   const owner = await readContract(getEVMClient(), {
-    address: getAddress(classId),
+    address,
     abi: LIKE_NFT_CLASS_ABI,
     functionName: 'owner',
   });
+  nftClassOwnerCache.set(address, owner);
   return owner as string;
 }
 
@@ -121,9 +132,18 @@ export async function getNFTOwner(classId, tokenId: number) {
   return owner as string;
 }
 
-export async function getNFTClassDataById(classId) {
+const nftClassDataCache = new LRU({ max: 4096, ttl: 10 * 60 * 1000 }); // 10 min
+
+export async function getNFTClassDataById(classId, { skipCache = false }: {
+  skipCache?: boolean;
+} = {}) {
+  const address = getAddress(classId);
+  if (!skipCache) {
+    const cachedData = nftClassDataCache.get(address);
+    if (cachedData !== undefined) return cachedData;
+  }
   let dataString = await readContract(getEVMClient(), {
-    address: getAddress(classId),
+    address,
     abi: LIKE_NFT_CLASS_ABI,
     functionName: 'contractURI',
   }) as string;
@@ -137,7 +157,9 @@ export async function getNFTClassDataById(classId) {
   if (isBase64) {
     dataString = Buffer.from(dataString, 'base64').toString('utf-8');
   }
-  return JSON.parse(dataString);
+  const data = JSON.parse(dataString);
+  nftClassDataCache.set(address, data);
+  return data;
 }
 
 export async function getNFTClassBalanceOf(classId, wallet) {


### PR DESCRIPTION
owner() and contractURI() are effectively immutable per class and were firing on every metadata request, so memoize getNFTClassOwner and getNFTClassDataById in 10-min LRUs to absorb cache-miss bursts on Base.

Add a skipCache opt-out and use it on the paths that must read fresh:
- new-listing authorization (a stale owner could let a prior owner pass the NOT_OWNER_OF_NFT_CLASS check for up to 10 min after transfer)
- syncNFTBookInfoWithISCN, which refreshes the DB after a user updates on-chain metadata and so must not read a stale cached copy