### PR TITLE
🔒 Wrap Arweave content keys at rest with Cloud KMS

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -70,6 +70,9 @@ config.REPLICA_IPFS_ENDPOINTS = [];
 config.ARWEAVE_LINK_INTERNAL_TOKEN = '';
 config.ARWEAVE_SPONSORED_DAILY_UPLOAD_LIMIT = 10;
 config.ARWEAVE_SPONSORED_DAILY_BYTES_LIMIT = 100 * 1024 * 1024; // 100MB
+// Cloud KMS cryptoKey resource name used to wrap content keys at rest in
+// Firestore. Empty = passthrough (dev/test store plaintext); prod sets this.
+config.ARWEAVE_KEY_KMS_NAME = process.env.ARWEAVE_KEY_KMS_NAME || '';
 
 config.LIKER_NFT_TARGET_ADDRESS = '';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-ses": "^3.0.0",
         "@cosmjs/stargate": "^0.30.1",
+        "@google-cloud/kms": "^5.5.1",
         "@google-cloud/pubsub": "^5.2.0",
         "@google-cloud/storage": "^7.16.0",
         "@irys/sdk": "^0.2.11",
@@ -2904,6 +2905,18 @@
       "optional": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@google-cloud/kms": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/kms/-/kms-5.5.1.tgz",
+      "integrity": "sha512-7O3mnspIlotzToIsSrv+YfnGhGdncOyZmjI0gG/r+jcsYN0t8WCa8v9YGuZ0F1VRa+49p/hUT/6ZQh9/s79PfA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-gax": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@google-cloud/paginator": {
@@ -20914,6 +20927,14 @@
           "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
           "optional": true
         }
+      }
+    },
+    "@google-cloud/kms": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/kms/-/kms-5.5.1.tgz",
+      "integrity": "sha512-7O3mnspIlotzToIsSrv+YfnGhGdncOyZmjI0gG/r+jcsYN0t8WCa8v9YGuZ0F1VRa+49p/hUT/6ZQh9/s79PfA==",
+      "requires": {
+        "google-gax": "^5.0.0"
       }
     },
     "@google-cloud/paginator": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@aws-sdk/client-ses": "^3.0.0",
     "@cosmjs/stargate": "^0.30.1",
+    "@google-cloud/kms": "^5.5.1",
     "@google-cloud/pubsub": "^5.2.0",
     "@google-cloud/storage": "^7.16.0",
     "@irys/sdk": "^0.2.11",

--- a/src/routes/arweave/index.ts
+++ b/src/routes/arweave/index.ts
@@ -17,6 +17,7 @@ import {
   getArweaveTxInfo,
   updateArweaveTxStatus,
   rotateArweaveTxAccessToken,
+  resolveArweaveTxKey,
 } from '../../util/api/arweave/tx';
 import { getRemainingQuota, checkAndReserveQuota, rollbackQuota } from '../../util/api/arweave/quota';
 import {
@@ -264,7 +265,7 @@ router.get(
       const tx = await getArweaveTxInfo(txHash);
       if (!tx) throw new ValidationError('TX_NOT_FOUND', 404);
       const {
-        arweaveId, token: docToken, isRequireAuth, ownerWallet, key,
+        arweaveId, token: docToken, isRequireAuth, ownerWallet,
         accessToken: docAccessToken,
       } = tx;
       if (isRequireAuth) {
@@ -275,6 +276,9 @@ router.get(
           || (docAccessToken && token === docAccessToken);
         if (!isUserAuthed && !isTokenAuthed) throw new ValidationError('INVALID_TOKEN', 403);
       }
+      // Unwrap only after access checks pass, so we never call KMS for a request
+      // that isn't authorized to receive the key.
+      const key = await resolveArweaveTxKey(tx, txHash);
       const link = new URL(`${ARWEAVE_GATEWAY}/${arweaveId}`);
       if (key) {
         link.searchParams.set('key', key);

--- a/src/types/transaction.d.ts
+++ b/src/types/transaction.d.ts
@@ -39,7 +39,8 @@ export interface ArweaveTxData {
   lastUpdateTimestamp?: any;
   arweaveId?: string;
   isRequireAuth?: boolean;
-  key?: string;
+  key?: string; // legacy plaintext content key; superseded by encryptedKey
+  encryptedKey?: string; // base64 KMS-wrapped content key (AAD = txHash)
   accessToken?: string;
   isSponsored?: boolean;
   sponsoredETH?: string;

--- a/src/util/api/arweave/tx.ts
+++ b/src/util/api/arweave/tx.ts
@@ -1,5 +1,6 @@
 import uuidv4 from 'uuid/v4';
 import { FieldValue, iscnArweaveTxCollection } from '../../firebase';
+import { wrapKey, unwrapKey, isKMSEnabled } from '../../kms';
 import type { ArweaveTxData } from '../../../types/transaction';
 
 export async function createNewArweaveTx(docId: string, {
@@ -47,16 +48,36 @@ export async function updateArweaveTxStatus(txHash: string, {
   isRequireAuth?: boolean;
 }): Promise<string> {
   const accessToken = uuidv4();
+  // Under KMS store wrapped ciphertext in `encryptedKey` (AAD = txHash); in
+  // passthrough store plaintext in legacy `key` so enabling KMS later never
+  // decrypts non-ciphertext. Delete the opposite field to leave no plaintext.
+  let keyFields = {};
+  if (key) {
+    keyFields = isKMSEnabled()
+      ? { encryptedKey: await wrapKey(key, txHash), key: FieldValue.delete() }
+      : { key, encryptedKey: FieldValue.delete() };
+  }
   await iscnArweaveTxCollection.doc(txHash).update({
     status: 'complete',
     arweaveId,
     isRequireAuth,
     ownerWallet,
-    key,
+    ...keyFields,
     accessToken,
     lastUpdateTimestamp: FieldValue.serverTimestamp(),
   });
   return accessToken;
+}
+
+// Dual-read: KMS-wrapped `encryptedKey` (AAD = txHash) vs legacy plaintext `key`.
+// Gate unwrap on isKMSEnabled() — a passthrough unwrapKey returns ciphertext
+// verbatim, so a KMS-written doc read without KMS yields '' not leaked ciphertext.
+export async function resolveArweaveTxKey(
+  tx: ArweaveTxData,
+  txHash: string,
+): Promise<string> {
+  if (tx.encryptedKey && isKMSEnabled()) return unwrapKey(tx.encryptedKey, txHash);
+  return tx.key || '';
 }
 
 export async function rotateArweaveTxAccessToken(txHash: string): Promise<string> {

--- a/src/util/api/likernft/book/cache.ts
+++ b/src/util/api/likernft/book/cache.ts
@@ -4,7 +4,7 @@ import type { File } from '@google-cloud/storage';
 
 import { ARWEAVE_GATEWAY, API_HOSTNAME } from '../../../../constant';
 import { bookCacheBucket } from '../../../gcloudStorage';
-import { getArweaveTxInfo } from '../../arweave/tx';
+import { getArweaveTxInfo, resolveArweaveTxKey } from '../../arweave/tx';
 import type { NFTClassData } from './index';
 
 // Mirrors the gateway lists in likecoin-cloud-functions/ebook-cors/nft/http.js.
@@ -71,7 +71,8 @@ async function resolveBookFileCacheURL(
     const tx = await getArweaveTxInfo(txHash);
     if (!tx?.arweaveId) return undefined;
     const link = new URL(`${ARWEAVE_GATEWAY}/${tx.arweaveId}`);
-    if (tx.key) link.searchParams.set('key', tx.key);
+    const key = await resolveArweaveTxKey(tx, txHash);
+    if (key) link.searchParams.set('key', key);
     parsedURL = link;
   }
 

--- a/src/util/kms.ts
+++ b/src/util/kms.ts
@@ -1,0 +1,49 @@
+import { KeyManagementServiceClient } from '@google-cloud/kms';
+import { ARWEAVE_KEY_KMS_NAME } from '../../config/config';
+
+import serviceAccount from '../../config/serviceAccountKey.json';
+
+// Lazily construct the client so dev/test runs without KMS configured never
+// build a KMS client or open a network connection. (The service-account JSON
+// is still loaded at module import — only the client/network is deferred.)
+let client: KeyManagementServiceClient | undefined;
+function getClient(): KeyManagementServiceClient {
+  if (!client) {
+    client = new KeyManagementServiceClient({ credentials: serviceAccount });
+  }
+  return client;
+}
+
+// Whether KMS wrapping is active. When false, wrapKey/unwrapKey passthrough
+// and callers should store the content key in the legacy plaintext field.
+export function isKMSEnabled(): boolean {
+  return !!ARWEAVE_KEY_KMS_NAME;
+}
+
+// Wrap a plaintext content key with Cloud KMS, returning base64 ciphertext
+// (or the plaintext unchanged when KMS is unconfigured — passthrough).
+// `aad` (the txHash) binds the ciphertext to its document — a wrapped key
+// copied to another doc fails to decrypt.
+export async function wrapKey(plaintext: string, aad: string): Promise<string> {
+  if (!ARWEAVE_KEY_KMS_NAME) return plaintext;
+  const [result] = await getClient().encrypt({
+    name: ARWEAVE_KEY_KMS_NAME,
+    plaintext: Buffer.from(plaintext, 'utf8'),
+    additionalAuthenticatedData: Buffer.from(aad, 'utf8'),
+  });
+  if (!result.ciphertext) throw new Error('KMS_ENCRYPT_EMPTY_CIPHERTEXT');
+  return Buffer.from(result.ciphertext).toString('base64');
+}
+
+// Unwrap a base64 ciphertext produced by wrapKey. The same `aad` must be
+// supplied or KMS rejects the decrypt. Passthrough when KMS is unconfigured.
+export async function unwrapKey(ciphertextB64: string, aad: string): Promise<string> {
+  if (!ARWEAVE_KEY_KMS_NAME) return ciphertextB64;
+  const [result] = await getClient().decrypt({
+    name: ARWEAVE_KEY_KMS_NAME,
+    ciphertext: Buffer.from(ciphertextB64, 'base64'),
+    additionalAuthenticatedData: Buffer.from(aad, 'utf8'),
+  });
+  if (!result.plaintext) throw new Error('KMS_DECRYPT_EMPTY_PLAINTEXT');
+  return Buffer.from(result.plaintext).toString('utf8');
+}

--- a/test/util/kms.test.ts
+++ b/test/util/kms.test.ts
@@ -1,0 +1,53 @@
+import {
+  describe, it, expect, vi,
+} from 'vitest';
+
+// Resolve to the in-repo config path (unlike test/setup.ts, whose mock path
+// lands outside the repo) so this mock actually reaches src/util/kms.ts and
+// makes it treat KMS as configured.
+vi.mock('../../config/config', () => ({
+  ARWEAVE_KEY_KMS_NAME: 'projects/p/locations/l/keyRings/r/cryptoKeys/k',
+}));
+
+// In-memory KMS that enforces AAD: ciphertext carries both the plaintext and
+// the AAD, and decrypt rejects when the supplied AAD differs.
+vi.mock('@google-cloud/kms', () => {
+  class KeyManagementServiceClient {
+    // eslint-disable-next-line class-methods-use-this
+    async encrypt({ plaintext, additionalAuthenticatedData }) {
+      const payload = JSON.stringify({
+        p: Buffer.from(plaintext).toString('utf8'),
+        a: Buffer.from(additionalAuthenticatedData).toString('utf8'),
+      });
+      return [{ ciphertext: Buffer.from(payload, 'utf8') }];
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    async decrypt({ ciphertext, additionalAuthenticatedData }) {
+      const { p, a } = JSON.parse(Buffer.from(ciphertext).toString('utf8'));
+      if (a !== Buffer.from(additionalAuthenticatedData).toString('utf8')) {
+        throw new Error('AAD mismatch');
+      }
+      return [{ plaintext: Buffer.from(p, 'utf8') }];
+    }
+  }
+  return { KeyManagementServiceClient };
+});
+
+// eslint-disable-next-line import/first
+import { wrapKey, unwrapKey } from '../../src/util/kms';
+
+describe('kms key wrapping', () => {
+  it('round-trips a content key under the same AAD', async () => {
+    const key = 'a'.repeat(64); // 32-byte key, hex-encoded
+    const wrapped = await wrapKey(key, 'tx-hash-1');
+    expect(wrapped).not.toBe(key);
+    const unwrapped = await unwrapKey(wrapped, 'tx-hash-1');
+    expect(unwrapped).toBe(key);
+  });
+
+  it('rejects unwrapping with a different AAD (anti-transplant)', async () => {
+    const wrapped = await wrapKey('secret', 'tx-hash-1');
+    await expect(unwrapKey(wrapped, 'tx-hash-2')).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
Encrypt the Firestore content key via Cloud KMS, binding the ciphertext to its document with AAD = txHash so a wrapped key can't be transplanted. A shared resolver dual-reads new encryptedKey and legacy plaintext key, and both write and read no-op to passthrough when KMS is unconfigured (dev/test). Wire contract is unchanged — readers still get the plaintext key after access checks pass.