### PR TITLE
[TAS-5398] 🔥 Drop AuthCore email-change restriction

### DIFF
--- a/src/routes/users/registerLogin.ts
+++ b/src/routes/users/registerLogin.ts
@@ -213,7 +213,6 @@ router.post(
         displayName: oldDisplayName,
         email: oldEmail,
         locale: oldLocale,
-        authCoreUserId,
         magicUserId,
       } = oldUserData;
 
@@ -225,7 +224,6 @@ router.post(
       };
 
       if (email) {
-        if (authCoreUserId && oldEmail) throw new ValidationError('EMAIL_CANNOT_BE_CHANGED');
         // Only re-run uniqueness/verification when the email actually changes, so
         // resubmitting an unchanged email doesn't reset isEmailVerified for wallet users.
         if (email.toLowerCase() !== (oldEmail || '').toLowerCase()) {
@@ -299,8 +297,9 @@ router.post(
     try {
       const { user } = req.user;
       const { email } = req.body;
-      // Advisory pre-check before triggering a Magic email change: throws
-      // EMAIL_ALREADY_USED if another user holds the email (self is excluded).
+      // Advisory pre-check before a Magic email change, mirroring /update's only
+      // reachable error here: EMAIL_ALREADY_USED if another user holds the email
+      // (self excluded). Format is already rejected by the shared zod .email() schema.
       await userOrWalletByEmailQuery({ user }, email);
       res.sendStatus(200);
     } catch (err) {

--- a/src/routes/users/registerLogin.ts
+++ b/src/routes/users/registerLogin.ts
@@ -213,6 +213,7 @@ router.post(
         displayName: oldDisplayName,
         email: oldEmail,
         locale: oldLocale,
+        evmWallet,
         magicUserId,
       } = oldUserData;
 
@@ -228,17 +229,27 @@ router.post(
         // resubmitting an unchanged email doesn't reset isEmailVerified for wallet users.
         if (email.toLowerCase() !== (oldEmail || '').toLowerCase()) {
           await userOrWalletByEmailQuery({ user }, email);
-          // Magic OTP-verifies email changes, so a DID token whose issuer matches the
-          // user's magicUserId lets us keep isEmailVerified; wallet users (no token)
-          // reset it. The issuer match stops a wallet user claiming verification.
+          // Magic OTP-verifies email changes, so a DID token lets us keep
+          // isEmailVerified; wallet users (no token) reset it. When the user
+          // already has a magicUserId the token issuer must match it.
           let isEmailVerified = false;
           if (magicDIDToken) {
             const magicUserMetadata = await getMagicUserMetadataByDIDToken(magicDIDToken);
-            if (!magicUserId || magicUserMetadata.issuer !== magicUserId) {
+            if (magicUserId && magicUserMetadata.issuer !== magicUserId) {
               throw new ValidationError('MAGIC_USER_MISMATCH');
             }
             if (!verifyEmailByMagicUserMetadata(email, magicUserMetadata)) {
               throw new ValidationError('MAGIC_EMAIL_MISMATCH');
+            }
+            // Some users were migrated without a magicUserId. Backfill it from the
+            // token only when its wallet matches the account's evmWallet, so an
+            // authenticated session can't bind an unrelated Magic identity.
+            if (!magicUserId) {
+              if (!evmWallet
+                || magicUserMetadata.publicAddress?.toLowerCase() !== evmWallet.toLowerCase()) {
+                throw new ValidationError('MAGIC_USER_MISMATCH');
+              }
+              updateObj.magicUserId = magicUserMetadata.issuer;
             }
             isEmailVerified = true;
           }

--- a/test/api/user.test.ts
+++ b/test/api/user.test.ts
@@ -215,7 +215,7 @@ describe('USER tests', () => {
     expect(res.status).toBe(200);
   });
 
-  it('USER: Edit user by JSON from Web. Case: editing existing email', async () => {
+  it('USER: Edit user by JSON from Web. Case: authCore user resubmitting existing email is allowed', async () => {
     const user = testingUser1;
     const token = jwtSign({ user });
     const payload = {
@@ -231,8 +231,7 @@ describe('USER tests', () => {
       },
     }).catch((err) => (err as any).response);
 
-    expect(res.status).toBe(400);
-    expect(res.data).toBe('EMAIL_CANNOT_BE_CHANGED');
+    expect(res.status).toBe(200);
   });
 
   it('USER: Edit user by JSON from Web. Case: change email for wallet user', async () => {

--- a/test/api/user.test.ts
+++ b/test/api/user.test.ts
@@ -311,13 +311,49 @@ describe('USER tests', () => {
     }
   });
 
-  it('USER: Edit user by JSON from Web. Case: magic DID token for non-magic user rejected', async () => {
+  it('USER: Edit user by JSON from Web. Case: magic DID token backfills missing magicUserId', async () => {
     const user = testingUser2;
     const token = jwtSign({ user });
     const newEmail = 'magic-no-binding@example.com';
-    // testingUser2 has no magicUserId; a wallet user must not be able to mark an
-    // email verified by supplying any valid Magic token.
-    mockGetMagicMetadata.mockResolvedValue({ issuer: 'did:ethr:0xAnyIssuer', email: newEmail } as any);
+    const issuer = 'did:ethr:0xAnyIssuer';
+    const before = { ...(await userCollection.doc(user).get()).data() } as any;
+    try {
+      // testingUser2 has no magicUserId (migrated without it); a valid Magic
+      // token whose wallet matches the account backfills the binding and verifies.
+      mockGetMagicMetadata.mockResolvedValue({
+        issuer, email: newEmail, publicAddress: testingWallet2,
+      } as any);
+      const res = await axiosist.post('/api/users/update', {
+        user,
+        email: newEmail,
+        magicDIDToken: 'valid-token',
+      }, {
+        headers: {
+          Cookie: `likecoin_auth=${token};`,
+        },
+      }).catch((err) => (err as any).response);
+
+      expect(res.status).toBe(200);
+      const data = (await userCollection.doc(user).get()).data() as any;
+      expect(data.email).toBe(newEmail);
+      expect(data.magicUserId).toBe(issuer);
+      expect(data.isEmailVerified).toBe(true);
+    } finally {
+      await restoreEmailFields(user, before);
+    }
+  });
+
+  it('USER: Edit user by JSON from Web. Case: magic token from unrelated wallet rejected', async () => {
+    const user = testingUser2;
+    const token = jwtSign({ user });
+    const newEmail = 'magic-wrong-wallet@example.com';
+    // Without a stored magicUserId, a token whose wallet differs from the
+    // account's evmWallet must not bind an unrelated Magic identity.
+    mockGetMagicMetadata.mockResolvedValue({
+      issuer: 'did:ethr:0xUnrelated',
+      email: newEmail,
+      publicAddress: '0x0000000000000000000000000000000000000001',
+    } as any);
     const res = await axiosist.post('/api/users/update', {
       user,
       email: newEmail,


### PR DESCRIPTION
AuthCore users are migrated to Magic/wallet, so the EMAIL_CANNOT_BE_CHANGED guard in POST /users/update no longer applies. Removing it lets them change their login email like everyone else, and keeps POST /users/email/check a faithful pre-check: both now surface the same reachable error (EMAIL_ALREADY_USED), with format guarded by the shared zod schema.