### PR TITLE
[TAS-5398] 🐛 Run Magic verification on email update even when unchanged

### DIFF
--- a/src/routes/users/registerLogin.ts
+++ b/src/routes/users/registerLogin.ts
@@ -225,13 +225,13 @@ router.post(
       };
 
       if (email) {
-        // Only re-run uniqueness/verification when the email actually changes, so
-        // resubmitting an unchanged email doesn't reset isEmailVerified for wallet users.
-        if (email.toLowerCase() !== (oldEmail || '').toLowerCase()) {
-          await userOrWalletByEmailQuery({ user }, email);
+        const isEmailChanged = email.toLowerCase() !== (oldEmail || '').toLowerCase();
+        // Process when the email changes, or when a Magic token is present so an
+        // unchanged email can still re-verify and backfill magicUserId. A wallet
+        // user resubmitting an unchanged email (no token) keeps isEmailVerified.
+        if (isEmailChanged || magicDIDToken) {
           // Magic OTP-verifies email changes, so a DID token lets us keep
-          // isEmailVerified; wallet users (no token) reset it. When the user
-          // already has a magicUserId the token issuer must match it.
+          // isEmailVerified; wallet users (no token) reset it.
           let isEmailVerified = false;
           if (magicDIDToken) {
             const magicUserMetadata = await getMagicUserMetadataByDIDToken(magicDIDToken);
@@ -253,20 +253,23 @@ router.post(
             }
             isEmailVerified = true;
           }
-          const {
-            normalizedEmail,
-            isEmailBlacklisted,
-            isEmailDuplicated,
-          } = await normalizeUserEmail(user, email);
-          if (normalizedEmail) {
+          // Uniqueness and normalization only matter when the email actually changes.
+          if (isEmailChanged) {
+            await userOrWalletByEmailQuery({ user }, email);
+            const {
+              normalizedEmail,
+              isEmailBlacklisted,
+              isEmailDuplicated,
+            } = await normalizeUserEmail(user, email);
+            if (!normalizedEmail) {
+              throw new ValidationError('EMAIL_FORMAT_INCORRECT');
+            }
             updateObj.email = email;
             updateObj.normalizedEmail = normalizedEmail;
-            updateObj.isEmailVerified = isEmailVerified;
-          } else {
-            throw new ValidationError('EMAIL_FORMAT_INCORRECT');
+            if (isEmailBlacklisted !== undefined) updateObj.isEmailBlacklisted = isEmailBlacklisted;
+            if (isEmailDuplicated !== undefined) updateObj.isEmailDuplicated = isEmailDuplicated;
           }
-          if (isEmailBlacklisted !== undefined) updateObj.isEmailBlacklisted = isEmailBlacklisted;
-          if (isEmailDuplicated !== undefined) updateObj.isEmailDuplicated = isEmailDuplicated;
+          updateObj.isEmailVerified = isEmailVerified;
         }
       }
 

--- a/test/api/user.test.ts
+++ b/test/api/user.test.ts
@@ -368,6 +368,37 @@ describe('USER tests', () => {
     expect(res.data).toBe('MAGIC_USER_MISMATCH');
   });
 
+  it('USER: Edit user by JSON from Web. Case: magic token backfills magicUserId without email change', async () => {
+    const user = testingUser2;
+    const token = jwtSign({ user });
+    const issuer = 'did:ethr:0xSameWallet';
+    const before = { ...(await userCollection.doc(user).get()).data() } as any;
+    try {
+      // Resubmitting the unchanged email with a wallet-matching Magic token still
+      // backfills magicUserId and re-verifies, instead of returning INVALID_PAYLOAD.
+      mockGetMagicMetadata.mockResolvedValue({
+        issuer, email: testingEmail2, publicAddress: testingWallet2,
+      } as any);
+      const res = await axiosist.post('/api/users/update', {
+        user,
+        email: testingEmail2,
+        magicDIDToken: 'valid-token',
+      }, {
+        headers: {
+          Cookie: `likecoin_auth=${token};`,
+        },
+      }).catch((err) => (err as any).response);
+
+      expect(res.status).toBe(200);
+      const data = (await userCollection.doc(user).get()).data() as any;
+      expect(data.email).toBe(testingEmail2);
+      expect(data.magicUserId).toBe(issuer);
+      expect(data.isEmailVerified).toBe(true);
+    } finally {
+      await restoreEmailFields(user, before);
+    }
+  });
+
   it('USER: Edit user by JSON from Web. Case: email already used by another user', async () => {
     const user = testingUser2;
     const token = jwtSign({ user });


### PR DESCRIPTION
The /users/update email block only ran when the email actually changed, so a Magic user resubmitting their current email (sending just email + magicDIDToken) got INVALID_PAYLOAD and could never re-verify or backfill a missing magicUserId. Gate the block on isEmailChanged || magicDIDToken: process the token whenever present, while keeping the uniqueness and normalization writes change-only so an unchanged email skips those calls. Wallet users with no token still no-op.