### PR TITLE
📈 Emit PlusAcquisition conversion event from webhooks

### DIFF
--- a/src/util/analyticsEvents.ts
+++ b/src/util/analyticsEvents.ts
@@ -3,6 +3,7 @@ export type ServerEventName =
   | 'InitiateCheckout'
   | 'StartTrial'
   | 'Subscribe'
+  | 'PlusAcquisition'
   | 'SubscriptionCancelled'
   | 'TrialEnded'
   | 'SubscriptionRenewed'
@@ -19,6 +20,7 @@ export const SERVER_EVENT_MAP: Record<ServerEventName, string> = {
   InitiateCheckout: 'begin_checkout',
   StartTrial: 'start_trial',
   Subscribe: 'subscribe',
+  PlusAcquisition: 'plus_acquisition',
   SubscriptionCancelled: 'subscription_cancelled',
   TrialEnded: 'trial_ended',
   SubscriptionRenewed: 'subscription_renewed',

--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -454,7 +454,9 @@ export async function processStripeSubscriptionInvoice(
   // Trial to paid upgrade is handled in processStripeSubscriptionUpdate
   if (isSubscriptionCreation || isTrialToPaidUpgrade) {
     const { value: predictedLTV } = getPlusPredictedLTV(isTrial, currency);
-    await logServerEvents(isTrial ? 'StartTrial' : 'Subscribe', {
+    // Shared payload for the Subscribe/StartTrial and PlusAcquisition events; they must
+    // carry identical attribution and value so the browser pixel can dedup against them.
+    const acquisitionEventPayload = {
       email: user.email || stripeCustomer.email || undefined,
       items: [{
         productId: `plus-${period}ly`,
@@ -486,7 +488,19 @@ export async function processStripeSubscriptionInvoice(
         $referrer: referrer,
       },
       setOnce: referrer ? { $initial_referrer: referrer } : undefined,
-    });
+    };
+    // Independent analytics emits — fire in parallel (matches the renewal/Airtable paths).
+    const events = [logServerEvents(isTrial ? 'StartTrial' : 'Subscribe', acquisitionEventPayload)];
+    // Unified acquisition event — fired once per new subscription (creation only,
+    // NOT on trial→paid upgrade) so it counts each subscription exactly once. This is
+    // the single signal to optimize Meta on; mirrored by the browser pixel.
+    if (isSubscriptionCreation) {
+      events.push(logServerEvents('PlusAcquisition', {
+        ...acquisitionEventPayload,
+        extraProperties: { ...acquisitionEventPayload.extraProperties, is_trial: isTrial },
+      }));
+    }
+    await Promise.all(events);
   } else if (billingReason === 'subscription_cycle' && amountPaid > 0) {
     await logServerEvents('SubscriptionRenewed', {
       evmWallet,

--- a/src/util/api/plus/revenuecat.ts
+++ b/src/util/api/plus/revenuecat.ts
@@ -411,7 +411,11 @@ async function handleGrant(
     // IAP server-side conversion (Meta CAPI / GA / PostHog) carries the same
     // attribution the Stripe Subscribe/StartTrial event does (see index.ts).
     const referrer = getSubscriberAttribute(event, 'referrer');
-    sideEffects.push(logServerEvents(logEvent, {
+    // Shared payload for the Subscribe/StartTrial/Renewed event and PlusAcquisition,
+    // which mirror the Stripe path and must carry identical attribution and value. The
+    // isInitial-conditional fields resolve to their unconditional form in the
+    // PlusAcquisition branch below (which only fires when isInitial), so it reuses them.
+    const acquisitionEventPayload = {
       email: user.email,
       evmWallet: user.evmWallet,
       value: isTrial ? predictedLTV : paymentAmount,
@@ -451,7 +455,17 @@ async function handleGrant(
         $referrer: referrer,
       },
       setOnce: referrer ? { $initial_referrer: referrer } : undefined,
-    }));
+    };
+    sideEffects.push(logServerEvents(logEvent, acquisitionEventPayload));
+    // Unified acquisition event — one per new subscription, the single signal to
+    // optimize Meta on (mirrors the Stripe path; app has no browser pixel to mirror).
+    // Gated on isInitial so renewals never inflate it.
+    if (isInitial) {
+      sideEffects.push(logServerEvents('PlusAcquisition', {
+        ...acquisitionEventPayload,
+        extraProperties: { ...acquisitionEventPayload.extraProperties, is_trial: isTrial },
+      }));
+    }
     // Mirror the Stripe path's Airtable payment record. RevenueCat carries no Stripe
     // customer/invoice/coupon/price-id, so those columns stay empty; record only on
     // payment-bearing events (initial purchase + renewal) — the same gate as the


### PR DESCRIPTION
Server-side mirror of the browser PlusAcquisition event, fired once per net-new subscription — Stripe subscription creation and RevenueCat initial purchase only, never renewals or trial→paid upgrades. Carries subscription_id, is_trial, platform and provider so Meta/GA/PostHog get one clean cross-platform acquisition signal to optimize on.