### PR TITLE
📈 Tag RevenueCat Plus events with stable subscription_id

### DIFF
--- a/src/util/api/plus/revenuecat.ts
+++ b/src/util/api/plus/revenuecat.ts
@@ -410,6 +410,9 @@ async function handleGrant(
       gaSessionId: getSubscriberAttribute(event, 'gaSessionId'),
       posthogDistinctId: getSubscriberAttribute(event, 'posthogDistinctId'),
       extraProperties: {
+        // transactionId is original_transaction_id (stable across the sub lifetime),
+        // so it serves as subscription_id here — parity with the Stripe path.
+        subscription_id: transactionId,
         provider: 'revenuecat',
         store: event.store,
         product_id: event.product_id,


### PR DESCRIPTION
IAP subscribe/start_trial/renewal events only carried transaction_id, so PostHog could not count unique subscriptions across web + IAP. Pass original_transaction_id as subscription_id too, matching the Stripe path.