### PR TITLE
📈 Unify Stripe and RevenueCat Plus event payloads

### DIFF
--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -8,6 +8,7 @@ import {
   PLUS_PAID_TRIAL_PRICE,
   PUBSUB_TOPIC_MISC,
   STRIPE_PAYMENT_INTENT_EXPAND_OBJECTS,
+  SUPPORTED_PLUS_CURRENCIES,
 } from '../../../constant';
 import type { SupportedCheckoutUIMode, SupportedPlusCurrency } from '../../../constant';
 import { convertCurrencyToUSDPrice, convertUSDPriceToCurrency } from '../../pricing';
@@ -142,13 +143,21 @@ export function mapAttributionExtraProperties({
 // Predicted LTV in `currency` for Plus acquisition events; trials are discounted
 // by the expected trial→paid rate. Shared by the Stripe and IAP paths so both
 // report the same value signal (IAP trials charge 0 and would otherwise send 0).
-export function getPlusPredictedLTV(isTrial: boolean, currency?: string): number {
+export function getPlusPredictedLTV(
+  isTrial: boolean,
+  currency?: string,
+): { value: number; currency: SupportedPlusCurrency } {
   const ltvUSD = LIKER_PLUS_LTV || 100;
   const predictedLTVUSD = isTrial ? ltvUSD * (LIKER_PLUS_TRIAL_CONVERSION_RATE || 0.5) : ltvUSD;
-  return convertUSDPriceToCurrency(
-    predictedLTVUSD,
-    (currency || 'USD').toLowerCase() as SupportedPlusCurrency,
-  );
+  // convertUSDPriceToCurrency only knows Plus currencies and silently returns USD
+  // for the rest; normalize so the returned currency always matches the value.
+  const normalized = (currency || 'usd').toLowerCase();
+  const ltvCurrency: SupportedPlusCurrency = (SUPPORTED_PLUS_CURRENCIES as readonly string[])
+    .includes(normalized) ? (normalized as SupportedPlusCurrency) : 'usd';
+  return {
+    value: convertUSDPriceToCurrency(predictedLTVUSD, ltvCurrency),
+    currency: ltvCurrency,
+  };
 }
 
 export async function processStripeSubscriptionInvoice(
@@ -444,7 +453,7 @@ export async function processStripeSubscriptionInvoice(
 
   // Trial to paid upgrade is handled in processStripeSubscriptionUpdate
   if (isSubscriptionCreation || isTrialToPaidUpgrade) {
-    const predictedLTV = getPlusPredictedLTV(isTrial, currency);
+    const { value: predictedLTV } = getPlusPredictedLTV(isTrial, currency);
     await logServerEvents(isTrial ? 'StartTrial' : 'Subscribe', {
       email: user.email || stripeCustomer.email || undefined,
       items: [{

--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -139,6 +139,18 @@ export function mapAttributionExtraProperties({
   };
 }
 
+// Predicted LTV in `currency` for Plus acquisition events; trials are discounted
+// by the expected trial→paid rate. Shared by the Stripe and IAP paths so both
+// report the same value signal (IAP trials charge 0 and would otherwise send 0).
+export function getPlusPredictedLTV(isTrial: boolean, currency?: string): number {
+  const ltvUSD = LIKER_PLUS_LTV || 100;
+  const predictedLTVUSD = isTrial ? ltvUSD * (LIKER_PLUS_TRIAL_CONVERSION_RATE || 0.5) : ltvUSD;
+  return convertUSDPriceToCurrency(
+    predictedLTVUSD,
+    (currency || 'USD').toLowerCase() as SupportedPlusCurrency,
+  );
+}
+
 export async function processStripeSubscriptionInvoice(
   invoice: Stripe.Invoice,
   req: Express.Request,
@@ -432,13 +444,7 @@ export async function processStripeSubscriptionInvoice(
 
   // Trial to paid upgrade is handled in processStripeSubscriptionUpdate
   if (isSubscriptionCreation || isTrialToPaidUpgrade) {
-    const trialConversionRate = LIKER_PLUS_TRIAL_CONVERSION_RATE || 0.5;
-    const ltvUSD = LIKER_PLUS_LTV || 100;
-    const predictedLTVUSD = isTrial ? ltvUSD * trialConversionRate : ltvUSD;
-    const predictedLTV = convertUSDPriceToCurrency(
-      predictedLTVUSD,
-      currency.toLowerCase() as SupportedPlusCurrency,
-    );
+    const predictedLTV = getPlusPredictedLTV(isTrial, currency);
     await logServerEvents(isTrial ? 'StartTrial' : 'Subscribe', {
       email: user.email || stripeCustomer.email || undefined,
       items: [{
@@ -460,8 +466,11 @@ export async function processStripeSubscriptionInvoice(
       customerType: isNewSubscription ? getCustomerType(user) : 'returning',
       extraProperties: {
         subscription_id: subscriptionId,
+        provider: 'stripe',
+        platform: 'web',
         period,
         price_id: item.price.id,
+        product_id: productId,
         ...mapAttributionExtraProperties({
           utmSource, utmMedium, utmCampaign, utmContent, utmTerm, from,
         }),

--- a/src/util/api/plus/revenuecat.ts
+++ b/src/util/api/plus/revenuecat.ts
@@ -395,7 +395,10 @@ async function handleGrant(
   if (logEvent) {
     // Mirror the Stripe path's value signal so Meta/GA optimize the same for web
     // and IAP — app IAP trials charge 0, so value falls back to predicted LTV.
-    const predictedLTV = getPlusPredictedLTV(isTrial, paymentCurrency);
+    const {
+      value: predictedLTV,
+      currency: ltvCurrency,
+    } = getPlusPredictedLTV(isTrial, paymentCurrency);
     // Ad-attribution the native app forwarded as subscriber attributes, so the
     // IAP server-side conversion (Meta CAPI / GA / PostHog) carries the same
     // attribution the Stripe Subscribe/StartTrial event does (see index.ts).
@@ -404,7 +407,9 @@ async function handleGrant(
       email: user.email,
       evmWallet: user.evmWallet,
       value: isTrial ? predictedLTV : paymentAmount,
-      currency: paymentCurrency,
+      // ltvCurrency is a lowercase Plus currency; uppercase it so the analytics
+      // currency dimension stays ISO 4217 like paymentCurrency and the Stripe path.
+      currency: isTrial ? ltvCurrency.toUpperCase() : paymentCurrency,
       paymentId: transactionId,
       items: period ? [{ productId: `plus-${period}ly`, quantity: 1 }] : undefined,
       referrer,

--- a/src/util/api/plus/revenuecat.ts
+++ b/src/util/api/plus/revenuecat.ts
@@ -5,7 +5,7 @@ import { IS_TESTNET, PUBSUB_TOPIC_MISC, SUBSCRIPTION_GRACE_PERIOD } from '../../
 import { userCollection } from '../../firebase';
 import { normalizeLikerId } from '../../ValidationHelper';
 import { getUserWithCivicLikerProperties } from '../users/getPublicInfo';
-import { getCustomerType } from '../users/payment';
+import { getCustomerType, getPaymentUpdateFields } from '../users/payment';
 import { createFreeBookCartFromSubscription } from '../likernft/book/cart';
 import { getPlusPredictedLTV, mapAttributionExtraProperties, resolveAffiliateGift } from './index';
 import { calculatePlusDailyValue, recordPlusSubscriptionAccrual } from './revenueShare';
@@ -242,7 +242,16 @@ async function handleGrant(
     if (user.likerPlus?.giftClaimToken) likerPlus.giftClaimToken = user.likerPlus.giftClaimToken;
     if (user.likerPlus?.affiliateFrom) likerPlus.affiliateFrom = user.likerPlus.affiliateFrom;
   }
-  await userCollection.doc(likerId).update({ likerPlus });
+  // A real charge: priced, non-trial grants. Trials and no-charge grants
+  // (uncancel/extend/product-change) carry no price. Reused by the gift block below.
+  const hasCharge = !isTrial && event.price != null && event.price > 0;
+  const grantUpdate: Record<string, unknown> = { likerPlus };
+  // Track first/last real payment like the Stripe path so getCustomerType can tell
+  // resubscribers from first-time buyers.
+  if (hasCharge) {
+    Object.assign(grantUpdate, getPaymentUpdateFields(!!user.firstPaidAt));
+  }
+  await userCollection.doc(likerId).update(grantUpdate);
 
   // Quarantine reviewer (sandbox-on-prod) traffic out of CRM, Slack, revenue
   // analytics, and Airtable so it doesn't contaminate prod metrics. Testnet's
@@ -289,7 +298,6 @@ async function handleGrant(
         // re-delivered INITIAL_PURCHASE idempotent, but only for the same
         // subscription — a resubscribe earns a fresh gift even though the lapsed
         // sub's giftCartId still lingers on the record.
-        const hasCharge = !isTrial && event.price != null && event.price > 0;
         const isGiftEligible = hasCharge || (!!affiliateGiftOnTrial && isTrial);
         if (
           planPeriod === 'yearly'
@@ -407,9 +415,9 @@ async function handleGrant(
       email: user.email,
       evmWallet: user.evmWallet,
       value: isTrial ? predictedLTV : paymentAmount,
-      // ltvCurrency is a lowercase Plus currency; uppercase it so the analytics
-      // currency dimension stays ISO 4217 like paymentCurrency and the Stripe path.
-      currency: isTrial ? ltvCurrency.toUpperCase() : paymentCurrency,
+      // ltvCurrency is a lowercase Plus currency; uppercase both branches so the
+      // analytics currency dimension stays ISO 4217 like the Stripe path.
+      currency: isTrial ? ltvCurrency.toUpperCase() : paymentCurrency?.toUpperCase(),
       paymentId: transactionId,
       items: period ? [{ productId: `plus-${period}ly`, quantity: 1 }] : undefined,
       referrer,

--- a/src/util/api/plus/revenuecat.ts
+++ b/src/util/api/plus/revenuecat.ts
@@ -5,8 +5,9 @@ import { IS_TESTNET, PUBSUB_TOPIC_MISC, SUBSCRIPTION_GRACE_PERIOD } from '../../
 import { userCollection } from '../../firebase';
 import { normalizeLikerId } from '../../ValidationHelper';
 import { getUserWithCivicLikerProperties } from '../users/getPublicInfo';
+import { getCustomerType } from '../users/payment';
 import { createFreeBookCartFromSubscription } from '../likernft/book/cart';
-import { mapAttributionExtraProperties, resolveAffiliateGift } from './index';
+import { getPlusPredictedLTV, mapAttributionExtraProperties, resolveAffiliateGift } from './index';
 import { calculatePlusDailyValue, recordPlusSubscriptionAccrual } from './revenueShare';
 import { updateIntercomUserAttributes, sendIntercomEvent } from '../../intercom';
 import { sendPlusSubscriptionSlackNotification } from '../../slack';
@@ -165,6 +166,7 @@ async function handleGrant(
     email?: string;
     evmWallet?: string;
     likerPlus?: LikerPlusData;
+    firstPaidAt?: unknown;
   },
   isSandbox: boolean,
 ) {
@@ -391,6 +393,9 @@ async function handleGrant(
     }),
   ];
   if (logEvent) {
+    // Mirror the Stripe path's value signal so Meta/GA optimize the same for web
+    // and IAP — app IAP trials charge 0, so value falls back to predicted LTV.
+    const predictedLTV = getPlusPredictedLTV(isTrial, paymentCurrency);
     // Ad-attribution the native app forwarded as subscriber attributes, so the
     // IAP server-side conversion (Meta CAPI / GA / PostHog) carries the same
     // attribution the Stripe Subscribe/StartTrial event does (see index.ts).
@@ -398,7 +403,7 @@ async function handleGrant(
     sideEffects.push(logServerEvents(logEvent, {
       email: user.email,
       evmWallet: user.evmWallet,
-      value: paymentAmount,
+      value: isTrial ? predictedLTV : paymentAmount,
       currency: paymentCurrency,
       paymentId: transactionId,
       items: period ? [{ productId: `plus-${period}ly`, quantity: 1 }] : undefined,
@@ -409,11 +414,14 @@ async function handleGrant(
       gaClientId: getSubscriberAttribute(event, 'gaClientId'),
       gaSessionId: getSubscriberAttribute(event, 'gaSessionId'),
       posthogDistinctId: getSubscriberAttribute(event, 'posthogDistinctId'),
+      predictedLTV: isInitial ? predictedLTV : undefined,
+      customerType: isInitial ? getCustomerType(user) : 'returning',
       extraProperties: {
         // transactionId is original_transaction_id (stable across the sub lifetime),
         // so it serves as subscription_id here — parity with the Stripe path.
         subscription_id: transactionId,
         provider: 'revenuecat',
+        platform: 'app',
         store: event.store,
         product_id: event.product_id,
         period,


### PR DESCRIPTION
Make subscribe/start_trial carry the same dimensions on both paths: add provider, platform, and product_id; on RevenueCat also add predicted_ltv and customerType. Extract a shared getPlusPredictedLTV so IAP trials report predicted LTV instead of a 0-value conversion to Meta/GA, matching the Stripe path.