### PR TITLE
🐛 Accept legacy 'cn' locale in user response schema

### DIFF
--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -7,4 +7,19 @@ export const supportedLocales = [
 
 export type SupportedLocale = typeof supportedLocales[number];
 
+// Locales that may appear in stored data but are no longer offered as input.
+// 'cn' is the pre-rename code for Chinese (now 'zh') still present on legacy docs.
+export const legacyLocales = [
+  'cn',
+] as const;
+
+// Superset of every locale code that can appear in persisted data. Use this for
+// response schemas/types; keep `supportedLocales` for validating new input.
+export const storedLocales = [
+  ...supportedLocales,
+  ...legacyLocales,
+] as const;
+
+export type StoredLocale = typeof storedLocales[number];
+
 export default supportedLocales;

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -1,5 +1,5 @@
 import type { Timestamp } from '@google-cloud/firestore';
-import type { SupportedLocale } from '../locales';
+import type { StoredLocale } from '../locales';
 import type { LIKER_PLUS_SUBSCRIPTION_STATUSES } from '../util/api/users/schemas';
 
 export interface CivicLikerData {
@@ -118,7 +118,8 @@ export interface UserData {
   lastPaidAt?: Timestamp;
 
   // Metadata fields
-  locale?: SupportedLocale;
+  // Stored locale may include legacy codes (e.g. 'cn') beyond supportedLocales.
+  locale?: StoredLocale;
   timestamp?: number;
   bonusCooldown?: number;
   referrer?: string;

--- a/src/util/api/users/schemas.ts
+++ b/src/util/api/users/schemas.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod';
-import { supportedLocales } from '../../../locales';
+import { storedLocales } from '../../../locales';
 
 export const LIKER_PLUS_SUBSCRIPTION_STATUSES = ['active', 'past_due', 'canceled'] as const;
 const LikerPlusSubscriptionStatusSchema = z.enum(LIKER_PLUS_SUBSCRIPTION_STATUSES);
-const LocaleSchema = z.enum(supportedLocales);
+// Response locale reflects stored data, which includes legacy codes (e.g. 'cn').
+// Input locale is guarded against supportedLocales separately.
+const LocaleSchema = z.enum(storedLocales);
 
 export const UsersNewCheckBodySchema = z.object({
   user: z.string().optional(),

--- a/test/unit/response-schemas.test.ts
+++ b/test/unit/response-schemas.test.ts
@@ -7,6 +7,7 @@ import {
   filterBookPurchaseCommission,
   filterLikeNFTMetadata,
   filterLikeNFTISCNData,
+  filterUserData,
 } from '../../src/util/ValidationHelper';
 import {
   BookContributorSchema,
@@ -22,6 +23,9 @@ import {
   AffiliateConfigSchema,
   PlusAffiliateResponseSchema,
 } from '../../src/util/api/plus/schemas';
+import {
+  UserDataFilteredResponseSchema,
+} from '../../src/util/api/users/schemas';
 
 // Regression guard for the recurring "response schema stricter than real data" 500s.
 // Each case reproduces a legacy/partial Firestore shape that 500'd a live endpoint
@@ -126,6 +130,13 @@ describe('Response schema ↔ legacy data alignment', () => {
 
     it('still accepts the inactive-affiliate variant of the discriminated union', () => {
       expectParses(PlusAffiliateResponseSchema, { active: false, isPlusDiscountAllowed: false });
+    });
+  });
+
+  describe('UserDataFilteredResponseSchema (filter→schema)', () => {
+    it('accepts a legacy locale code outside supportedLocales (e.g. "cn")', () => {
+      const filtered = filterUserData({ user: 'legacyuser', locale: 'cn' } as any);
+      expectParses(UserDataFilteredResponseSchema, filtered);
     });
   });
 });


### PR DESCRIPTION
Stored user docs carry the pre-rename Chinese code 'cn', but the response schema only allowed supportedLocales ('en'|'zh'), so /users/self and /users/id/:id 500'd with RESPONSE_SCHEMA_MISMATCH. Add a storedLocales superset (supported + legacy) and use it for the response schema and UserData type; input validation keeps supportedLocales.