### PR TITLE
✨ Add Google Merchant Center product feed for book listings

### DIFF
--- a/src/routes/likernft/book/store.ts
+++ b/src/routes/likernft/book/store.ts
@@ -39,6 +39,7 @@ import {
   BookCatalogOpenAIResponseSchema,
   BookCatalogOpenAIFeedResponseSchema,
   BookCatalogStripeResponseSchema,
+  BookCatalogGoogleResponseSchema,
   BookListResponseSchema,
   BookListModeratedResponseSchema,
   BookSearchResponseSchema,
@@ -97,6 +98,7 @@ import {
   formatOpenAIFeedCSV,
 } from '../../../util/api/likernft/book/openaiCatalog';
 import { getStripeFeedItems, formatStripeFeedCSV } from '../../../util/api/likernft/book/stripeCatalog';
+import { getGoogleMerchantFeedItems, formatGoogleMerchantFeedXML } from '../../../util/api/likernft/book/googleMerchantCatalog';
 import { normalizeClassIdParam } from '../../../middleware/likernft';
 
 const router = Router();
@@ -190,6 +192,24 @@ router.get('/catalog/stripe', validateQuery(BookCatalogQuerySchema), async (req,
       return;
     }
     sendValidatedJSON(res, BookCatalogStripeResponseSchema, { products: items });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Google Merchant Center product feed (RSS 2.0 XML in the Google-Shopping field
+// dialect). Google fetches this URL on a schedule; default returns XML, and
+// `?format=json` returns the same items as JSON for debugging.
+router.get('/catalog/google', validateQuery(BookCatalogQuerySchema), async (req, res, next) => {
+  try {
+    const items = await getGoogleMerchantFeedItems();
+    res.set('Cache-Control', `public, max-age=${ONE_HOUR_IN_S}, s-maxage=${ONE_HOUR_IN_S}, stale-while-revalidate=${ONE_DAY_IN_S}, stale-if-error=${ONE_DAY_IN_S}`);
+    if (req.query.format === 'json') {
+      sendValidatedJSON(res, BookCatalogGoogleResponseSchema, { products: items });
+      return;
+    }
+    res.type('application/xml; charset=utf-8');
+    res.send(formatGoogleMerchantFeedXML(items));
   } catch (err) {
     next(err);
   }

--- a/src/util/api/likernft/book/catalogSource.ts
+++ b/src/util/api/likernft/book/catalogSource.ts
@@ -19,8 +19,10 @@ const CATALOG_FALLBACK_BRAND = '3ook.com';
 // Per the catalog specs, `brand` should be the product's real brand, not the
 // storefront name. On an independent-author storefront the author is the
 // strongest brand signal, so prefer author, fall back to publisher/imprint,
-// then 3ook.com. Returns author/publisher too so feeds can also expose them
-// as their own labels.
+// then 3ook.com. This must stay in sync with the storefront landing page brand
+// (liker-land-v3 use-book-info.ts `brandName`), since Google Merchant Center
+// compares the feed `brand` against the crawled page. Returns author/publisher
+// too so feeds can also expose them as their own labels.
 export function resolveCatalogBrand(book: NFTBookListingInfo): {
   author: string;
   publisher: string;

--- a/src/util/api/likernft/book/googleMerchantCatalog.ts
+++ b/src/util/api/likernft/book/googleMerchantCatalog.ts
@@ -1,0 +1,119 @@
+import xml from 'xml';
+import { BOOK3_HOSTNAME } from '../../../../constant';
+import { listCatalogVariants } from './catalogSource';
+import type { CatalogVariant } from './catalogSource';
+
+// Google Merchant Center product feed
+// (https://support.google.com/merchants/answer/7052112). Same lineage as the
+// Meta/OpenAI/Stripe feeds, so it reuses the shared catalog source and helpers;
+// only the field names, the RSS 2.0 serialization, and the books-specific
+// identifier rules differ. Google fetches the hosted feed URL on a schedule.
+
+// Exact Google product taxonomy value for digital books (ID 543542). Note the
+// lowercase "b" — this differs from the Meta/Stripe feeds' "E-Books", which use
+// their own validators; Google validates against its own taxonomy.
+const GOOGLE_MERCHANT_PRODUCT_CATEGORY = 'Media > Books > E-books';
+// Google enforces max 150 chars on title and 5000 on description.
+const GOOGLE_MERCHANT_TITLE_MAX = 150;
+const GOOGLE_MERCHANT_DESCRIPTION_MAX = 5000;
+
+const GOOGLE_MERCHANT_FEED_TITLE = '3ook.com';
+const GOOGLE_MERCHANT_FEED_LINK = `https://${BOOK3_HOSTNAME}`;
+const GOOGLE_MERCHANT_FEED_DESCRIPTION = 'Books on 3ook.com';
+
+/* eslint-disable camelcase -- Google product feed attribute names are snake_case per spec */
+export interface GoogleMerchantItem {
+  id: string;
+  title: string;
+  description: string;
+  link: string;
+  image_link: string;
+  price: string;
+  availability: 'in_stock' | 'out_of_stock';
+  condition: 'new';
+  brand: string;
+  google_product_category: string;
+  gtin?: string;
+  // Books have no brand/mpn/gtin fallback, so Google requires identifier_exists
+  // to be "no" when there is no valid GTIN (ISBN-13); otherwise the item is rejected.
+  identifier_exists?: 'no';
+  // Present only for multi-edition books, to group their variants.
+  item_group_id?: string;
+  item_group_title?: string;
+}
+/* eslint-enable camelcase */
+
+function truncate(text: string, max: number): string {
+  return text.slice(0, max);
+}
+
+function buildItem(v: CatalogVariant): GoogleMerchantItem {
+  const item: GoogleMerchantItem = {
+    id: v.id,
+    title: truncate(v.title, GOOGLE_MERCHANT_TITLE_MAX),
+    description: truncate(v.description, GOOGLE_MERCHANT_DESCRIPTION_MAX),
+    link: v.link,
+    image_link: v.image,
+    price: v.priceUSD,
+    availability: v.inStock ? 'in_stock' : 'out_of_stock',
+    condition: 'new',
+    brand: v.brand,
+    google_product_category: GOOGLE_MERCHANT_PRODUCT_CATEGORY,
+  };
+  if (v.gtin) {
+    item.gtin = v.gtin;
+  } else {
+    item.identifier_exists = 'no';
+  }
+  if (v.hasVariations) {
+    item.item_group_id = v.classId;
+    item.item_group_title = v.baseTitle;
+  }
+  return item;
+}
+
+export async function getGoogleMerchantFeedItems(): Promise<GoogleMerchantItem[]> {
+  const variants = await listCatalogVariants();
+  return variants.map(buildItem);
+}
+
+// RSS 2.0 with Google's `g:` namespace. The core RSS elements (title, link,
+// description) carry the product's title/URL/description; every other attribute
+// uses the `g:` prefix per Google's spec.
+function buildItemNodes(item: GoogleMerchantItem) {
+  const nodes: Array<Record<string, string>> = [
+    { 'g:id': item.id },
+    { title: item.title },
+    { description: item.description },
+    { link: item.link },
+    { 'g:image_link': item.image_link },
+    { 'g:price': item.price },
+    { 'g:availability': item.availability },
+    { 'g:condition': item.condition },
+    { 'g:brand': item.brand },
+    { 'g:google_product_category': item.google_product_category },
+  ];
+  // Serialize the identifier and grouping fields buildItem already decided, so
+  // the XML and JSON (?format=json) representations can't diverge on Google's rules.
+  if (item.gtin) nodes.push({ 'g:gtin': item.gtin });
+  if (item.identifier_exists) nodes.push({ 'g:identifier_exists': item.identifier_exists });
+  if (item.item_group_id) nodes.push({ 'g:item_group_id': item.item_group_id });
+  if (item.item_group_title) nodes.push({ 'g:item_group_title': item.item_group_title });
+  return nodes;
+}
+
+export function formatGoogleMerchantFeedXML(items: GoogleMerchantItem[]): string {
+  const channel: Array<unknown> = [
+    { title: GOOGLE_MERCHANT_FEED_TITLE },
+    { link: GOOGLE_MERCHANT_FEED_LINK },
+    { description: GOOGLE_MERCHANT_FEED_DESCRIPTION },
+    ...items.map((item) => ({ item: buildItemNodes(item) })),
+  ];
+  const feed = {
+    rss: [
+      { _attr: { version: '2.0', 'xmlns:g': 'http://base.google.com/ns/1.0' } },
+      { channel },
+    ],
+  };
+  return xml(feed, { declaration: { encoding: 'utf-8' } });
+}

--- a/src/util/api/likernft/book/schemas.ts
+++ b/src/util/api/likernft/book/schemas.ts
@@ -654,6 +654,28 @@ export const BookCatalogStripeResponseSchema = z.object({
   })),
 });
 
+// Mirrors GoogleMerchantItem (googleMerchantCatalog.ts) — the Google Merchant
+// Center product feed. Google-Shopping field dialect; the XML feed is the
+// primary representation, this JSON mirror backs `?format=json` for debugging.
+export const BookCatalogGoogleResponseSchema = z.object({
+  products: z.array(z.object({
+    id: z.string(),
+    title: z.string(),
+    description: z.string(),
+    link: z.string(),
+    image_link: z.string(),
+    price: z.string(),
+    availability: z.enum(['in_stock', 'out_of_stock']),
+    condition: z.literal('new'),
+    brand: z.string(),
+    google_product_category: z.string(),
+    gtin: z.string().optional(),
+    identifier_exists: z.literal('no').optional(),
+    item_group_id: z.string().optional(),
+    item_group_title: z.string().optional(),
+  })),
+});
+
 const StripePayoutSummarySchema = z.object({
   amount: z.number(),
   currency: z.string(),

--- a/test/unit/google-catalog.test.ts
+++ b/test/unit/google-catalog.test.ts
@@ -1,0 +1,172 @@
+import {
+  describe, it, expect, beforeEach, vi,
+} from 'vitest';
+import { getGoogleMerchantFeedItems, formatGoogleMerchantFeedXML } from '../../src/util/api/likernft/book/googleMerchantCatalog';
+import type { GoogleMerchantItem } from '../../src/util/api/likernft/book/googleMerchantCatalog';
+import { listLatestNFTBookInfo } from '../../src/util/api/likernft/book/index';
+import type { NFTBookListingInfo } from '../../src/types/book';
+
+// Mock only the data fetch; keep the real pure helpers so the mapping logic is
+// exercised end-to-end.
+vi.mock('../../src/util/api/likernft/book/index', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/util/api/likernft/book/index')>();
+  return {
+    ...actual,
+    listLatestNFTBookInfo: vi.fn(),
+  };
+});
+
+const mockedList = vi.mocked(listLatestNFTBookInfo);
+
+function setBooks(books: Array<Partial<NFTBookListingInfo>>) {
+  mockedList.mockResolvedValue(books as any);
+}
+
+describe('getGoogleMerchantFeedItems', () => {
+  beforeEach(() => {
+    mockedList.mockReset();
+  });
+
+  it('maps each price into a Google Merchant item', async () => {
+    setBooks([{
+      id: 'class-a',
+      classId: 'class-a',
+      name: 'The Great Book',
+      image: 'https://img.example/a.jpg',
+      author: 'Jane Doe',
+      publisher: 'Penguin',
+      isbn: '978-3-16-148410-0',
+      descriptionFull: 'Full description',
+      prices: [
+        { priceInDecimal: 1500, name: 'Hardcover', stock: 5 },
+        { priceInDecimal: 999, stock: 0, isAutoDeliver: false },
+      ],
+    }]);
+
+    const items = await getGoogleMerchantFeedItems();
+    expect(items).toHaveLength(2);
+    const [first] = items;
+    expect(first.id).toBe('class-a-0');
+    expect(first.title).toBe('The Great Book - Hardcover');
+    expect(first.link).toContain('/store/class-a');
+    expect(first.image_link).toBe('https://img.example/a.jpg');
+    expect(first.price).toBe('15.00 USD');
+    // Google requires the underscore enum (NOT the legacy "in stock" form)
+    expect(first.availability).toBe('in_stock');
+    expect(first.condition).toBe('new');
+    // author wins over publisher for brand (shared resolveCatalogBrand)
+    expect(first.brand).toBe('Jane Doe');
+    expect(first.gtin).toBe('9783161484100');
+    // valid GTIN present → identifier_exists omitted
+    expect(first.identifier_exists).toBeUndefined();
+    // multi-edition book → grouped
+    expect(first.item_group_id).toBe('class-a');
+    expect(first.item_group_title).toBe('The Great Book');
+    // exact Google taxonomy value (lowercase "b")
+    expect(first.google_product_category).toBe('Media > Books > E-books');
+
+    expect(items[1].availability).toBe('out_of_stock');
+  });
+
+  it('emits identifier_exists=no when there is no valid GTIN (ISBN-10)', async () => {
+    setBooks([{
+      id: 'class-f',
+      classId: 'class-f',
+      name: 'Solo Work',
+      image: 'https://img.example/f.jpg',
+      isbn: '0-306-40615-2', // ISBN-10 → not a valid GTIN length
+      description: 'short',
+      prices: [{ priceInDecimal: 999, stock: 3 }],
+    }]);
+
+    const [item] = await getGoogleMerchantFeedItems();
+    expect(item.gtin).toBeUndefined();
+    expect(item.identifier_exists).toBe('no');
+    expect(item.brand).toBe('3ook.com'); // no author/publisher → fallback
+    // single edition → no group
+    expect(item.item_group_id).toBeUndefined();
+  });
+
+  it('truncates title and description to Google limits', async () => {
+    setBooks([{
+      id: 'long',
+      classId: 'long',
+      name: 'T'.repeat(200),
+      image: 'https://img/o.jpg',
+      descriptionFull: 'D'.repeat(6000),
+      prices: [{ priceInDecimal: 100, stock: 1 }],
+    }]);
+    const [item] = await getGoogleMerchantFeedItems();
+    expect(item.title).toHaveLength(150);
+    expect(item.description).toHaveLength(5000);
+  });
+
+  it('applies the same eligibility and variant drop rules as the other feeds', async () => {
+    setBooks([
+      {
+        id: 'hidden', classId: 'hidden', name: 'Hidden', image: 'https://img/x.jpg', isHidden: true, prices: [{ priceInDecimal: 100 }],
+      },
+      {
+        id: 'noimage', classId: 'noimage', name: 'No Image', prices: [{ priceInDecimal: 100 }],
+      },
+      {
+        id: 'ok', classId: 'ok', name: 'OK', image: 'https://img/o.jpg', prices: [{ priceInDecimal: 100, isUnlisted: true }, { priceInDecimal: 200 }],
+      },
+    ]);
+    const items = await getGoogleMerchantFeedItems();
+    expect(items.map((i) => i.id)).toEqual(['ok-1']);
+  });
+});
+
+describe('formatGoogleMerchantFeedXML', () => {
+  const baseItem: GoogleMerchantItem = {
+    id: 'class-a-0',
+    title: 'The Great Book',
+    description: 'Full description',
+    link: 'https://3ook.com/en/store/class-a?price_index=0',
+    image_link: 'https://img.example/a.jpg',
+    price: '15.00 USD',
+    availability: 'in_stock',
+    condition: 'new',
+    brand: 'Jane Doe',
+    google_product_category: 'Media > Books > E-books',
+    gtin: '9783161484100',
+    item_group_id: 'class-a',
+    item_group_title: 'The Great Book',
+  };
+
+  it('produces an RSS 2.0 document with the g: namespace', () => {
+    const feed = formatGoogleMerchantFeedXML([baseItem]);
+    expect(feed).toContain('<?xml version="1.0" encoding="utf-8"?>');
+    expect(feed).toContain('<rss version="2.0" xmlns:g="http://base.google.com/ns/1.0">');
+    expect(feed).toContain('<channel>');
+    expect(feed).toContain('<g:id>class-a-0</g:id>');
+    // core RSS elements have no g: prefix
+    expect(feed).toContain('<title>The Great Book</title>');
+    expect(feed).toContain('<link>https://3ook.com/en/store/class-a?price_index=0</link>');
+    expect(feed).toContain('<g:availability>in_stock</g:availability>');
+    expect(feed).toContain('<g:gtin>9783161484100</g:gtin>');
+    expect(feed).toContain('<g:item_group_id>class-a</g:item_group_id>');
+  });
+
+  it('emits g:identifier_exists=no instead of g:gtin when GTIN is absent', () => {
+    const feed = formatGoogleMerchantFeedXML([{
+      ...baseItem,
+      gtin: undefined,
+      identifier_exists: 'no',
+      item_group_id: undefined,
+      item_group_title: undefined,
+    }]);
+    expect(feed).toContain('<g:identifier_exists>no</g:identifier_exists>');
+    expect(feed).not.toContain('<g:gtin>');
+    expect(feed).not.toContain('<g:item_group_id>');
+  });
+
+  it('escapes XML special characters in field values', () => {
+    const feed = formatGoogleMerchantFeedXML([{
+      ...baseItem,
+      title: 'Cats & Dogs <vol 1>',
+    }]);
+    expect(feed).toContain('<title>Cats &amp; Dogs &lt;vol 1&gt;</title>');
+  });
+});


### PR DESCRIPTION
Add GET /likernft/book/store/catalog/google, a fourth sibling to the Meta/OpenAI/Stripe catalog feeds built on the shared listCatalogVariants source. Serves RSS 2.0 XML (Google-Shopping field dialect) by default for scheduled URL fetch, with ?format=json for debugging.

Uses the exact Google taxonomy value 'Media > Books > E-books' and emits g:identifier_exists=no for books without a valid ISBN-13 GTIN. Notes on resolveCatalogBrand that feed brand must stay in sync with the storefront landing page, since Merchant Center compares the two.