### PR TITLE
📈 Fire CompleteRegistration CAPI event on registration

### DIFF
--- a/src/routes/users/registerLogin.ts
+++ b/src/routes/users/registerLogin.ts
@@ -18,6 +18,7 @@ import {
   checkEVMSignPayload,
 } from '../../util/api/users';
 import { handleUserRegistration } from '../../util/api/users/register';
+import logPixelEvents from '../../util/fbq';
 import { ValidationError } from '../../util/ValidationError';
 import { supportedLocales, defaultLocale } from '../../locales';
 import { handleAvatarUploadAndGetURL } from '../../util/fileupload';
@@ -156,6 +157,19 @@ router.post(
       publisher.publish(PUBSUB_TOPIC_MISC, req, {
         ...userPayload,
         logType: 'eventUserRegister',
+      });
+      // Server-side Meta CAPI CompleteRegistration (Pixel only); browser fires GA4/PostHog sign_up.
+      // Meta dedups on event_id — the lowercased wallet matches the browser key, merging the pair.
+      // PostHog can't dedup sign_up: it fires pre-identify, so distinct_id differs from the wallet.
+      logPixelEvents('CompleteRegistration', {
+        email: userPayload.email,
+        evmWallet: userPayload.evmWallet,
+        paymentId: userPayload.evmWallet
+          ? userPayload.evmWallet.toLowerCase()
+          : undefined,
+        userAgent: req.get('User-Agent'),
+        clientIp: (req.headers['x-real-ip'] as string) || req.ip,
+        referrer: userPayload.sourceURL,
       });
     } catch (err) {
       publisher.publish(PUBSUB_TOPIC_MISC, req, {

--- a/src/util/analyticsEvents.ts
+++ b/src/util/analyticsEvents.ts
@@ -1,6 +1,7 @@
 export type ServerEventName =
   | 'Purchase'
   | 'InitiateCheckout'
+  | 'CompleteRegistration'
   | 'StartTrial'
   | 'Subscribe'
   | 'PlusAcquisition'
@@ -18,6 +19,7 @@ export interface AnalyticsItem {
 export const SERVER_EVENT_MAP: Record<ServerEventName, string> = {
   Purchase: 'purchase',
   InitiateCheckout: 'begin_checkout',
+  CompleteRegistration: 'sign_up',
   StartTrial: 'start_trial',
   Subscribe: 'subscribe',
   PlusAcquisition: 'plus_acquisition',

--- a/src/util/fbq.ts
+++ b/src/util/fbq.ts
@@ -35,9 +35,9 @@ export default async function logPixelEvents(event: ServerEventName, {
   items?: AnalyticsItem[];
   userAgent?: string;
   clientIp?: string;
-  value: number;
+  value?: number;
   predictedLTV?: number;
-  currency: string;
+  currency?: string;
   likeWallet?: string;
   paymentId?: string;
   referrer?: string;
@@ -67,7 +67,7 @@ export default async function logPixelEvents(event: ServerEventName, {
             action_source: 'website',
             referrer_url: referrer,
             user_data: {
-              em: email ? [sha256(email)] : undefined,
+              em: email ? [sha256(email.trim().toLowerCase())] : undefined,
               client_user_agent: userAgent,
               client_ip_address: clientIp,
               external_id: evmWallet && evmWallet.startsWith('0x')
@@ -82,7 +82,7 @@ export default async function logPixelEvents(event: ServerEventName, {
               currency,
               order_id: paymentId,
               customer_type: customerType,
-              content_type: 'product',
+              content_type: items ? 'product' : undefined,
               content_ids: items
                 ? items.map((item) => buildItemId(item.productId, item.priceIndex))
                 : undefined,


### PR DESCRIPTION
Send a server-side Meta CompleteRegistration conversion when a user registers, using hashed email and wallet for match quality. Only the Pixel fires here: the browser already covers GA4/PostHog for sign_up, and PostHog can't dedup it since sign_up fires pre-identify. Meta dedups on event_id, keyed off the same lowercased wallet the browser sends.