### PR TITLE
📈 Include UTM medium and campaign in registration event

### DIFF
--- a/src/util/api/users/register.ts
+++ b/src/util/api/users/register.ts
@@ -92,6 +92,8 @@ export async function handleUserRegistration({
     email,
     phone,
     utmSource,
+    utmMedium,
+    utmCampaign,
     sourceURL,
   } = payload;
   let { isEmailEnabled = true } = payload;
@@ -299,6 +301,8 @@ export async function handleUserRegistration({
       registerMethod: platform,
       sourceURL,
       utmSource,
+      utmMedium,
+      utmCampaign,
       mediaChannels: createObj.mediaChannels,
     },
   };

--- a/src/util/api/users/schemas.ts
+++ b/src/util/api/users/schemas.ts
@@ -67,6 +67,10 @@ export const UsersRegisterBodySchema = z.object({
   description: z.string().optional(),
   locale: z.string().optional(),
   email: z.string().optional(),
+  sourceURL: z.string().optional(),
+  utmSource: z.string().optional(),
+  utmMedium: z.string().optional(),
+  utmCampaign: z.string().optional(),
 }).passthrough();
 
 export const UsersLoginBodySchema = z.object({


### PR DESCRIPTION
Add utmMedium and utmCampaign to the handleUserRegistration payload so they flow into the eventUserRegister pubsub alongside utmSource.