### PR TITLE
🐛 Type migratedLikerLandUser as raw object in migrate schema

### DIFF
--- a/src/util/api/wallet/schemas.ts
+++ b/src/util/api/wallet/schemas.ts
@@ -51,9 +51,10 @@ export const WalletEvmMigrateResponseSchema = z.object({
   isMigratedLikerId: z.boolean(),
   isMigratedLikerLand: z.boolean(),
   // migrateLikeWalletToEVMWallet returns null (not undefined) for absent values,
-  // and the liker-land error is an untyped axios response body.
+  // and both the migrated liker-land user and the error are untyped axios
+  // response bodies (the user is the raw liker-land migrate response object).
   migratedLikerId: z.string().nullable(),
-  migratedLikerLandUser: z.string().nullable(),
+  migratedLikerLandUser: z.unknown().nullable(),
   migrateBookUserError: z.string().nullable(),
   migrateBookOwnerError: z.string().nullable(),
   migrateLikerIdError: z.string().nullable(),


### PR DESCRIPTION
The EVM migrate endpoint 500'd with RESPONSE_SCHEMA_MISMATCH because migratedLikerLandUser was declared z.string() but is populated with the raw liker-land migrate response body (an object). Match the untyped axios-body treatment used for the sibling error fields.