### PR TITLE
🔒 Allowlist migratedLikerLandUser fields to strip upstream PII

### DIFF
--- a/src/util/api/wallet/schemas.ts
+++ b/src/util/api/wallet/schemas.ts
@@ -51,10 +51,21 @@ export const WalletEvmMigrateResponseSchema = z.object({
   isMigratedLikerId: z.boolean(),
   isMigratedLikerLand: z.boolean(),
   // migrateLikeWalletToEVMWallet returns null (not undefined) for absent values,
-  // and both the migrated liker-land user and the error are untyped axios
-  // response bodies (the user is the raw liker-land migrate response object).
+  // and migrateLikerLandError is an untyped axios response body.
   migratedLikerId: z.string().nullable(),
-  migratedLikerLandUser: z.unknown().nullable(),
+  // Allowlist the safe fields of the raw liker-land migrate response so
+  // sendValidatedJSON strips any other (potentially PII) fields it returns.
+  // Fields are lenient and non-object bodies coerce to null since the
+  // upstream shape is not guaranteed (never re-trigger the 500).
+  migratedLikerLandUser: z.preprocess(
+    (value) => (value && typeof value === 'object' && !Array.isArray(value) ? value : null),
+    z.object({
+      id: z.string().nullish(),
+      likeWallet: z.string().nullish(),
+      lastLoginMethod: z.string().nullish(),
+      registerLoginMethod: z.string().nullish(),
+    }).nullable(),
+  ),
   migrateBookUserError: z.string().nullable(),
   migrateBookOwnerError: z.string().nullable(),
   migrateLikerIdError: z.string().nullable(),

--- a/test/unit/response-schemas.test.ts
+++ b/test/unit/response-schemas.test.ts
@@ -26,6 +26,9 @@ import {
 import {
   UserDataFilteredResponseSchema,
 } from '../../src/util/api/users/schemas';
+import {
+  WalletEvmMigrateResponseSchema,
+} from '../../src/util/api/wallet/schemas';
 
 // Regression guard for the recurring "response schema stricter than real data" 500s.
 // Each case reproduces a legacy/partial Firestore shape that 500'd a live endpoint
@@ -137,6 +140,57 @@ describe('Response schema ↔ legacy data alignment', () => {
     it('accepts a legacy locale code outside supportedLocales (e.g. "cn")', () => {
       const filtered = filterUserData({ user: 'legacyuser', locale: 'cn' } as any);
       expectParses(UserDataFilteredResponseSchema, filtered);
+    });
+  });
+
+  describe('WalletEvmMigrateResponseSchema (migratedLikerLandUser allowlist)', () => {
+    const base = {
+      isMigratedBookUser: true,
+      isMigratedBookOwner: true,
+      isMigratedLikerId: true,
+      isMigratedLikerLand: true,
+      migratedLikerId: 'liker-1',
+      migrateBookUserError: null,
+      migrateBookOwnerError: null,
+      migrateLikerIdError: null,
+      migrateLikerLandError: null,
+    };
+
+    it('strips extra (potentially PII) keys from the raw liker-land user object', () => {
+      // migratedLikerLandUser is the raw liker-land migrate body (commit 49dfbddd);
+      // only the allowlisted fields should survive.
+      const parsed = WalletEvmMigrateResponseSchema.parse({
+        ...base,
+        migratedLikerLandUser: {
+          id: 'u1',
+          likeWallet: 'like1',
+          lastLoginMethod: 'magic',
+          registerLoginMethod: 'wallet',
+          email: 'secret@pii.com',
+          displayName: 'Bob',
+        },
+      });
+      expect(parsed.migratedLikerLandUser).toEqual({
+        id: 'u1',
+        likeWallet: 'like1',
+        lastLoginMethod: 'magic',
+        registerLoginMethod: 'wallet',
+      });
+    });
+
+    it('accepts null (migration not run) and partial/missing inner fields', () => {
+      expectParses(WalletEvmMigrateResponseSchema, { ...base, migratedLikerLandUser: null });
+      expectParses(WalletEvmMigrateResponseSchema, {
+        ...base,
+        migratedLikerLandUser: { likeWallet: 'like1' },
+      });
+    });
+
+    it('coerces a non-object upstream body to null instead of 500ing', () => {
+      // liker-land could 200 with an empty string / array body; must not throw.
+      const S = WalletEvmMigrateResponseSchema;
+      expect(S.parse({ ...base, migratedLikerLandUser: '' }).migratedLikerLandUser).toBeNull();
+      expect(S.parse({ ...base, migratedLikerLandUser: [] }).migratedLikerLandUser).toBeNull();
     });
   });
 });


### PR DESCRIPTION
Replace the z.unknown() passthrough with an explicit 4-field object (id, likeWallet, lastLoginMethod, registerLoginMethod) matching the liker-land migrate response the clients actually consume. Since sendValidatedJSON parses-and-strips with default object schemas, any other field liker-land returns is now dropped instead of forwarded. Inner fields are nullish to avoid re-triggering RESPONSE_SCHEMA_MISMATCH on upstream shape drift.