### PR TITLE
🔒 Verify manual /sent delivery tx transfers NFT to buyer

### DIFF
--- a/src/routes/likernft/book/purchase.ts
+++ b/src/routes/likernft/book/purchase.ts
@@ -35,7 +35,7 @@ import {
 import { claimNFTBookCart, handleNewCartStripeCheckout } from '../../../util/api/likernft/book/cart';
 import logServerEvents from '../../../util/logServerEvents';
 import { getBook3CartURL, getBook3NFTClassPageURL } from '../../../util/liker-land';
-import { isEVMClassId, triggerNFTIndexerUpdate } from '../../../util/evm/nft';
+import { isEVMClassId, triggerNFTIndexerUpdate, verifyNFTTransferTxHash } from '../../../util/evm/nft';
 import { isValidEVMAddress } from '../../../util/evm';
 import { isValidLikeAddress } from '../../../util/cosmos';
 import { claimFreeBooks, getFreeBooksForUser } from '../../../util/api/likernft/book/free';
@@ -726,6 +726,29 @@ router.post(
       const { ownerWallet, moderatorWallets = [] } = listingData;
       const isAuthorized = checkIsAuthorized({ ownerWallet, moderatorWallets }, req);
       if (!isAuthorized) throw new ValidationError('UNAUTHORIZED', 403);
+      // Verify a seller-reported delivery txHash actually transfers the NFT on-chain.
+      // Auto-deliver mints server-side via claimNFTBook and never reaches this route.
+      if (isEVMClassId(classId) && txHash) {
+        try {
+          const paymentDoc = await likeNFTBookCollection.doc(classId)
+            .collection('transactions').doc(paymentId).get();
+          if (!paymentDoc.exists) throw new ValidationError('PAYMENT_ID_NOT_FOUND', 404);
+          const toWallet = paymentDoc.data()?.wallet;
+          // Claim enforces a valid EVM wallet, so a legit delivery always has one.
+          // Fail closed on empty/invalid wallet to avoid an unverified /sent bypass.
+          if (!toWallet || !isValidEVMAddress(toWallet)) {
+            throw new ValidationError('INVALID_WALLET_ADDRESS', 400);
+          }
+          await verifyNFTTransferTxHash({
+            classId, txHash, toWallet, quantity,
+          });
+        } catch (err) {
+          if (err instanceof ValidationError) throw err;
+          // Tolerate RPC/network failures so a flaky node does not block delivery.
+          // eslint-disable-next-line no-console
+          console.error(`Failed to verify delivery tx ${txHash} for class ${classId}:`, err);
+        }
+      }
       const result = await db.runTransaction(async (t: admin.firestore.Transaction) => {
         const paymentData = await updateNFTBookPostDeliveryData({
           classId,

--- a/src/util/api/likernft/book/purchase.ts
+++ b/src/util/api/likernft/book/purchase.ts
@@ -1222,7 +1222,8 @@ export async function updateNFTBookPostDeliveryData({
   quantity?: number,
   isAutoDeliver?: boolean,
 }, t: any) {
-  // TODO: check tx content contains valid nft info and address
+  // Manual /sent txHashes are verified on-chain in the route before this
+  // transaction (verifyNFTTransferTxHash); RPC can't run inside a Firestore tx.
   const bookDocRef = likeNFTBookCollection.doc(classId);
   const paymentDocRef = bookDocRef.collection('transactions').doc(paymentId);
   const paymentDoc = await t.get(paymentDocRef);

--- a/src/util/evm/nft.ts
+++ b/src/util/evm/nft.ts
@@ -1,9 +1,10 @@
 /* eslint-disable camelcase */
 import { readContract } from 'viem/actions';
-import { getAddress } from 'viem';
+import { getAddress, parseEventLogs } from 'viem';
 import axios from 'axios';
 import LRU from 'lru-cache';
 import { getEVMClient, getEVMWalletAccount, getEVMWalletClient } from './client';
+import { ValidationError } from '../ValidationError';
 import { LIKE_NFT_ABI, LIKE_NFT_CLASS_ABI, LIKE_NFT_CONTRACT_ADDRESS } from '../../constant/contract/likeNFT';
 import { sendWriteContractWithNonce } from './tx';
 import { logEVMMintNFTsTx } from '../txLogger';
@@ -409,4 +410,55 @@ export async function getTokenById(booknftId: string, tokenId: string): Promise<
     `${LIKE_NFT_EVM_INDEXER_API}/token/${booknftId}/${tokenId}`,
   );
   return data;
+}
+
+// Verify that txHash is an on-chain transfer of the class's NFT to toWallet.
+// Throws ValidationError on a definitive mismatch (malformed hash, failed tx, or
+// too few matching transfers). RPC/network errors bubble up as plain errors for
+// the caller to tolerate.
+export async function verifyNFTTransferTxHash({
+  classId,
+  txHash,
+  toWallet,
+  quantity = 1,
+}: {
+  classId: string,
+  txHash: string,
+  toWallet: string,
+  quantity?: number,
+}): Promise<bigint[]> {
+  // Reject malformed hashes up front as a definitive mismatch, so an invalid
+  // input is not swallowed as a tolerated RPC/network error by the caller.
+  if (!/^0x[0-9a-fA-F]{64}$/.test(txHash)) {
+    throw new ValidationError('DELIVERY_TX_HASH_INVALID', 400);
+  }
+  const client = getEVMClient();
+  const receipt = await client.waitForTransactionReceipt({
+    hash: txHash as `0x${string}`,
+    timeout: 60000,
+  });
+  if (receipt.status !== 'success') {
+    throw new ValidationError('DELIVERY_TX_FAILED', 400);
+  }
+  const classAddress = getAddress(classId);
+  const recipient = getAddress(toWallet);
+  // Manual sends use batchTransferWithMemo (TransferWithMemo); mints/plain
+  // transfers emit standard Transfer. Accept either to cover both paths.
+  const transferLogs = parseEventLogs({
+    abi: LIKE_NFT_CLASS_ABI,
+    eventName: ['Transfer', 'TransferWithMemo'],
+    logs: receipt.logs,
+  });
+  const matched = transferLogs
+    .map((log) => ({ address: log.address, args: log.args as { to: string, tokenId: bigint } }))
+    .filter(({ address, args }) => (
+      getAddress(address) === classAddress && getAddress(args.to) === recipient
+    ));
+  // Dedupe by tokenId: Transfer and TransferWithMemo can both fire for one
+  // transfer, which would otherwise double-count against quantity.
+  const tokenIds = [...new Set(matched.map(({ args }) => args.tokenId))];
+  if (tokenIds.length < quantity) {
+    throw new ValidationError('DELIVERY_TX_NFT_MISMATCH', 400);
+  }
+  return tokenIds;
 }

--- a/test/unit/evm-nft-transfer.test.ts
+++ b/test/unit/evm-nft-transfer.test.ts
@@ -1,0 +1,161 @@
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest';
+import { encodeAbiParameters, encodeEventTopics, getAddress } from 'viem';
+import { LIKE_NFT_CLASS_ABI } from '../../src/constant/contract/likeNFT';
+import { verifyNFTTransferTxHash } from '../../src/util/evm/nft';
+import { ValidationError } from '../../src/util/ValidationError';
+
+// vi.mock is hoisted above these imports; the `mock`-prefixed name is
+// whitelisted by Vitest's factory scope check.
+const mockWaitForTransactionReceipt = vi.fn();
+
+vi.mock('../../src/util/evm/client', () => ({
+  getEVMClient: () => ({
+    waitForTransactionReceipt: mockWaitForTransactionReceipt,
+  }),
+  getEVMWalletAccount: vi.fn(),
+  getEVMWalletClient: vi.fn(),
+}));
+
+const CLASS_ID = '0x1234567890abcdef1234567890abcdef12345678';
+const BUYER = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+const OTHER = '0x9999999999999999999999999999999999999999';
+const TX_HASH = '0xdeadbeef00000000000000000000000000000000000000000000000000000000';
+
+function makeTransferLog({
+  address = CLASS_ID, from = '0x0000000000000000000000000000000000000000', to, tokenId,
+}) {
+  return {
+    address,
+    topics: encodeEventTopics({
+      abi: LIKE_NFT_CLASS_ABI,
+      eventName: 'Transfer',
+      args: { from: getAddress(from), to: getAddress(to), tokenId: BigInt(tokenId) },
+    }),
+    data: '0x',
+  };
+}
+
+// batchTransferWithMemo (the manual seller send path) emits TransferWithMemo,
+// whose indexed args match Transfer plus a non-indexed `memo` string in data.
+function makeTransferWithMemoLog({
+  address = CLASS_ID, from = getAddress(CLASS_ID), to, tokenId, memo = 'gift',
+}) {
+  return {
+    address,
+    topics: encodeEventTopics({
+      abi: LIKE_NFT_CLASS_ABI,
+      eventName: 'TransferWithMemo',
+      args: { from: getAddress(from), to: getAddress(to), tokenId: BigInt(tokenId) },
+    }),
+    data: encodeAbiParameters([{ type: 'string', name: 'memo' }], [memo]),
+  };
+}
+
+describe('verifyNFTTransferTxHash', () => {
+  beforeEach(() => {
+    mockWaitForTransactionReceipt.mockReset();
+  });
+
+  it('resolves with the token id on a matching transfer', async () => {
+    mockWaitForTransactionReceipt.mockResolvedValue({
+      status: 'success',
+      logs: [makeTransferLog({ to: BUYER, tokenId: 5 })],
+    });
+    const tokenIds = await verifyNFTTransferTxHash({
+      classId: CLASS_ID, txHash: TX_HASH, toWallet: BUYER,
+    });
+    expect(tokenIds).toEqual([5n]);
+  });
+
+  it('accepts TransferWithMemo (batchTransferWithMemo manual send path)', async () => {
+    mockWaitForTransactionReceipt.mockResolvedValue({
+      status: 'success',
+      logs: [makeTransferWithMemoLog({ to: BUYER, tokenId: 7 })],
+    });
+    const tokenIds = await verifyNFTTransferTxHash({
+      classId: CLASS_ID, txHash: TX_HASH, toWallet: BUYER,
+    });
+    expect(tokenIds).toEqual([7n]);
+  });
+
+  it('counts one NFT once when Transfer and TransferWithMemo both fire for it', async () => {
+    const bothLogs = [
+      makeTransferLog({ to: BUYER, tokenId: 7 }),
+      makeTransferWithMemoLog({ to: BUYER, tokenId: 7 }),
+    ];
+    mockWaitForTransactionReceipt.mockResolvedValue({ status: 'success', logs: bothLogs });
+    expect(await verifyNFTTransferTxHash({
+      classId: CLASS_ID, txHash: TX_HASH, toWallet: BUYER,
+    })).toEqual([7n]);
+
+    mockWaitForTransactionReceipt.mockResolvedValue({ status: 'success', logs: bothLogs });
+    await expect(verifyNFTTransferTxHash({
+      classId: CLASS_ID, txHash: TX_HASH, toWallet: BUYER, quantity: 2,
+    })).rejects.toMatchObject({ message: 'DELIVERY_TX_NFT_MISMATCH' });
+  });
+
+  it('throws DELIVERY_TX_FAILED when the receipt reverted', async () => {
+    mockWaitForTransactionReceipt.mockResolvedValue({ status: 'reverted', logs: [] });
+    await expect(verifyNFTTransferTxHash({
+      classId: CLASS_ID, txHash: TX_HASH, toWallet: BUYER,
+    })).rejects.toSatisfy((err) => err instanceof ValidationError && err.message === 'DELIVERY_TX_FAILED');
+  });
+
+  it('throws DELIVERY_TX_NFT_MISMATCH when the transfer went to another wallet', async () => {
+    mockWaitForTransactionReceipt.mockResolvedValue({
+      status: 'success',
+      logs: [makeTransferLog({ to: OTHER, tokenId: 5 })],
+    });
+    await expect(verifyNFTTransferTxHash({
+      classId: CLASS_ID, txHash: TX_HASH, toWallet: BUYER,
+    })).rejects.toMatchObject({ message: 'DELIVERY_TX_NFT_MISMATCH' });
+  });
+
+  it('throws DELIVERY_TX_NFT_MISMATCH when a Transfer came from an unrelated contract', async () => {
+    mockWaitForTransactionReceipt.mockResolvedValue({
+      status: 'success',
+      logs: [makeTransferLog({ address: OTHER, to: BUYER, tokenId: 5 })],
+    });
+    await expect(verifyNFTTransferTxHash({
+      classId: CLASS_ID, txHash: TX_HASH, toWallet: BUYER,
+    })).rejects.toMatchObject({ message: 'DELIVERY_TX_NFT_MISMATCH' });
+  });
+
+  it('requires at least `quantity` matching transfers', async () => {
+    mockWaitForTransactionReceipt.mockResolvedValue({
+      status: 'success',
+      logs: [makeTransferLog({ to: BUYER, tokenId: 5 })],
+    });
+    await expect(verifyNFTTransferTxHash({
+      classId: CLASS_ID, txHash: TX_HASH, toWallet: BUYER, quantity: 2,
+    })).rejects.toMatchObject({ message: 'DELIVERY_TX_NFT_MISMATCH' });
+
+    mockWaitForTransactionReceipt.mockResolvedValue({
+      status: 'success',
+      logs: [
+        makeTransferLog({ to: BUYER, tokenId: 5 }),
+        makeTransferLog({ to: BUYER, tokenId: 6 }),
+      ],
+    });
+    const tokenIds = await verifyNFTTransferTxHash({
+      classId: CLASS_ID, txHash: TX_HASH, toWallet: BUYER, quantity: 2,
+    });
+    expect(tokenIds).toEqual([5n, 6n]);
+  });
+
+  it('throws DELIVERY_TX_HASH_INVALID for a malformed txHash without hitting the RPC', async () => {
+    await expect(verifyNFTTransferTxHash({
+      classId: CLASS_ID, txHash: '0xdeadbeef', toWallet: BUYER,
+    })).rejects.toSatisfy((err) => err instanceof ValidationError && err.message === 'DELIVERY_TX_HASH_INVALID');
+    expect(mockWaitForTransactionReceipt).not.toHaveBeenCalled();
+  });
+
+  it('propagates RPC errors as non-ValidationError (route tolerates these)', async () => {
+    mockWaitForTransactionReceipt.mockRejectedValue(new Error('RPC timeout'));
+    await expect(verifyNFTTransferTxHash({
+      classId: CLASS_ID, txHash: TX_HASH, toWallet: BUYER,
+    })).rejects.toSatisfy((err) => err instanceof Error && !(err instanceof ValidationError));
+  });
+});


### PR DESCRIPTION
The /sent route trusted the seller-reported txHash without checking it on-chain. Add verifyNFTTransferTxHash to confirm the receipt succeeded and emitted a Transfer of the class's NFT to the buyer wallet, run before the Firestore transaction (RPC can't run inside a txn). Only manual EVM sends with a txHash are checked; auto-deliver mints server-side and never reaches this route. RPC/network failures are tolerated so a flaky node does not block delivery.