### PR TITLE
🐛 Derive listing isSoldOut from per-price flags

### DIFF
--- a/src/util/ValidationHelper.ts
+++ b/src/util/ValidationHelper.ts
@@ -595,7 +595,7 @@ export function filterNFTBookListingInfo(
     chain,
     prices,
     minPrice: Number.isFinite(minPriceInDecimal) ? (minPriceInDecimal as number) / 100 : undefined,
-    isSoldOut: stock <= 0,
+    isSoldOut: prices.every((p) => p.isSoldOut),
     stock,
     ownerWallet,
     mustClaimToView,


### PR DESCRIPTION
Listing-level isSoldOut recomputed stock <= 0, ignoring the auto-deliver rule the per-price flag already applies. An all-auto-deliver book with 0 stock reported price isSoldOut false but listing isSoldOut true. Derive the aggregate from the per-price flags so both stay consistent.