### PR TITLE
[TAS-6147] ✨ Accept plaintext fileSHA256 provenance anchor at arweave register

### DIFF
--- a/src/routes/arweave/index.ts
+++ b/src/routes/arweave/index.ts
@@ -208,7 +208,7 @@ router.post(
   async (req, res, next) => {
     try {
       const {
-        txHash, arweaveId, token, key, isRequireAuth = true,
+        txHash, arweaveId, token, key, isRequireAuth = true, fileSHA256,
       } = req.body;
       if (isRequireAuth && !req.user?.wallet) throw new ValidationError('MISSING_USER', 401);
       const tx = await getArweaveTxInfo(txHash);
@@ -224,6 +224,7 @@ router.post(
         ownerWallet: req.user?.wallet || '',
         key,
         isRequireAuth,
+        fileSHA256,
       });
       sendValidatedJSON(res, ArweaveRegisterResponseSchema, {
         link: `https://${API_HOSTNAME}/arweave/v2/link/${txHash}`,

--- a/src/types/transaction.d.ts
+++ b/src/types/transaction.d.ts
@@ -41,6 +41,7 @@ export interface ArweaveTxData {
   isRequireAuth?: boolean;
   key?: string; // legacy plaintext content key; superseded by encryptedKey
   encryptedKey?: string; // base64 KMS-wrapped content key (AAD = txHash)
+  fileSHA256?: string; // hex SHA-256 of the plaintext content (provenance anchor)
   accessToken?: string;
   isSponsored?: boolean;
   sponsoredETH?: string;

--- a/src/util/api/arweave/schemas.ts
+++ b/src/util/api/arweave/schemas.ts
@@ -19,6 +19,7 @@ export const ArweaveRegisterBodySchema = z.object({
   token: z.string().optional(),
   key: z.string().optional(),
   isRequireAuth: z.boolean().optional(),
+  fileSHA256: z.string().regex(/^[0-9a-f]{64}$/i).optional(),
 });
 
 export const ArweaveTxHashParamsSchema = z.object({

--- a/src/util/api/arweave/tx.ts
+++ b/src/util/api/arweave/tx.ts
@@ -41,11 +41,13 @@ export async function updateArweaveTxStatus(txHash: string, {
   ownerWallet,
   key = '',
   isRequireAuth = false,
+  fileSHA256 = '',
 }: {
   arweaveId: string;
   ownerWallet: string;
   key?: string;
   isRequireAuth?: boolean;
+  fileSHA256?: string;
 }): Promise<string> {
   const accessToken = uuidv4();
   // Under KMS store wrapped ciphertext in `encryptedKey` (AAD = txHash); in
@@ -63,6 +65,7 @@ export async function updateArweaveTxStatus(txHash: string, {
     isRequireAuth,
     ownerWallet,
     ...keyFields,
+    ...(fileSHA256 ? { fileSHA256: fileSHA256.toLowerCase() } : {}),
     accessToken,
     lastUpdateTimestamp: FieldValue.serverTimestamp(),
   });


### PR DESCRIPTION
Stores the client-computed hash of the original (pre-encryption) file on the tx doc so decrypted content can be verified end-to-end (ADR 0001).