### PR TITLE
🐛 Fall back to ownerWallet royalty payout on empty connectedWallets

### DIFF
--- a/src/util/api/likernft/book/purchase.ts
+++ b/src/util/api/likernft/book/purchase.ts
@@ -141,8 +141,8 @@ export async function handleStripeConnectedAccount({
 
   const stripe = getStripeClient();
   let connectedWallets = connectedWalletsInput;
-  if (!connectedWallets) {
-    // if connectedWallets is not set before, default to ownerWallet
+  if (!connectedWallets || !Object.keys(connectedWallets).length) {
+    // if connectedWallets is not set (or empty), default to ownerWallet
     connectedWallets = {
       [ownerWallet]: 1,
     };


### PR DESCRIPTION
Previously the fallback only fired when connectedWallets was unset; an empty {} map skipped the royalty split entirely, paying no one. Treat an empty map the same as unset so the owner still gets paid.