### PR TITLE
[TAS-6147] ✨ Dual-store protected uploads into a private CMEK bucket

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -78,6 +78,9 @@ config.ARWEAVE_IRYS_FUND_MULTIPLIER = Number(process.env.ARWEAVE_IRYS_FUND_MULTI
 config.ARWEAVE_IRYS_DEPOSIT_ADDRESS = process.env.ARWEAVE_IRYS_DEPOSIT_ADDRESS || '';
 // Bearer secret for the admin/cron funding-reconcile endpoint.
 config.ARWEAVE_RECONCILE_ADMIN_TOKEN = process.env.ARWEAVE_RECONCILE_ADMIN_TOKEN || '';
+// Private CMEK-protected GCS bucket holding plaintext-at-rest protected ebooks
+// (ADR 0001 Phase 3). Empty = ingest disabled.
+config.EBOOK_PROTECTED_BUCKET = process.env.EBOOK_PROTECTED_BUCKET || '';
 
 config.LIKER_NFT_TARGET_ADDRESS = '';
 

--- a/src/constant/index.ts
+++ b/src/constant/index.ts
@@ -180,6 +180,9 @@ export const SYSTEM_EMAIL = '"3ook.com" <cs@3ook.com>';
 export const LIKER_LAND_WAIVED_CHANNEL = 'liker_land_waived';
 
 export const ARWEAVE_GATEWAY = 'https://gateway.irys.xyz';
+// Irys first: it is the bundler we upload through, so it serves fresh uploads
+// without propagation lag. Fallback order is irrelevant to membership checks.
+export const ARWEAVE_GATEWAYS = [`${ARWEAVE_GATEWAY}/`, 'https://arweave.net/'];
 
 export const MIN_BOOK_PRICE_DECIMAL = 90; // 0.90 USD
 export const NFT_BOOK_TEXT_LOCALES = ['zh', 'en'];

--- a/src/routes/arweave/index.ts
+++ b/src/routes/arweave/index.ts
@@ -22,6 +22,7 @@ import {
 import { getRemainingQuota, checkAndReserveQuota, rollbackQuota } from '../../util/api/arweave/quota';
 import { reconcilePendingIrysFunding, fundUploadIfNeeded } from '../../util/api/arweave/funding';
 import { ingestProtectedContent } from '../../util/api/arweave/ingest';
+import { getProtectedContentUri } from '../../util/gcloudStorage';
 import {
   ArweaveEstimateBodySchema,
   ArweaveEstimateResponseSchema,
@@ -312,11 +313,16 @@ router.get(
         link.searchParams.set('key', key);
       }
       if (req.accepts('application/json')) {
+        // Advertise the private-bucket plaintext copy (ADR 0001 Phase 3) so
+        // readers with bucket access can go GCS-first; key + link remain the
+        // fallback. contentType rides along so they can skip a metadata call.
+        const contentUri = getProtectedContentUri(tx.contentBucketPath);
         sendValidatedJSON(res, ArweaveLinkResponseSchema, {
           arweaveId,
           txHash,
           key,
           link: link.toString(),
+          ...(contentUri ? { contentUri, contentType: tx.contentType } : {}),
         });
         return;
       }

--- a/src/routes/arweave/index.ts
+++ b/src/routes/arweave/index.ts
@@ -21,6 +21,7 @@ import {
 } from '../../util/api/arweave/tx';
 import { getRemainingQuota, checkAndReserveQuota, rollbackQuota } from '../../util/api/arweave/quota';
 import { reconcilePendingIrysFunding, fundUploadIfNeeded } from '../../util/api/arweave/funding';
+import { ingestProtectedContent } from '../../util/api/arweave/ingest';
 import {
   ArweaveEstimateBodySchema,
   ArweaveEstimateResponseSchema,
@@ -248,6 +249,32 @@ router.post(
         arweaveId,
         txHash,
       });
+      // Dual-store protected uploads into the private CMEK bucket (Phase 3).
+      // Best-effort: a failure here leaves Arweave as the only copy, which is
+      // today's status quo; Phase 4's re-ingest sweep catches stragglers.
+      if (key) {
+        try {
+          const ingested = await ingestProtectedContent(txHash, {
+            arweaveId, key, ipfsHash, fileSize, fileSHA256,
+          });
+          if (ingested) {
+            publisher.publish(PUBSUB_TOPIC_MISC, req, {
+              logType: 'arweaveProtectedIngestCompleteV2',
+              arweaveId,
+              txHash,
+              contentBucketPath: ingested.contentBucketPath,
+              fileSHA256: ingested.fileSHA256,
+            });
+          }
+        } catch (error) {
+          publisher.publish(PUBSUB_TOPIC_MISC, req, {
+            logType: 'arweaveProtectedIngestErrorV2',
+            arweaveId,
+            txHash,
+            error: (error as Error).message,
+          });
+        }
+      }
     } catch (error) {
       next(error);
     }

--- a/src/types/transaction.d.ts
+++ b/src/types/transaction.d.ts
@@ -42,6 +42,7 @@ export interface ArweaveTxData {
   key?: string; // legacy plaintext content key; superseded by encryptedKey
   encryptedKey?: string; // base64 KMS-wrapped content key (AAD = txHash)
   fileSHA256?: string; // hex SHA-256 of the plaintext content (provenance anchor)
+  contentBucketPath?: string; // object path in the protected GCS bucket once ingested
   accessToken?: string;
   isSponsored?: boolean;
   sponsoredETH?: string;

--- a/src/types/transaction.d.ts
+++ b/src/types/transaction.d.ts
@@ -43,6 +43,7 @@ export interface ArweaveTxData {
   encryptedKey?: string; // base64 KMS-wrapped content key (AAD = txHash)
   fileSHA256?: string; // hex SHA-256 of the plaintext content (provenance anchor)
   contentBucketPath?: string; // object path in the protected GCS bucket once ingested
+  contentType?: string; // MIME type of the ingested object, advertised with contentUri
   accessToken?: string;
   isSponsored?: boolean;
   sponsoredETH?: string;

--- a/src/util/api/arweave/ingest.ts
+++ b/src/util/api/arweave/ingest.ts
@@ -1,7 +1,10 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import crypto from 'crypto';
+import { Readable, Transform } from 'stream';
+import { pipeline } from 'stream/promises';
 import { ARWEAVE_GATEWAY } from '../../../constant';
 import { getEbookProtectedBucket, isEbookProtectedBucketEnabled } from '../../gcloudStorage';
+import { ARWEAVE_MAX_SIZE_V2 } from './index';
 import { markArweaveTxIngested } from './tx';
 
 // Same gateway set as ebook-cors/book cache; the Irys gateway is the bundler
@@ -11,54 +14,125 @@ const ARWEAVE_GATEWAY_PREFIXES = [`${ARWEAVE_GATEWAY}/`, 'https://arweave.net/']
 const AES_GCM_IV_LENGTH = 12;
 const AES_GCM_TAG_LENGTH = 16;
 const DOWNLOAD_TIMEOUT_MS = 120000;
+const STAGING_PREFIX = 'staging/';
 
-async function downloadArweaveData(
+/**
+ * Decrypt the client-side AES-256-GCM format produced by publish-3ook-com
+ * (arweavekit layout): 12-byte IV ‖ ciphertext ‖ 16-byte auth tag.
+ *
+ * The tag only arrives with the final 16 bytes, so this withholds a rolling
+ * tail and authenticates in flush(). Plaintext is therefore emitted before it
+ * is known to be authentic — callers must stage the output and only promote it
+ * once the stream completes without error.
+ */
+export function createGcmDecryptTransform(keyBase64: string): Transform {
+  const key = Buffer.from(keyBase64, 'base64');
+  if (key.length !== 32) throw new Error('INVALID_CONTENT_KEY');
+  let decipher: crypto.DecipherGCM | undefined;
+  // Holds the IV until the decipher exists, then the withheld tail candidate.
+  let pending = Buffer.alloc(0);
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      try {
+        let body = chunk as Buffer;
+        if (!decipher) {
+          pending = Buffer.concat([pending, body]);
+          if (pending.length < AES_GCM_IV_LENGTH) {
+            callback();
+            return;
+          }
+          const iv = pending.subarray(0, AES_GCM_IV_LENGTH);
+          decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+          body = pending.subarray(AES_GCM_IV_LENGTH);
+          pending = Buffer.alloc(0);
+        }
+        // A chunk at least as long as the tag proves the withheld tail is not
+        // the tag, so release it and withhold this chunk's last 16 bytes — the
+        // steady state, and the reason this doesn't concat per chunk.
+        if (body.length >= AES_GCM_TAG_LENGTH) {
+          if (pending.length) this.push(decipher.update(pending));
+          const cut = body.length - AES_GCM_TAG_LENGTH;
+          // Copy, so the tail stops pinning the whole chunk allocation.
+          pending = Buffer.from(body.subarray(cut));
+          if (!cut) {
+            callback();
+            return;
+          }
+          callback(null, decipher.update(body.subarray(0, cut)));
+          return;
+        }
+        const buffered = Buffer.concat([pending, body]);
+        if (buffered.length <= AES_GCM_TAG_LENGTH) {
+          pending = buffered;
+          callback();
+          return;
+        }
+        const cut = buffered.length - AES_GCM_TAG_LENGTH;
+        pending = Buffer.from(buffered.subarray(cut));
+        callback(null, decipher.update(buffered.subarray(0, cut)));
+      } catch (error) {
+        callback(error as Error);
+      }
+    },
+    flush(callback) {
+      try {
+        if (!decipher || pending.length !== AES_GCM_TAG_LENGTH) {
+          throw new Error('INVALID_ENCRYPTED_PAYLOAD');
+        }
+        decipher.setAuthTag(pending);
+        callback(null, decipher.final());
+      } catch (error) {
+        callback(error as Error);
+      }
+    },
+  });
+}
+
+// Hash the plaintext as it streams past, leaving the bytes untouched. Only read
+// the digest once the pipeline has resolved.
+function createHashTransform(hash: crypto.Hash): Transform {
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      hash.update(chunk);
+      callback(null, chunk);
+    },
+  });
+}
+
+// Gateway fallback only covers the request itself; once bytes are flowing into
+// GCS a mid-stream failure aborts the ingest rather than restarting the upload.
+async function openArweaveStream(
   arweaveId: string,
-  fileSize?: number,
-): Promise<{ data: Buffer; contentType: string }> {
-  // Ciphertext is plaintext + 28 bytes; fileSize may be either, so pad 1MB.
-  const maxContentLength = fileSize ? fileSize + (1024 * 1024) : 1024 * 1024 * 1024;
+  maxContentLength: number,
+): Promise<{ stream: Readable; contentType: string }> {
   let lastError: unknown;
   for (const prefix of ARWEAVE_GATEWAY_PREFIXES) {
     try {
       // eslint-disable-next-line no-await-in-loop
-      const res = await axios.get(`${prefix}${arweaveId}`, {
-        responseType: 'arraybuffer',
+      const res = await axios.get<Readable>(`${prefix}${arweaveId}`, {
+        responseType: 'stream',
         timeout: DOWNLOAD_TIMEOUT_MS,
         maxContentLength,
       });
       const contentTypeHeader = res.headers['content-type'];
       return {
-        data: Buffer.from(res.data),
+        stream: res.data,
         contentType: typeof contentTypeHeader === 'string' && contentTypeHeader
           ? contentTypeHeader : 'application/octet-stream',
       };
     } catch (error) {
+      // A stream response body is left open on a non-2xx; drop it or the socket
+      // is held until the gateway times out.
+      (error as AxiosError<Readable>).response?.data?.destroy?.();
       lastError = error;
     }
   }
   throw lastError;
 }
 
-// Decrypt the client-side AES-256-GCM format produced by publish-3ook-com
-// (arweavekit layout): 12-byte IV ‖ ciphertext ‖ 16-byte auth tag.
-export function decryptContentBuffer(combined: Buffer, keyBase64: string): Buffer {
-  if (combined.length < AES_GCM_IV_LENGTH + AES_GCM_TAG_LENGTH) {
-    throw new Error('INVALID_ENCRYPTED_PAYLOAD');
-  }
-  const key = Buffer.from(keyBase64, 'base64');
-  if (key.length !== 32) throw new Error('INVALID_CONTENT_KEY');
-  const iv = combined.subarray(0, AES_GCM_IV_LENGTH);
-  const authTag = combined.subarray(combined.length - AES_GCM_TAG_LENGTH);
-  const ciphertext = combined.subarray(AES_GCM_IV_LENGTH, combined.length - AES_GCM_TAG_LENGTH);
-  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
-  decipher.setAuthTag(authTag);
-  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
-}
-
 /**
  * Ingest a protected upload into the private CMEK bucket (ADR 0001 Phase 3):
- * fetch ciphertext from Arweave, decrypt with the content key, verify the
+ * stream the ciphertext from Arweave, decrypt with the content key, verify the
  * plaintext SHA-256 against the client-supplied provenance anchor when one
  * exists (record the computed hash otherwise), and store plaintext-at-rest
  * under a key-free path. No-op when the bucket is not configured.
@@ -77,30 +151,45 @@ export async function ingestProtectedContent(txHash: string, {
   fileSHA256?: string;
 }): Promise<{ contentBucketPath: string; fileSHA256: string } | null> {
   if (!isEbookProtectedBucketEnabled() || !arweaveId || !key) return null;
-  const { data, contentType } = await downloadArweaveData(arweaveId, fileSize);
-  const plaintext = decryptContentBuffer(data, key);
-  const computedSHA256 = crypto.createHash('sha256').update(plaintext).digest('hex');
-  if (fileSHA256 && fileSHA256.toLowerCase() !== computedSHA256) {
-    throw new Error('PLAINTEXT_HASH_MISMATCH');
-  }
-  const contentBucketPath = txHash;
-  await getEbookProtectedBucket().file(contentBucketPath).save(plaintext, {
-    contentType,
-    resumable: false,
-    metadata: {
+  // Ciphertext is plaintext + 28 bytes; fileSize may be either, so pad 1MB.
+  const maxContentLength = (fileSize || ARWEAVE_MAX_SIZE_V2) + (1024 * 1024);
+  // Throws INVALID_CONTENT_KEY before any network or storage work happens.
+  const decrypt = createGcmDecryptTransform(key);
+  const hash = crypto.createHash('sha256');
+  const bucket = getEbookProtectedBucket();
+  const stagingFile = bucket.file(`${STAGING_PREFIX}${txHash}`);
+  const { stream, contentType } = await openArweaveStream(arweaveId, maxContentLength);
+  try {
+    await pipeline(
+      stream,
+      decrypt,
+      createHashTransform(hash),
+      stagingFile.createWriteStream({ resumable: false, metadata: { contentType } }),
+    );
+    const computedSHA256 = hash.digest('hex');
+    if (fileSHA256 && fileSHA256.toLowerCase() !== computedSHA256) {
+      throw new Error('PLAINTEXT_HASH_MISMATCH');
+    }
+    const contentBucketPath = txHash;
+    await stagingFile.copy(bucket.file(contentBucketPath), {
+      contentType,
       metadata: {
         arweaveId,
         ...(ipfsHash ? { ipfsHash } : {}),
         fileSHA256: computedSHA256,
       },
-    },
-  });
-  await markArweaveTxIngested(txHash, {
-    contentBucketPath,
-    contentType,
-    // Only backfill the doc hash when the client supplied none; a client
-    // anchor was already stored at register and verified above.
-    ...(fileSHA256 ? {} : { fileSHA256: computedSHA256 }),
-  });
-  return { contentBucketPath, fileSHA256: computedSHA256 };
+    });
+    await markArweaveTxIngested(txHash, {
+      contentBucketPath,
+      contentType,
+      // Only backfill the doc hash when the client supplied none; a client
+      // anchor was already stored at register and verified above.
+      ...(fileSHA256 ? {} : { fileSHA256: computedSHA256 }),
+    });
+    return { contentBucketPath, fileSHA256: computedSHA256 };
+  } finally {
+    // Swallow: a failed cleanup would mask the real error, and the bucket's
+    // staging/ lifecycle rule sweeps whatever is left behind.
+    await stagingFile.delete({ ignoreNotFound: true }).catch(() => undefined);
+  }
 }

--- a/src/util/api/arweave/ingest.ts
+++ b/src/util/api/arweave/ingest.ts
@@ -97,6 +97,7 @@ export async function ingestProtectedContent(txHash: string, {
   });
   await markArweaveTxIngested(txHash, {
     contentBucketPath,
+    contentType,
     // Only backfill the doc hash when the client supplied none; a client
     // anchor was already stored at register and verified above.
     ...(fileSHA256 ? {} : { fileSHA256: computedSHA256 }),

--- a/src/util/api/arweave/ingest.ts
+++ b/src/util/api/arweave/ingest.ts
@@ -1,0 +1,105 @@
+import axios from 'axios';
+import crypto from 'crypto';
+import { ARWEAVE_GATEWAY } from '../../../constant';
+import { getEbookProtectedBucket, isEbookProtectedBucketEnabled } from '../../gcloudStorage';
+import { markArweaveTxIngested } from './tx';
+
+// Same gateway set as ebook-cors/book cache; the Irys gateway is the bundler
+// we upload through, so it serves fresh uploads without propagation lag.
+const ARWEAVE_GATEWAY_PREFIXES = [`${ARWEAVE_GATEWAY}/`, 'https://arweave.net/'];
+
+const AES_GCM_IV_LENGTH = 12;
+const AES_GCM_TAG_LENGTH = 16;
+const DOWNLOAD_TIMEOUT_MS = 120000;
+
+async function downloadArweaveData(
+  arweaveId: string,
+  fileSize?: number,
+): Promise<{ data: Buffer; contentType: string }> {
+  // Ciphertext is plaintext + 28 bytes; fileSize may be either, so pad 1MB.
+  const maxContentLength = fileSize ? fileSize + (1024 * 1024) : 1024 * 1024 * 1024;
+  let lastError: unknown;
+  for (const prefix of ARWEAVE_GATEWAY_PREFIXES) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const res = await axios.get(`${prefix}${arweaveId}`, {
+        responseType: 'arraybuffer',
+        timeout: DOWNLOAD_TIMEOUT_MS,
+        maxContentLength,
+      });
+      const contentTypeHeader = res.headers['content-type'];
+      return {
+        data: Buffer.from(res.data),
+        contentType: typeof contentTypeHeader === 'string' && contentTypeHeader
+          ? contentTypeHeader : 'application/octet-stream',
+      };
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
+// Decrypt the client-side AES-256-GCM format produced by publish-3ook-com
+// (arweavekit layout): 12-byte IV ‖ ciphertext ‖ 16-byte auth tag.
+export function decryptContentBuffer(combined: Buffer, keyBase64: string): Buffer {
+  if (combined.length < AES_GCM_IV_LENGTH + AES_GCM_TAG_LENGTH) {
+    throw new Error('INVALID_ENCRYPTED_PAYLOAD');
+  }
+  const key = Buffer.from(keyBase64, 'base64');
+  if (key.length !== 32) throw new Error('INVALID_CONTENT_KEY');
+  const iv = combined.subarray(0, AES_GCM_IV_LENGTH);
+  const authTag = combined.subarray(combined.length - AES_GCM_TAG_LENGTH);
+  const ciphertext = combined.subarray(AES_GCM_IV_LENGTH, combined.length - AES_GCM_TAG_LENGTH);
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+}
+
+/**
+ * Ingest a protected upload into the private CMEK bucket (ADR 0001 Phase 3):
+ * fetch ciphertext from Arweave, decrypt with the content key, verify the
+ * plaintext SHA-256 against the client-supplied provenance anchor when one
+ * exists (record the computed hash otherwise), and store plaintext-at-rest
+ * under a key-free path. No-op when the bucket is not configured.
+ */
+export async function ingestProtectedContent(txHash: string, {
+  arweaveId,
+  key,
+  ipfsHash,
+  fileSize,
+  fileSHA256,
+}: {
+  arweaveId: string;
+  key: string;
+  ipfsHash?: string;
+  fileSize?: number;
+  fileSHA256?: string;
+}): Promise<{ contentBucketPath: string; fileSHA256: string } | null> {
+  if (!isEbookProtectedBucketEnabled() || !arweaveId || !key) return null;
+  const { data, contentType } = await downloadArweaveData(arweaveId, fileSize);
+  const plaintext = decryptContentBuffer(data, key);
+  const computedSHA256 = crypto.createHash('sha256').update(plaintext).digest('hex');
+  if (fileSHA256 && fileSHA256.toLowerCase() !== computedSHA256) {
+    throw new Error('PLAINTEXT_HASH_MISMATCH');
+  }
+  const contentBucketPath = txHash;
+  await getEbookProtectedBucket().file(contentBucketPath).save(plaintext, {
+    contentType,
+    resumable: false,
+    metadata: {
+      metadata: {
+        arweaveId,
+        ...(ipfsHash ? { ipfsHash } : {}),
+        fileSHA256: computedSHA256,
+      },
+    },
+  });
+  await markArweaveTxIngested(txHash, {
+    contentBucketPath,
+    // Only backfill the doc hash when the client supplied none; a client
+    // anchor was already stored at register and verified above.
+    ...(fileSHA256 ? {} : { fileSHA256: computedSHA256 }),
+  });
+  return { contentBucketPath, fileSHA256: computedSHA256 };
+}

--- a/src/util/api/arweave/ingest.ts
+++ b/src/util/api/arweave/ingest.ts
@@ -1,15 +1,11 @@
-import axios, { AxiosError } from 'axios';
 import crypto from 'crypto';
-import { Readable, Transform } from 'stream';
+import { Transform } from 'stream';
 import { pipeline } from 'stream/promises';
-import { ARWEAVE_GATEWAY } from '../../../constant';
+import { ARWEAVE_GATEWAYS } from '../../../constant';
+import { fetchStreamWithFallback } from '../../fetchStream';
 import { getEbookProtectedBucket, isEbookProtectedBucketEnabled } from '../../gcloudStorage';
 import { ARWEAVE_MAX_SIZE_V2 } from './index';
 import { markArweaveTxIngested } from './tx';
-
-// Same gateway set as ebook-cors/book cache; the Irys gateway is the bundler
-// we upload through, so it serves fresh uploads without propagation lag.
-const ARWEAVE_GATEWAY_PREFIXES = [`${ARWEAVE_GATEWAY}/`, 'https://arweave.net/'];
 
 const AES_GCM_IV_LENGTH = 12;
 const AES_GCM_TAG_LENGTH = 16;
@@ -36,40 +32,32 @@ export function createGcmDecryptTransform(keyBase64: string): Transform {
       try {
         let body = chunk as Buffer;
         if (!decipher) {
-          pending = Buffer.concat([pending, body]);
-          if (pending.length < AES_GCM_IV_LENGTH) {
+          body = Buffer.concat([pending, body]);
+          pending = Buffer.alloc(0);
+          if (body.length < AES_GCM_IV_LENGTH) {
+            pending = body;
             callback();
             return;
           }
-          const iv = pending.subarray(0, AES_GCM_IV_LENGTH);
+          const iv = body.subarray(0, AES_GCM_IV_LENGTH);
           decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
-          body = pending.subarray(AES_GCM_IV_LENGTH);
+          body = body.subarray(AES_GCM_IV_LENGTH);
+        } else if (pending.length) {
+          // A chunk at least as long as the tag proves the withheld tail is not
+          // the tag, so release it instead of concatenating it onto every chunk.
+          if (body.length >= AES_GCM_TAG_LENGTH) this.push(decipher.update(pending));
+          else body = Buffer.concat([pending, body]);
           pending = Buffer.alloc(0);
         }
-        // A chunk at least as long as the tag proves the withheld tail is not
-        // the tag, so release it and withhold this chunk's last 16 bytes — the
-        // steady state, and the reason this doesn't concat per chunk.
-        if (body.length >= AES_GCM_TAG_LENGTH) {
-          if (pending.length) this.push(decipher.update(pending));
-          const cut = body.length - AES_GCM_TAG_LENGTH;
+        if (body.length <= AES_GCM_TAG_LENGTH) {
           // Copy, so the tail stops pinning the whole chunk allocation.
-          pending = Buffer.from(body.subarray(cut));
-          if (!cut) {
-            callback();
-            return;
-          }
-          callback(null, decipher.update(body.subarray(0, cut)));
-          return;
-        }
-        const buffered = Buffer.concat([pending, body]);
-        if (buffered.length <= AES_GCM_TAG_LENGTH) {
-          pending = buffered;
+          pending = Buffer.from(body);
           callback();
           return;
         }
-        const cut = buffered.length - AES_GCM_TAG_LENGTH;
-        pending = Buffer.from(buffered.subarray(cut));
-        callback(null, decipher.update(buffered.subarray(0, cut)));
+        const cut = body.length - AES_GCM_TAG_LENGTH;
+        pending = Buffer.from(body.subarray(cut));
+        callback(null, decipher.update(body.subarray(0, cut)));
       } catch (error) {
         callback(error as Error);
       }
@@ -99,43 +87,11 @@ function createHashTransform(hash: crypto.Hash): Transform {
   });
 }
 
-// Gateway fallback only covers the request itself; once bytes are flowing into
-// GCS a mid-stream failure aborts the ingest rather than restarting the upload.
-async function openArweaveStream(
-  arweaveId: string,
-  maxContentLength: number,
-): Promise<{ stream: Readable; contentType: string }> {
-  let lastError: unknown;
-  for (const prefix of ARWEAVE_GATEWAY_PREFIXES) {
-    try {
-      // eslint-disable-next-line no-await-in-loop
-      const res = await axios.get<Readable>(`${prefix}${arweaveId}`, {
-        responseType: 'stream',
-        timeout: DOWNLOAD_TIMEOUT_MS,
-        maxContentLength,
-      });
-      const contentTypeHeader = res.headers['content-type'];
-      return {
-        stream: res.data,
-        contentType: typeof contentTypeHeader === 'string' && contentTypeHeader
-          ? contentTypeHeader : 'application/octet-stream',
-      };
-    } catch (error) {
-      // A stream response body is left open on a non-2xx; drop it or the socket
-      // is held until the gateway times out.
-      (error as AxiosError<Readable>).response?.data?.destroy?.();
-      lastError = error;
-    }
-  }
-  throw lastError;
-}
-
 /**
- * Ingest a protected upload into the private CMEK bucket (ADR 0001 Phase 3):
- * stream the ciphertext from Arweave, decrypt with the content key, verify the
- * plaintext SHA-256 against the client-supplied provenance anchor when one
- * exists (record the computed hash otherwise), and store plaintext-at-rest
- * under a key-free path. No-op when the bucket is not configured.
+ * Ingest a protected upload into the private CMEK bucket (ADR 0001 Phase 3),
+ * storing plaintext-at-rest under a key-free path. No-op when the bucket is
+ * unconfigured. Gateway fallback only covers opening the stream; once bytes are
+ * flowing into GCS a mid-stream failure aborts rather than restarting.
  */
 export async function ingestProtectedContent(txHash: string, {
   arweaveId,
@@ -151,6 +107,9 @@ export async function ingestProtectedContent(txHash: string, {
   fileSHA256?: string;
 }): Promise<{ contentBucketPath: string; fileSHA256: string } | null> {
   if (!isEbookProtectedBucketEnabled() || !arweaveId || !key) return null;
+  // txHash is the object name; callers only ever mint an on-chain hash or a
+  // sponsored-<uuid>, so reject anything that could collide with STAGING_PREFIX.
+  if (!/^[A-Za-z0-9_-]+$/.test(txHash)) throw new Error('INVALID_TX_HASH');
   // Ciphertext is plaintext + 28 bytes; fileSize may be either, so pad 1MB.
   const maxContentLength = (fileSize || ARWEAVE_MAX_SIZE_V2) + (1024 * 1024);
   // Throws INVALID_CONTENT_KEY before any network or storage work happens.
@@ -158,7 +117,11 @@ export async function ingestProtectedContent(txHash: string, {
   const hash = crypto.createHash('sha256');
   const bucket = getEbookProtectedBucket();
   const stagingFile = bucket.file(`${STAGING_PREFIX}${txHash}`);
-  const { stream, contentType } = await openArweaveStream(arweaveId, maxContentLength);
+  const { stream, contentType: fetchedContentType } = await fetchStreamWithFallback(
+    ARWEAVE_GATEWAYS.map((gateway) => `${gateway}${arweaveId}`),
+    { timeout: DOWNLOAD_TIMEOUT_MS, maxContentLength },
+  );
+  const contentType = fetchedContentType || 'application/octet-stream';
   try {
     await pipeline(
       stream,
@@ -188,6 +151,9 @@ export async function ingestProtectedContent(txHash: string, {
     });
     return { contentBucketPath, fileSHA256: computedSHA256 };
   } finally {
+    // pipeline() destroys the source on its own error paths, but not if
+    // createWriteStream() throws before it ever runs.
+    if (!stream.destroyed) stream.destroy();
     // Swallow: a failed cleanup would mask the real error, and the bucket's
     // staging/ lifecycle rule sweeps whatever is left behind.
     await stagingFile.delete({ ignoreNotFound: true }).catch(() => undefined);

--- a/src/util/api/arweave/schemas.ts
+++ b/src/util/api/arweave/schemas.ts
@@ -60,6 +60,8 @@ export const ArweaveLinkResponseSchema = z.object({
   txHash: z.string().optional(),
   key: z.string().optional(),
   link: z.string(),
+  contentUri: z.string().optional(),
+  contentType: z.string().optional(),
 });
 
 export const ArweaveAccessTokenResponseSchema = z.object({

--- a/src/util/api/arweave/tx.ts
+++ b/src/util/api/arweave/tx.ts
@@ -73,17 +73,21 @@ export async function updateArweaveTxStatus(txHash: string, {
 }
 
 // Record the outcome of a protected-content ingest: where the plaintext lives
-// in the private bucket, and the plaintext hash when it was computed server-side
+// in the private bucket, its MIME type (so readers can skip a GCS metadata
+// round-trip), and the plaintext hash when it was computed server-side
 // (i.e. the client never supplied a provenance anchor).
 export async function markArweaveTxIngested(txHash: string, {
   contentBucketPath,
+  contentType,
   fileSHA256,
 }: {
   contentBucketPath: string;
+  contentType: string;
   fileSHA256?: string;
 }): Promise<void> {
   await iscnArweaveTxCollection.doc(txHash).update({
     contentBucketPath,
+    contentType,
     ...(fileSHA256 ? { fileSHA256: fileSHA256.toLowerCase() } : {}),
     lastUpdateTimestamp: FieldValue.serverTimestamp(),
   });

--- a/src/util/api/arweave/tx.ts
+++ b/src/util/api/arweave/tx.ts
@@ -72,10 +72,9 @@ export async function updateArweaveTxStatus(txHash: string, {
   return accessToken;
 }
 
-// Record the outcome of a protected-content ingest: where the plaintext lives
-// in the private bucket, its MIME type (so readers can skip a GCS metadata
-// round-trip), and the plaintext hash when it was computed server-side
-// (i.e. the client never supplied a provenance anchor).
+// Record a protected-content ingest: the plaintext's path in the private
+// bucket, its MIME type (so readers skip a GCS metadata round-trip), and the
+// plaintext hash only when computed server-side (client supplied no anchor).
 export async function markArweaveTxIngested(txHash: string, {
   contentBucketPath,
   contentType,

--- a/src/util/api/arweave/tx.ts
+++ b/src/util/api/arweave/tx.ts
@@ -72,6 +72,23 @@ export async function updateArweaveTxStatus(txHash: string, {
   return accessToken;
 }
 
+// Record the outcome of a protected-content ingest: where the plaintext lives
+// in the private bucket, and the plaintext hash when it was computed server-side
+// (i.e. the client never supplied a provenance anchor).
+export async function markArweaveTxIngested(txHash: string, {
+  contentBucketPath,
+  fileSHA256,
+}: {
+  contentBucketPath: string;
+  fileSHA256?: string;
+}): Promise<void> {
+  await iscnArweaveTxCollection.doc(txHash).update({
+    contentBucketPath,
+    ...(fileSHA256 ? { fileSHA256: fileSHA256.toLowerCase() } : {}),
+    lastUpdateTimestamp: FieldValue.serverTimestamp(),
+  });
+}
+
 // Dual-read: KMS-wrapped `encryptedKey` (AAD = txHash) vs legacy plaintext `key`.
 // Gate unwrap on isKMSEnabled() — a passthrough unwrapKey returns ciphertext
 // verbatim, so a KMS-written doc read without KMS yields '' not leaked ciphertext.

--- a/src/util/api/likernft/book/cache.ts
+++ b/src/util/api/likernft/book/cache.ts
@@ -1,4 +1,5 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
+import type { Readable } from 'stream';
 import { pipeline } from 'stream/promises';
 import type { File } from '@google-cloud/storage';
 
@@ -23,6 +24,10 @@ const IPFS_GATEWAYS = ['https://ipfs.io/ipfs/', 'https://w3s.link/ipfs/', 'https
 // concurrent downloads — pre-warming is best-effort and ebook-cors still
 // serves any uncached file on demand.
 const MAX_CACHE_FILES_PER_CLASS = 10;
+
+// Ceiling on a single cached file; axios defaults maxContentLength to unlimited,
+// so without this a gateway could stream any amount into the bucket.
+const MAX_CACHE_FILE_BYTES = 1024 * 1024 * 1024;
 
 function getCacheFilePath(classId: string, url: string) {
   // Must match ebook-cors nft/cache.js getCacheFilePath() exactly.
@@ -112,12 +117,16 @@ async function isAlreadyCached(fileRef: File): Promise<boolean> {
 
 async function fetchStreamWithFallback(url: string, fallbackURLs: string[]) {
   try {
-    return await axios.get(url, {
+    return await axios.get<Readable>(url, {
       responseType: 'stream',
       timeout: 60000,
+      maxContentLength: MAX_CACHE_FILE_BYTES,
       headers: { accept: 'application/pdf, application/epub+zip' },
     });
   } catch (err) {
+    // A stream response body is left open on a non-2xx; drop it or the socket
+    // is held until the gateway times out.
+    (err as AxiosError<Readable>).response?.data?.destroy?.();
     if (fallbackURLs.length > 0) {
       return fetchStreamWithFallback(fallbackURLs[0], fallbackURLs.slice(1));
     }
@@ -133,7 +142,14 @@ async function cacheBookFile(classId: string, targetURI: string) {
 
   const { data, headers } = await fetchStreamWithFallback(url, getFallbackURLs(url));
   const contentType = String(headers['content-type'] || '');
-  assertSupportedContentType(contentType);
+  try {
+    assertSupportedContentType(contentType);
+  } catch (err) {
+    // Nothing will consume the response, so release the socket rather than
+    // leaving it open until the gateway or the timeout closes it.
+    data.destroy();
+    throw err;
+  }
 
   // Stream straight to GCS (the raw, still-encrypted bytes — ebook-cors caches
   // before decryption) so large ebooks never get fully buffered in memory.

--- a/src/util/api/likernft/book/cache.ts
+++ b/src/util/api/likernft/book/cache.ts
@@ -1,9 +1,8 @@
-import axios, { AxiosError } from 'axios';
-import type { Readable } from 'stream';
 import { pipeline } from 'stream/promises';
 import type { File } from '@google-cloud/storage';
 
-import { ARWEAVE_GATEWAY, API_HOSTNAME } from '../../../../constant';
+import { ARWEAVE_GATEWAY, ARWEAVE_GATEWAYS, API_HOSTNAME } from '../../../../constant';
+import { fetchStreamWithFallback } from '../../../fetchStream';
 import { bookCacheBucket } from '../../../gcloudStorage';
 import { getArweaveTxInfo, resolveArweaveTxKey } from '../../arweave/tx';
 import type { NFTClassData } from './index';
@@ -15,8 +14,8 @@ const PERMANENT_CACHE_TIME_IN_S = 31536000;
 
 const LIKECOIN_API_LINK_PREFIX = `https://${API_HOSTNAME}/arweave/v2/link/`;
 
-// Arweave / IPFS gateway fallbacks, same ordering as ebook-cors.
-const ARWEAVE_GATEWAYS = ['https://arweave.net/', 'https://gateway.irys.xyz/'];
+// IPFS gateway fallbacks, same ordering as ebook-cors. The Arweave set is
+// shared with the protected-content ingest; only membership matters here.
 const IPFS_GATEWAYS = ['https://ipfs.io/ipfs/', 'https://w3s.link/ipfs/', 'https://gateway.irys.xyz/ipfs/'];
 
 // A real book class points at a handful of files (e.g. epub + pdf). Cap the
@@ -115,45 +114,32 @@ async function isAlreadyCached(fileRef: File): Promise<boolean> {
   }
 }
 
-async function fetchStreamWithFallback(url: string, fallbackURLs: string[]) {
-  try {
-    return await axios.get<Readable>(url, {
-      responseType: 'stream',
-      timeout: 60000,
-      maxContentLength: MAX_CACHE_FILE_BYTES,
-      headers: { accept: 'application/pdf, application/epub+zip' },
-    });
-  } catch (err) {
-    // A stream response body is left open on a non-2xx; drop it or the socket
-    // is held until the gateway times out.
-    (err as AxiosError<Readable>).response?.data?.destroy?.();
-    if (fallbackURLs.length > 0) {
-      return fetchStreamWithFallback(fallbackURLs[0], fallbackURLs.slice(1));
-    }
-    throw err;
-  }
-}
-
 async function cacheBookFile(classId: string, targetURI: string) {
   const url = await resolveBookFileCacheURL(targetURI);
   if (!url) return;
   const fileRef = bookCacheBucket.file(getCacheFilePath(classId, url));
   if (await isAlreadyCached(fileRef)) return;
 
-  const { data, headers } = await fetchStreamWithFallback(url, getFallbackURLs(url));
-  const contentType = String(headers['content-type'] || '');
+  const { stream, contentType } = await fetchStreamWithFallback(
+    [url, ...getFallbackURLs(url)],
+    {
+      timeout: 60000,
+      maxContentLength: MAX_CACHE_FILE_BYTES,
+      headers: { accept: 'application/pdf, application/epub+zip' },
+    },
+  );
   try {
     assertSupportedContentType(contentType);
   } catch (err) {
     // Nothing will consume the response, so release the socket rather than
     // leaving it open until the gateway or the timeout closes it.
-    data.destroy();
+    stream.destroy();
     throw err;
   }
 
   // Stream straight to GCS (the raw, still-encrypted bytes — ebook-cors caches
   // before decryption) so large ebooks never get fully buffered in memory.
-  await pipeline(data, fileRef.createWriteStream({
+  await pipeline(stream, fileRef.createWriteStream({
     metadata: {
       contentType,
       cacheControl: `public, max-age=${PERMANENT_CACHE_TIME_IN_S}`,

--- a/src/util/fetchStream.ts
+++ b/src/util/fetchStream.ts
@@ -1,0 +1,41 @@
+import axios, { AxiosError } from 'axios';
+import type { Readable } from 'stream';
+
+/**
+ * GET the first URL that responds, as a stream. Used to fetch the same content
+ * addressed object through a list of interchangeable gateways (Arweave, IPFS).
+ */
+// eslint-disable-next-line import/prefer-default-export
+export async function fetchStreamWithFallback(urls: string[], {
+  timeout,
+  maxContentLength,
+  headers,
+}: {
+  timeout: number;
+  maxContentLength: number;
+  headers?: Record<string, string>;
+}): Promise<{ stream: Readable; contentType: string }> {
+  let lastError: unknown = new Error('NO_GATEWAY_URL');
+  for (const url of urls) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const res = await axios.get<Readable>(url, {
+        responseType: 'stream',
+        timeout,
+        maxContentLength,
+        ...(headers ? { headers } : {}),
+      });
+      const contentType = res.headers['content-type'];
+      return {
+        stream: res.data,
+        contentType: typeof contentType === 'string' ? contentType : '',
+      };
+    } catch (error) {
+      // A stream response body is left open on a non-2xx; drop it or the socket
+      // is held until the gateway times out.
+      (error as AxiosError<Readable>).response?.data?.destroy?.();
+      lastError = error;
+    }
+  }
+  throw lastError;
+}

--- a/src/util/gcloudStorage.ts
+++ b/src/util/gcloudStorage.ts
@@ -23,7 +23,7 @@ export function getProtectedContentUri(contentBucketPath?: string): string {
 // protected bucket configured must still import this module.
 let ebookProtectedBucket: Bucket | undefined;
 export function getEbookProtectedBucket(): Bucket {
-  if (!EBOOK_PROTECTED_BUCKET) throw new Error('EBOOK_PROTECTED_BUCKET_NOT_CONFIGURED');
+  if (!isEbookProtectedBucketEnabled()) throw new Error('EBOOK_PROTECTED_BUCKET_NOT_CONFIGURED');
   if (!ebookProtectedBucket) {
     ebookProtectedBucket = storage.bucket(EBOOK_PROTECTED_BUCKET);
   }

--- a/src/util/gcloudStorage.ts
+++ b/src/util/gcloudStorage.ts
@@ -12,6 +12,13 @@ export function isEbookProtectedBucketEnabled(): boolean {
   return !!EBOOK_PROTECTED_BUCKET;
 }
 
+// gs:// URI of an ingested protected file, for trusted readers (ebook-cors)
+// to fetch plaintext directly; '' when not ingested or bucket unconfigured.
+export function getProtectedContentUri(contentBucketPath?: string): string {
+  if (!isEbookProtectedBucketEnabled() || !contentBucketPath) return '';
+  return `gs://${EBOOK_PROTECTED_BUCKET}/${contentBucketPath}`;
+}
+
 // Lazy accessor — storage.bucket('') throws, and dev/test runs without the
 // protected bucket configured must still import this module.
 let ebookProtectedBucket: Bucket | undefined;

--- a/src/util/gcloudStorage.ts
+++ b/src/util/gcloudStorage.ts
@@ -1,9 +1,26 @@
 import { Storage } from '@google-cloud/storage';
+import type { Bucket } from '@google-cloud/storage';
 import { CACHE_BUCKET } from '../constant';
+import { EBOOK_PROTECTED_BUCKET } from '../../config/config';
 
 import serviceAccount from '../../config/serviceAccountKey.json';
 
 export const storage = new Storage({ credentials: serviceAccount });
 export const bookCacheBucket = storage.bucket(CACHE_BUCKET);
+
+export function isEbookProtectedBucketEnabled(): boolean {
+  return !!EBOOK_PROTECTED_BUCKET;
+}
+
+// Lazy accessor — storage.bucket('') throws, and dev/test runs without the
+// protected bucket configured must still import this module.
+let ebookProtectedBucket: Bucket | undefined;
+export function getEbookProtectedBucket(): Bucket {
+  if (!EBOOK_PROTECTED_BUCKET) throw new Error('EBOOK_PROTECTED_BUCKET_NOT_CONFIGURED');
+  if (!ebookProtectedBucket) {
+    ebookProtectedBucket = storage.bucket(EBOOK_PROTECTED_BUCKET);
+  }
+  return ebookProtectedBucket;
+}
 
 export default storage;

--- a/test/api/arweave-link.test.ts
+++ b/test/api/arweave-link.test.ts
@@ -1,0 +1,54 @@
+import {
+  describe, it, expect, beforeEach,
+} from 'vitest';
+import axiosist from './axiosist';
+import { iscnArweaveTxCollection } from '../../src/util/firebase';
+
+const TX_HASH = '0xarweavelinktest';
+const ARWEAVE_ID = 'test-arweave-id';
+const CONTENT_KEY = Buffer.alloc(32, 1).toString('base64');
+
+describe('Arweave link API', () => {
+  beforeEach(async () => {
+    await iscnArweaveTxCollection.doc(TX_HASH).set({
+      arweaveId: ARWEAVE_ID,
+      status: 'complete',
+      isRequireAuth: false,
+      key: CONTENT_KEY,
+    });
+  });
+
+  it('returns key and gateway link for a registered tx', async () => {
+    const res = await axiosist.get(`/api/arweave/v2/link/${TX_HASH}`)
+      .catch((err) => (err as any).response);
+
+    expect(res.status).toBe(200);
+    expect(res.data.arweaveId).toBe(ARWEAVE_ID);
+    expect(res.data.txHash).toBe(TX_HASH);
+    expect(res.data.key).toBe(CONTENT_KEY);
+    expect(res.data.link).toContain(ARWEAVE_ID);
+    expect(res.data.link).toContain(`key=${encodeURIComponent(CONTENT_KEY)}`);
+  });
+
+  it('omits contentUri when the protected bucket is not configured', async () => {
+    // The doc records an ingested copy, but EBOOK_PROTECTED_BUCKET is unset in
+    // tests, so the response must not advertise an unreadable gs:// URI.
+    await iscnArweaveTxCollection.doc(TX_HASH).update({
+      contentBucketPath: TX_HASH,
+      contentType: 'application/epub+zip',
+    });
+    const res = await axiosist.get(`/api/arweave/v2/link/${TX_HASH}`)
+      .catch((err) => (err as any).response);
+
+    expect(res.status).toBe(200);
+    expect(res.data.contentUri).toBeUndefined();
+    expect(res.data.contentType).toBeUndefined();
+  });
+
+  it('returns 404 for an unknown tx', async () => {
+    const res = await axiosist.get('/api/arweave/v2/link/0xunknown')
+      .catch((err) => (err as any).response);
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/test/util/arweave-ingest-storage.test.ts
+++ b/test/util/arweave-ingest-storage.test.ts
@@ -1,0 +1,135 @@
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest';
+import { webcrypto, createHash } from 'crypto';
+import { Readable, PassThrough } from 'stream';
+
+const calls: string[] = [];
+const objects = new Map<string, Buffer>();
+const copyOptions = new Map<string, unknown>();
+
+function makeFile(path: string) {
+  return {
+    createWriteStream: () => {
+      const pass = new PassThrough();
+      const chunks: Buffer[] = [];
+      pass.on('data', (c) => chunks.push(Buffer.from(c)));
+      pass.on('end', () => {
+        objects.set(path, Buffer.concat(chunks));
+        calls.push(`write:${path}`);
+      });
+      return pass;
+    },
+    copy: async (dest: { name: string }, options: unknown) => {
+      calls.push(`copy:${path}->${dest.name}`);
+      copyOptions.set(dest.name, options);
+      objects.set(dest.name, objects.get(path) as Buffer);
+    },
+    delete: async () => {
+      calls.push(`delete:${path}`);
+      objects.delete(path);
+    },
+    name: path,
+  };
+}
+
+vi.mock('../../src/util/gcloudStorage', () => ({
+  isEbookProtectedBucketEnabled: () => true,
+  getEbookProtectedBucket: () => ({ file: (p: string) => makeFile(p) }),
+}));
+
+vi.mock('../../src/util/api/arweave/tx', () => ({
+  markArweaveTxIngested: async (...args: unknown[]) => {
+    calls.push(`mark:${JSON.stringify(args[1])}`);
+  },
+}));
+
+// Override only `get` — ingest.ts also imports the named AxiosError export.
+const axiosGet = vi.fn();
+vi.mock('axios', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('axios')>();
+  return { ...actual, default: { ...actual.default, get: (...a: unknown[]) => axiosGet(...a) } };
+});
+
+const { ingestProtectedContent } = await import('../../src/util/api/arweave/ingest');
+
+const PLAINTEXT = Buffer.from(Array.from({ length: 50000 }, (_, i) => i % 256));
+
+async function encrypted() {
+  const cryptoKey = await webcrypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt']);
+  const iv = webcrypto.getRandomValues(new Uint8Array(12));
+  const enc = await webcrypto.subtle.encrypt({ name: 'AES-GCM', iv }, cryptoKey, PLAINTEXT);
+  const raw = await webcrypto.subtle.exportKey('raw', cryptoKey);
+  return {
+    keyBase64: Buffer.from(raw).toString('base64'),
+    combined: Buffer.concat([Buffer.from(iv), Buffer.from(enc)]),
+  };
+}
+
+describe('ingestProtectedContent (staging → verify → promote)', () => {
+  beforeEach(() => {
+    calls.length = 0;
+    objects.clear();
+    copyOptions.clear();
+  });
+
+  it('stages, verifies, promotes, and cleans up', async () => {
+    const { keyBase64, combined } = await encrypted();
+    const sha = createHash('sha256').update(PLAINTEXT).digest('hex');
+    axiosGet.mockResolvedValue({
+      data: Readable.from([combined], { objectMode: false }),
+      headers: { 'content-type': 'application/pdf' },
+    });
+
+    const result = await ingestProtectedContent('txhash1', {
+      arweaveId: 'ar1', key: keyBase64, ipfsHash: 'ipfs1', fileSHA256: sha,
+    });
+
+    expect(result).toEqual({ contentBucketPath: 'txhash1', fileSHA256: sha });
+    expect(calls).toEqual([
+      'write:staging/txhash1',
+      'copy:staging/txhash1->txhash1',
+      `mark:${JSON.stringify({ contentBucketPath: 'txhash1', contentType: 'application/pdf' })}`,
+      'delete:staging/txhash1',
+    ]);
+    expect((objects.get('txhash1') as Buffer).equals(PLAINTEXT)).toBe(true);
+    // copy() nests custom metadata differently from createWriteStream() — pin it.
+    expect(copyOptions.get('txhash1')).toEqual({
+      contentType: 'application/pdf',
+      metadata: { arweaveId: 'ar1', ipfsHash: 'ipfs1', fileSHA256: sha },
+    });
+  });
+
+  it('leaves nothing at the canonical path when the hash anchor mismatches', async () => {
+    const { keyBase64, combined } = await encrypted();
+    axiosGet.mockResolvedValue({
+      data: Readable.from([combined], { objectMode: false }),
+      headers: { 'content-type': 'application/pdf' },
+    });
+
+    await expect(ingestProtectedContent('txhash2', {
+      arweaveId: 'ar1', key: keyBase64, fileSHA256: 'deadbeef',
+    })).rejects.toThrow('PLAINTEXT_HASH_MISMATCH');
+
+    expect(objects.has('txhash2')).toBe(false);
+    expect(calls).toEqual(['write:staging/txhash2', 'delete:staging/txhash2']);
+  });
+
+  it('leaves nothing at the canonical path when the GCM tag is tampered', async () => {
+    const { keyBase64, combined } = await encrypted();
+    const i = combined.length - 30;
+    combined[i] = combined[i] === 0 ? 1 : 0;
+    axiosGet.mockResolvedValue({
+      data: Readable.from([combined], { objectMode: false }),
+      headers: { 'content-type': 'application/pdf' },
+    });
+
+    await expect(ingestProtectedContent('txhash3', {
+      arweaveId: 'ar1', key: keyBase64,
+    })).rejects.toThrow();
+
+    expect(objects.has('txhash3')).toBe(false);
+    expect(calls).toContain('delete:staging/txhash3');
+    expect(calls).not.toContain('copy:staging/txhash3->txhash3');
+  });
+});

--- a/test/util/arweave-ingest.test.ts
+++ b/test/util/arweave-ingest.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { webcrypto } from 'crypto';
+import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
 
-import { decryptContentBuffer, ingestProtectedContent } from '../../src/util/api/arweave/ingest';
+import { createGcmDecryptTransform, ingestProtectedContent } from '../../src/util/api/arweave/ingest';
 
 // Reproduce publish-3ook-com encryptDataWithAES (arweavekit layout):
 // 12-byte IV ‖ WebCrypto AES-256-GCM output (ciphertext ‖ 16-byte tag).
@@ -20,29 +22,63 @@ async function encryptLikeClient(plaintext: Buffer) {
   };
 }
 
-describe('decryptContentBuffer', () => {
+function split(buffer: Buffer, chunkSize: number): Buffer[] {
+  const chunks: Buffer[] = [];
+  for (let i = 0; i < buffer.length; i += chunkSize) {
+    chunks.push(buffer.subarray(i, i + chunkSize));
+  }
+  return chunks;
+}
+
+async function collect(source: Buffer[], transform: NodeJS.ReadWriteStream): Promise<Buffer> {
+  const output: Buffer[] = [];
+  await pipeline(
+    Readable.from(source, { objectMode: false }),
+    transform,
+    async (result) => {
+      for await (const chunk of result) output.push(Buffer.from(chunk as Buffer));
+    },
+  );
+  return Buffer.concat(output);
+}
+
+describe('createGcmDecryptTransform', () => {
   it('decrypts the client-side AES-256-GCM format', async () => {
     const plaintext = Buffer.from('protected ebook bytes');
     const { keyBase64, combined } = await encryptLikeClient(plaintext);
-    const decrypted = decryptContentBuffer(combined, keyBase64);
+    const decrypted = await collect([combined], createGcmDecryptTransform(keyBase64));
+    expect(decrypted.equals(plaintext)).toBe(true);
+  });
+
+  // The IV heads the stream and the auth tag trails it, so chunk boundaries that
+  // land inside either one are the failure mode this transform exists to handle.
+  it.each([1, 7, 12, 13, 16, 17, 4096])('decrypts in %i-byte chunks', async (chunkSize) => {
+    const plaintext = Buffer.from(Array.from({ length: 20000 }, (_, i) => i % 256));
+    const { keyBase64, combined } = await encryptLikeClient(plaintext);
+    const decrypted = await collect(
+      split(combined, chunkSize),
+      createGcmDecryptTransform(keyBase64),
+    );
     expect(decrypted.equals(plaintext)).toBe(true);
   });
 
   it('rejects tampered ciphertext (GCM auth)', async () => {
     const { keyBase64, combined } = await encryptLikeClient(Buffer.from('content'));
     combined[combined.length - 20] = combined[combined.length - 20] === 0 ? 1 : 0;
-    expect(() => decryptContentBuffer(combined, keyBase64)).toThrow();
+    await expect(collect(split(combined, 8), createGcmDecryptTransform(keyBase64)))
+      .rejects.toThrow();
   });
 
   it('rejects a wrong-length key', () => {
-    const combined = Buffer.alloc(40);
-    expect(() => decryptContentBuffer(combined, Buffer.alloc(16).toString('base64')))
+    expect(() => createGcmDecryptTransform(Buffer.alloc(16).toString('base64')))
       .toThrow('INVALID_CONTENT_KEY');
   });
 
-  it('rejects payloads shorter than IV + tag', () => {
-    expect(() => decryptContentBuffer(Buffer.alloc(10), Buffer.alloc(32).toString('base64')))
-      .toThrow('INVALID_ENCRYPTED_PAYLOAD');
+  // 10 bytes never yields an IV; 20 bytes yields one but leaves a short tail.
+  it.each([10, 20])('rejects a %i-byte payload (shorter than IV + tag)', async (size) => {
+    const key = Buffer.alloc(32).toString('base64');
+    await expect(collect([Buffer.alloc(size)], createGcmDecryptTransform(key)))
+      .rejects.toThrow('INVALID_ENCRYPTED_PAYLOAD');
   });
 });
 

--- a/test/util/arweave-ingest.test.ts
+++ b/test/util/arweave-ingest.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { webcrypto } from 'crypto';
+
+import { decryptContentBuffer, ingestProtectedContent } from '../../src/util/api/arweave/ingest';
+
+// Reproduce publish-3ook-com encryptDataWithAES (arweavekit layout):
+// 12-byte IV ‖ WebCrypto AES-256-GCM output (ciphertext ‖ 16-byte tag).
+async function encryptLikeClient(plaintext: Buffer) {
+  const cryptoKey = await webcrypto.subtle.generateKey(
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt', 'decrypt'],
+  );
+  const iv = webcrypto.getRandomValues(new Uint8Array(12));
+  const encrypted = await webcrypto.subtle.encrypt({ name: 'AES-GCM', iv }, cryptoKey, plaintext);
+  const rawKey = await webcrypto.subtle.exportKey('raw', cryptoKey);
+  return {
+    keyBase64: Buffer.from(rawKey).toString('base64'),
+    combined: Buffer.concat([Buffer.from(iv), Buffer.from(encrypted)]),
+  };
+}
+
+describe('decryptContentBuffer', () => {
+  it('decrypts the client-side AES-256-GCM format', async () => {
+    const plaintext = Buffer.from('protected ebook bytes');
+    const { keyBase64, combined } = await encryptLikeClient(plaintext);
+    const decrypted = decryptContentBuffer(combined, keyBase64);
+    expect(decrypted.equals(plaintext)).toBe(true);
+  });
+
+  it('rejects tampered ciphertext (GCM auth)', async () => {
+    const { keyBase64, combined } = await encryptLikeClient(Buffer.from('content'));
+    combined[combined.length - 20] = combined[combined.length - 20] === 0 ? 1 : 0;
+    expect(() => decryptContentBuffer(combined, keyBase64)).toThrow();
+  });
+
+  it('rejects a wrong-length key', () => {
+    const combined = Buffer.alloc(40);
+    expect(() => decryptContentBuffer(combined, Buffer.alloc(16).toString('base64')))
+      .toThrow('INVALID_CONTENT_KEY');
+  });
+
+  it('rejects payloads shorter than IV + tag', () => {
+    expect(() => decryptContentBuffer(Buffer.alloc(10), Buffer.alloc(32).toString('base64')))
+      .toThrow('INVALID_ENCRYPTED_PAYLOAD');
+  });
+});
+
+describe('ingestProtectedContent', () => {
+  it('is a no-op when the protected bucket is not configured', async () => {
+    const result = await ingestProtectedContent('tx-hash', {
+      arweaveId: 'ar-id',
+      key: Buffer.alloc(32).toString('base64'),
+    });
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
Server-side ingest at register (ADR 0001 Phase 3): fetch the ciphertext from Arweave, decrypt with the content key, verify the plaintext SHA-256 against the provenance anchor, and store plaintext-at-rest under a key-free path. Best-effort and disabled until EBOOK_PROTECTED_BUCKET is configured; Arweave remains the canonical serving copy.