### PR TITLE
[TAS-6137] ✨ Rank book listings by lifetime reading time

### DIFF
--- a/src/routes/likernft/book/store.ts
+++ b/src/routes/likernft/book/store.ts
@@ -7,6 +7,7 @@ import {
   getNftBookInfo,
   listLatestNFTBookInfo,
   listFilteredNFTBookInfo,
+  listPopularNFTBookInfo,
   listNftBookInfoByModeratorWallet,
   newNftBookInfo,
   updateNftBookInfo,
@@ -43,6 +44,9 @@ import {
   BookCatalogStripeResponseSchema,
   BookCatalogGoogleResponseSchema,
   BookListResponseSchema,
+  BookPopularListQuerySchema,
+  type BookPopularListQuery,
+  BookPopularListResponseSchema,
   BookListModeratedResponseSchema,
   BookSearchResponseSchema,
   BookInfoResponseSchema,
@@ -323,6 +327,41 @@ function createDerivedListHandler(filter: 'free' | 'drm-free') {
 
 router.get('/list/free', jwtOptionalAuth('read:nftbook'), validateQuery(BookListPaginationQuerySchema), createDerivedListHandler('free'));
 router.get('/list/drm-free', jwtOptionalAuth('read:nftbook'), validateQuery(BookListPaginationQuerySchema), createDerivedListHandler('drm-free'));
+
+// Books ranked by lifetime reading + TTS time; `library=1` scopes it to Plus-reading titles.
+// Separate from createDerivedListHandler because it paginates by class-id cursor rather
+// than by timestamp key, so its `nextKey` is a string.
+router.get('/list/popular', jwtOptionalAuth('read:nftbook'), validateQuery(BookPopularListQuerySchema), async (req: QueryRequest<BookPopularListQuery>, res, next) => {
+  try {
+    const { library, limit, key } = req.query;
+    const bookInfos = await listPopularNFTBookInfo({
+      isPlusReadingEnabled: library === '1' || undefined,
+      limit,
+      key,
+    });
+    const list = bookInfos.flatMap((b: NFTBookListingInfo) => {
+      const {
+        isHidden, redirectClassId, moderatorWallets = [], ownerWallet,
+      } = b;
+      if (redirectClassId) return [];
+      const isAuthorized = checkIsAuthorized({ ownerWallet, moderatorWallets }, req);
+      if (!isAuthorized && isHidden) return [];
+      return [filterNFTBookListingInfo(b, isAuthorized)];
+    });
+    // Cursor off the unfiltered Firestore result: filtered-out docs (hidden / redirected)
+    // must not end pagination early, and the next page resumes from the last doc read.
+    const lastBookInfo = bookInfos[bookInfos.length - 1];
+    const nextKey = bookInfos.length < limit ? null : (lastBookInfo?.id ?? null);
+    if (req.user) {
+      res.set('Cache-Control', 'no-store');
+    } else {
+      res.set('Cache-Control', `public, max-age=60, s-maxage=60, stale-while-revalidate=${ONE_DAY_IN_S}, stale-if-error=${ONE_DAY_IN_S}`);
+    }
+    sendValidatedJSON(res, BookPopularListResponseSchema, { list, nextKey });
+  } catch (err) {
+    next(err);
+  }
+});
 
 router.get('/list/moderated', jwtAuth('read:nftbook'), async (req, res, next) => {
   try {

--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -178,6 +178,9 @@ export interface NFTBookListingInfo {
   approvalStatus?: string;
   plusPromoEnabled?: boolean;
   isPlusReadingEnabled?: boolean;
+  // Lifetime recorded reading + TTS time, denormalized from the `plusUsage`
+  // rollups so listings can order by it. See recordPlusReadingUsage.
+  plusReadingTotalMs?: number;
   successUrl?: string;
   cancelUrl?: string;
 }

--- a/src/util/api/likernft/book/index.ts
+++ b/src/util/api/likernft/book/index.ts
@@ -326,6 +326,9 @@ export async function newNftBookInfo(
     isApprovedForIndexing: true,
     isApprovedForAds: (isAdultOnly ? false : isTrustedPublisher),
     approvalStatus: isTrustedPublisher ? 'approved' : 'pending',
+    // Seed the popularity sort key: Firestore drops documents missing an `orderBy`
+    // field, so an unseeded book would never surface in the popular listing at all.
+    plusReadingTotalMs: 0,
   };
   const minPriceInDecimal = getMinListedPriceInDecimal(newPrices);
   if (minPriceInDecimal !== undefined) payload.minPriceInDecimal = minPriceInDecimal;
@@ -617,6 +620,43 @@ export async function listFilteredNFTBookInfo({
   const tsNumber = before ?? key;
   if (tsNumber !== undefined) {
     snapshot = snapshot.startAfter(Timestamp.fromMillis(tsNumber));
+  }
+  if (limit !== undefined) {
+    snapshot = snapshot.limit(limit);
+  }
+  const query = await snapshot.get();
+  return query.docs.map((doc) => {
+    const docData = doc.data();
+    return { id: doc.id, ...docData };
+  });
+}
+
+/**
+ * Books ranked by lifetime recorded reading + TTS time (`plusReadingTotalMs`, maintained by
+ * `recordPlusReadingUsage`), then newest-first so the large unread tail — every book is
+ * zero-seeded — still browses in a sensible, stable order.
+ */
+export async function listPopularNFTBookInfo({
+  isPlusReadingEnabled,
+  limit,
+  key,
+}: {
+  isPlusReadingEnabled?: boolean;
+  limit?: number;
+  key?: string;
+} = {}) {
+  let snapshot = likeNFTBookCollection
+    .orderBy('plusReadingTotalMs', 'desc')
+    .orderBy('timestamp', 'desc');
+  if (isPlusReadingEnabled !== undefined) {
+    snapshot = snapshot.where('isPlusReadingEnabled', '==', isPlusReadingEnabled);
+  }
+  // A document cursor, not a value cursor: it resumes exactly, including the implicit
+  // `__name__` tiebreak, so the huge block of books tied at 0 ms can page without gaps.
+  if (key) {
+    const cursorDoc = await likeNFTBookCollection.doc(key.toLowerCase()).get();
+    if (!cursorDoc.exists) throw new ValidationError('INVALID_KEY', 400);
+    snapshot = snapshot.startAfter(cursorDoc);
   }
   if (limit !== undefined) {
     snapshot = snapshot.limit(limit);

--- a/src/util/api/likernft/book/schemas.ts
+++ b/src/util/api/likernft/book/schemas.ts
@@ -197,6 +197,17 @@ export const BookListQuerySchema = BookListPaginationQuerySchema.extend({
 });
 export type BookListQuery = z.infer<typeof BookListQuerySchema>;
 
+// Scopes and paginates like its `/list*` siblings, except the cursor is the previous page's
+// last class id rather than a timestamp — ranking ties can't be resumed from a value alone.
+export const BookPopularListQuerySchema = BookListPaginationQuerySchema
+  .omit({ before: true, key: true })
+  .extend({
+    // Cursor is a class id (EVM `0x…` or legacy Cosmos `likenft1…`); restrict to an
+    // alphanumeric charset so a stray `/` can't make Firestore's `.doc()` throw a 500.
+    key: z.string().regex(/^[a-zA-Z0-9]+$/).optional(),
+  });
+export type BookPopularListQuery = z.infer<typeof BookPopularListQuerySchema>;
+
 // Shared by the Meta, OpenAI, and Stripe catalog routes — output is selected via `format`.
 export const BookCatalogQuerySchema = z.object({
   format: z.string().optional(),
@@ -453,6 +464,10 @@ export const BookSearchResponseSchema = z.object({
 export const BookListResponseSchema = z.object({
   list: z.array(NFTBookListingInfoFilteredSchema),
   nextKey: z.number().nullable(),
+});
+
+export const BookPopularListResponseSchema = BookListResponseSchema.extend({
+  nextKey: z.string().nullable(),
 });
 
 export const BookListModeratedResponseSchema = z.object({

--- a/src/util/api/plus/revenueShare.ts
+++ b/src/util/api/plus/revenueShare.ts
@@ -177,6 +177,15 @@ export async function recordPlusReadingUsage({
   if (libraryReadingTimeMs > 0 || libraryTtsTimeMs > 0) {
     batch.set(readerDocRef, usageIncrement, { merge: true });
   }
+  // Denormalized onto the book doc because Firestore cannot sort on a subcollection sum.
+  // Counts non-library time too, so free books (which accrue none) can still rank, and so
+  // the public sort key isn't the payout basis settlement pays on.
+  batch.set(bookDocRef, {
+    plusReadingTotalMs: FieldValue.increment(
+      libraryReadingTimeMs + libraryTtsTimeMs
+      + statsNonLibraryReadingTimeMs + statsNonLibraryTtsTimeMs,
+    ),
+  }, { merge: true });
 
   try {
     await batch.commit();

--- a/test/api/book-list-popular.test.ts
+++ b/test/api/book-list-popular.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import axiosist from './axiosist';
+import mockEVMAddress from './address';
+import { likeNFTBookCollection } from '../../src/util/firebase';
+
+const PATH = '/api/likernft/book/store/list/popular';
+const OWNER = mockEVMAddress(0x33);
+
+// The stub firestore no-ops orderBy/limit/startAfter, so rank order and cursor paging are
+// not exercised here — those depend on the composite index and need a real Firestore.
+// What is exercised: the library scope flag, hidden/redirect exclusion, the null-cursor
+// boundary, and cursor validation.
+const seedBook = (classId: string, data: Record<string, unknown> = {}) => likeNFTBookCollection
+  .doc(classId)
+  .set({
+    classId, ownerWallet: OWNER, isPlusReadingEnabled: true, plusReadingTotalMs: 0, ...data,
+  } as any);
+
+const get = (query = '') => axiosist
+  .get(`${PATH}${query}`)
+  .catch((err) => (err as any).response);
+
+describe('GET /likernft/book/store/list/popular', () => {
+  it('scopes to Plus-reading books with library=1', async () => {
+    const inLibrary = mockEVMAddress(0xa1);
+    const notInLibrary = mockEVMAddress(0xa2);
+    await seedBook(inLibrary, { plusReadingTotalMs: 5000 });
+    await seedBook(notInLibrary, { isPlusReadingEnabled: false });
+
+    const res = await get('?library=1');
+    expect(res.status).toBe(200);
+    const classIds = res.data.list.map((b: any) => b.classId);
+    expect(classIds).toContain(inLibrary);
+    expect(classIds).not.toContain(notInLibrary);
+  });
+
+  it('lists the whole catalogue without library=1', async () => {
+    const inLibrary = mockEVMAddress(0xb1);
+    const notInLibrary = mockEVMAddress(0xb2);
+    await seedBook(inLibrary);
+    await seedBook(notInLibrary, { isPlusReadingEnabled: false });
+
+    const res = await get();
+    expect(res.status).toBe(200);
+    const classIds = res.data.list.map((b: any) => b.classId);
+    expect(classIds).toContain(inLibrary);
+    expect(classIds).toContain(notInLibrary);
+  });
+
+  it('does not leak the popularity counter to clients', async () => {
+    const classId = mockEVMAddress(0xa3);
+    await seedBook(classId, { plusReadingTotalMs: 123456 });
+
+    const res = await get();
+    const book = res.data.list.find((b: any) => b.classId === classId);
+    expect(book).toBeDefined();
+    // Rank order is public; the minutes behind it (the payout basis) are not.
+    expect(book.plusReadingTotalMs).toBeUndefined();
+  });
+
+  it('excludes hidden and redirected books from the list', async () => {
+    const visible = mockEVMAddress(0xa4);
+    const hidden = mockEVMAddress(0xa5);
+    const redirected = mockEVMAddress(0xa6);
+    await seedBook(visible);
+    await seedBook(hidden, { isHidden: true });
+    await seedBook(redirected, { redirectClassId: visible });
+
+    const res = await get();
+    const classIds = res.data.list.map((b: any) => b.classId);
+    expect(classIds).toContain(visible);
+    expect(classIds).not.toContain(hidden);
+    expect(classIds).not.toContain(redirected);
+  });
+
+  it('returns a null cursor when the page is not full', async () => {
+    await seedBook(mockEVMAddress(0xa7));
+
+    const res = await get('?limit=100');
+    expect(res.status).toBe(200);
+    expect(res.data.nextKey).toBeNull();
+  });
+
+  it('rejects a cursor that names no book', async () => {
+    const res = await get(`?key=${mockEVMAddress(0xbb)}`);
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts a mixed-case class id as the cursor', async () => {
+    // Books are keyed by lowercase class id; an EIP-55 checksummed cursor must still resolve.
+    const mixedCaseClassId = '0xAbCdEf8888888888888888888888888888888888';
+    await seedBook(mixedCaseClassId.toLowerCase());
+
+    const res = await get(`?key=${mixedCaseClassId}`);
+    expect(res.status).toBe(200);
+  });
+});

--- a/test/api/plus-reading-usage.test.ts
+++ b/test/api/plus-reading-usage.test.ts
@@ -122,6 +122,51 @@ describe('POST /plus/reading/usage', () => {
     // No rev-share-eligible time → no per-reader audit doc.
     const readers = await dayDocRef.collection('readers').get();
     expect(readers.size).toBe(0);
+
+    // ...but the read still counts toward popularity, or free books could never rank.
+    const book = (await likeNFTBookCollection.doc(classId).get()).data() as any;
+    expect(book.plusReadingTotalMs).toBe(5700);
+  });
+
+  it('sums all four duration buckets into the popularity counter on the book doc', async () => {
+    const classId = mockEVMAddress(0x66);
+    await likeNFTBookCollection.doc(classId).set({ classId, ownerWallet: OWNER } as any);
+
+    const res = await post({
+      readerWallet: READER,
+      classId,
+      readingTimeMs: 1000,
+      ttsTimeMs: 2000,
+      nonLibraryReadingTimeMs: 300,
+      nonLibraryTtsTimeMs: 700,
+      occurredAt: Date.UTC(2026, 2, 13, 8),
+    }, AUTH_HEADER);
+    expect(res.status).toBe(200);
+
+    // increment() is identity in the stub, so a single write stores the summed delta.
+    const book = (await likeNFTBookCollection.doc(classId).get()).data() as any;
+    expect(book.plusReadingTotalMs).toBe(4000);
+  });
+
+  it('does not double-count the popularity counter on a deduped retry', async () => {
+    const classId = mockEVMAddress(0x77);
+    await likeNFTBookCollection.doc(classId).set({ classId, ownerWallet: OWNER } as any);
+    const occurredAt = Date.UTC(2026, 2, 14, 8);
+    const entry = (id: string, readingTimeMs: number) => ({
+      id, readerWallet: READER, classId, readingTimeMs, ttsTimeMs: 0, occurredAt,
+    });
+    const readTotal = async () => (await likeNFTBookCollection
+      .doc(classId).get()).data()?.plusReadingTotalMs;
+
+    const first = await post(entry('pop-1', 1000), AUTH_HEADER);
+    expect(first.data.results).toEqual([{ dayId: '2026-03-14', applied: true }]);
+    expect(await readTotal()).toBe(1000);
+
+    // Same id, larger value: the receipt create() aborts the whole batch, so the counter
+    // (which lives in that batch) cannot drift — a non-deduped rewrite would show 5000.
+    const dup = await post(entry('pop-1', 5000), AUTH_HEADER);
+    expect(dup.data.results).toEqual([{ dayId: '2026-03-14', applied: false }]);
+    expect(await readTotal()).toBe(1000);
   });
 
   it('rejects usage for a class id with no book doc', async () => {


### PR DESCRIPTION
Adds GET /likernft/book/store/list/popular, ordering books by plusReadingTotalMs then newest-first, scoped to Plus-reading titles with library=1 like its /list* siblings.

recordPlusReadingUsage now denormalizes that counter onto the book doc in its existing batch, so it inherits the receipt's idempotency. Firestore cannot sort on a subcollection sum, hence the counter rather than reading the plusUsage rollups. It counts non-library time too, so free books (which accrue none) can still rank and the public sort key is not the basis settlement pays on.

newNftBookInfo seeds the field to 0: Firestore omits documents missing an orderBy field, so an unseeded book would never appear in the listing. For the same reason the cursor is a class id resolved to a document snapshot, not a value -- most of the catalogue is tied at 0.

Needs a composite index (isPlusReadingEnabled, plusReadingTotalMs desc, timestamp desc) and a one-off backfill before the route is usable.