### PR TITLE
📈 Attach fbc/fbp match keys to CompleteRegistration CAPI event

### DIFF
--- a/src/routes/users/registerLogin.ts
+++ b/src/routes/users/registerLogin.ts
@@ -170,6 +170,9 @@ router.post(
         userAgent: req.get('User-Agent'),
         clientIp: (req.headers['x-real-ip'] as string) || req.ip,
         referrer: userPayload.sourceURL,
+        fbClickId: req.body.fbClickId,
+        fbp: req.body.fbp,
+        fbc: req.body.fbc,
       });
     } catch (err) {
       publisher.publish(PUBSUB_TOPIC_MISC, req, {

--- a/src/util/api/users/schemas.ts
+++ b/src/util/api/users/schemas.ts
@@ -71,6 +71,9 @@ export const UsersRegisterBodySchema = z.object({
   utmSource: z.string().optional(),
   utmMedium: z.string().optional(),
   utmCampaign: z.string().optional(),
+  fbClickId: z.string().optional(),
+  fbp: z.string().optional(),
+  fbc: z.string().optional(),
 }).passthrough();
 
 export const UsersLoginBodySchema = z.object({


### PR DESCRIPTION
The registration pixel event only carried email/IP/UA/external_id, leaving Meta unable to match conversions back to ad clicks.