### PR TITLE
🐛 Emit Plus cancellation analytics past wallet/user guards

### DIFF
--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -1198,23 +1198,22 @@ export async function processStripeSubscriptionCancellation(
     utmContent,
     utmTerm,
   } = subscription.metadata || {};
-  if (!evmWallet && !likeWallet) {
-    // eslint-disable-next-line no-console
-    console.warn(`No evmWallet or likeWallet found in subscription: ${subscriptionId}`);
+  if (subscription.status !== 'canceled' && subscription.status !== 'unpaid') {
     return;
   }
-  const user = await getUserWithCivicLikerPropertiesByWallet(evmWallet || likeWallet);
-  if (!user) {
-    // eslint-disable-next-line no-console
-    console.warn(`No likerId found for evmWallet: ${evmWallet}, likeWallet: ${likeWallet}, subscription: ${subscriptionId}`);
-    return;
-  }
-  const likerId = user.user;
+
+  // User is optional here: wallet-less or unresolved cancellations still emit analytics below,
+  // only the Firestore/Intercom writes are skipped.
+  const user = (evmWallet || likeWallet)
+    ? await getUserWithCivicLikerPropertiesByWallet(evmWallet || likeWallet)
+    : null;
+  const likerId = user?.user;
   const isTrialEnd = subscription.trial_end && subscription.cancel_at === subscription.trial_end;
-  if (subscription.status === 'canceled' || subscription.status === 'unpaid') {
+
+  if (user) {
     const currentPeriodEnd = user.likerPlus?.currentPeriodEnd;
     if (currentPeriodEnd && currentPeriodEnd > Date.now()) {
-      await userCollection.doc(likerId).update({
+      await userCollection.doc(user.user).update({
         likerPlus: {
           ...user.likerPlus,
           currentPeriodEnd: Date.now(),
@@ -1223,51 +1222,50 @@ export async function processStripeSubscriptionCancellation(
       });
     }
 
-    await updateIntercomUserAttributes(likerId, {
+    await updateIntercomUserAttributes(user.user, {
       is_liker_plus: false,
       is_liker_plus_trial: false,
     });
-
-    const subscriptionItem = subscription.items?.data[0];
-    const period = subscriptionItem?.plan?.interval;
-    const priceId = subscriptionItem?.price?.id;
-    const cancellationExtraProperties = {
-      subscription_id: subscriptionId,
-      period,
-      price_id: priceId,
-      cancel_reason: subscription.cancellation_details?.reason,
-      cancel_feedback: subscription.cancellation_details?.feedback,
-      cancel_comment: subscription.cancellation_details?.comment?.substring(0, 500),
-      ...mapAttributionExtraProperties({
-        utmSource, utmMedium, utmCampaign, utmContent, utmTerm, from,
-      }),
-    };
-    if (isTrialEnd) {
-      await Promise.all([
-        sendIntercomEvent({
-          userId: likerId,
-          eventName: 'plus_trial_end',
-        }),
-        logServerEvents('TrialEnded', {
-          evmWallet,
-          paymentId: subscriptionId,
-          extraProperties: cancellationExtraProperties,
-        }),
-      ]);
-    } else {
-      await Promise.all([
-        sendIntercomEvent({
-          userId: likerId,
-          eventName: 'plus_subscription_end',
-        }),
-        logServerEvents('SubscriptionCancelled', {
-          evmWallet,
-          paymentId: subscriptionId,
-          extraProperties: cancellationExtraProperties,
-        }),
-      ]);
-    }
+  } else {
+    // eslint-disable-next-line no-console
+    console.warn(`No user record for evmWallet: ${evmWallet}, likeWallet: ${likeWallet}, subscription: ${subscriptionId}; emitting analytics only`);
   }
+
+  const subscriptionItem = subscription.items?.data[0];
+  const period = subscriptionItem?.plan?.interval;
+  const priceId = subscriptionItem?.price?.id;
+  // Wallet-less checkouts have no identity to attribute to; emit under a synthetic
+  // customer-scoped id so the churn is still counted, flagged as unattributed.
+  const customerId = typeof subscription.customer === 'string'
+    ? subscription.customer
+    : subscription.customer?.id;
+  const isUnattributed = !evmWallet && !likeWallet;
+  const cancellationExtraProperties = {
+    subscription_id: subscriptionId,
+    period,
+    price_id: priceId,
+    cancel_reason: subscription.cancellation_details?.reason,
+    cancel_feedback: subscription.cancellation_details?.feedback,
+    cancel_comment: subscription.cancellation_details?.comment?.substring(0, 500),
+    ...(isUnattributed ? { unattributed: true } : {}),
+    ...mapAttributionExtraProperties({
+      utmSource, utmMedium, utmCampaign, utmContent, utmTerm, from,
+    }),
+  };
+  const analyticsOptions = {
+    evmWallet,
+    likeWallet,
+    paymentId: subscriptionId,
+    posthogDistinctId: isUnattributed && customerId ? `stripe:${customerId}` : undefined,
+    extraProperties: cancellationExtraProperties,
+  };
+  await Promise.all([
+    ...(likerId ? [sendIntercomEvent({
+      userId: likerId,
+      eventName: isTrialEnd ? 'plus_trial_end' : 'plus_subscription_end',
+    })] : []),
+    logServerEvents(isTrialEnd ? 'TrialEnded' : 'SubscriptionCancelled', analyticsOptions),
+  ]);
 }
 
 export async function processStripePaymentFailure(

--- a/src/util/logServerEvents.ts
+++ b/src/util/logServerEvents.ts
@@ -21,6 +21,7 @@ export default async function logServerEvents(
     fbp?: string;
     fbc?: string;
     evmWallet?: string;
+    likeWallet?: string;
     gaClientId?: string;
     gaSessionId?: string;
     posthogDistinctId?: string;

--- a/src/util/posthog.ts
+++ b/src/util/posthog.ts
@@ -52,6 +52,7 @@ export async function shutdownPostHog(): Promise<void> {
 
 export default function logPostHogEvents(event: ServerEventName, {
   evmWallet,
+  likeWallet,
   email,
   items,
   value,
@@ -63,6 +64,7 @@ export default function logPostHogEvents(event: ServerEventName, {
   setOnce,
 }: {
   evmWallet?: string;
+  likeWallet?: string;
   email?: string;
   items?: AnalyticsItem[];
   value?: number;
@@ -77,7 +79,10 @@ export default function logPostHogEvents(event: ServerEventName, {
   if (!client) {
     return;
   }
-  if (!evmWallet) {
+  // Legacy likeWallet-only users (Cosmos-era, no evmWallet) must still be counted;
+  // callers with neither wallet may pass a synthetic posthogDistinctId (e.g. `stripe:<customer>`).
+  const distinctId = evmWallet || likeWallet || posthogDistinctId;
+  if (!distinctId) {
     return;
   }
   const posthogEvent = SERVER_EVENT_MAP[event];
@@ -88,11 +93,11 @@ export default function logPostHogEvents(event: ServerEventName, {
   }
   try {
     // $anon_distinct_id triggers PostHog's implicit person-merge; skip when equal to avoid a no-op.
-    const anonDistinctId = posthogDistinctId && posthogDistinctId !== evmWallet
+    const anonDistinctId = posthogDistinctId && posthogDistinctId !== distinctId
       ? posthogDistinctId
       : undefined;
     client.capture({
-      distinctId: evmWallet,
+      distinctId,
       event: posthogEvent,
       uuid: typeof paymentId === 'string' && paymentId
         ? derivePostHogEventUUID(posthogEvent, paymentId)


### PR DESCRIPTION
processStripeSubscriptionCancellation returned early when a wallet was missing or the user record couldn't be resolved, killing the churn event along with the Firestore write it was meant to protect. Gate only the Firestore/Intercom updates on the resolved user; always emit analytics, using a synthetic stripe:<customer> distinctId for wallet-less checkouts.

Also thread likeWallet through logServerEvents/logPostHogEvents and fall back to distinctId = evmWallet || likeWallet || posthogDistinctId, so legacy likeWallet-only (Cosmos-era) users are no longer dropped inside PostHog logging across every server-side event, not just cancellations.