### PR TITLE
🔥 Delete dead config vi.mock and correct AGENTS.md config guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,16 @@ Route handlers stay thin and delegate to the util layer.
 
 ### Configuration — `config/`
 
-Runtime config is plain `config/config.js` (CommonJS) with values pulled from environment variables. Secrets (`config/secret.js`, `config/serviceAccountKey.json`, `config/arweave-key.json`, `config/aws.json`) are gitignored. Tests `vi.mock` `../../config/config` directly in `test/setup.ts`, so adding a new config key means adding it to **both** `config/config.js` (for runtime) and `test/setup.ts` (for tests).
+Runtime config is plain `config/config.js` (CommonJS) with values pulled from environment variables. Secrets (`config/secret.js`, `config/serviceAccountKey.json`, `config/arweave-key.json`, `config/aws.json`) are gitignored.
+
+**Adding a config key: edit `config/config.js` only.** Tests read the *real* `config.js`, so a key with an env-driven default needs nothing else.
+
+Two ways to control config in tests:
+
+- **Suite-wide** — set `process.env.*` at the top of `test/setup.ts`, before any import. `config/config.js` reads env at import time, so this is the only thing that reaches the whole suite.
+- **Per-file** — `vi.mock('../../config/config', () => ({ ... }))` in an individual test file, as `test/util/kms.test.ts` and `test/middleware/alchemy-sponsorship-webhook.test.ts` do. The factory replaces the *entire* module, so only the keys you list exist — fine for a narrow unit test, not for the `test/api/` suites.
+
+The catch is path depth: `vi.mock` resolves relative to the calling file and only intercepts when it lands on the same resolved module as the source file's import. Source files two levels deep import `'../../config/config'` → `<repo>/config/config.js`, and a test at `test/<dir>/*.test.ts` is also two levels deep, so the same specifier hits the same file. A one-level-deep caller (`test/setup.ts`) resolves `'../../config/config'` *outside* the repo — it registers a mock nobody imports and fails silently. That is exactly why the old `setup.ts` config mock was dead and got deleted; don't reintroduce it there.
 
 Many keys are `FIRESTORE_*_ROOT` collection roots — they're env-driven so testnet vs. mainnet collections don't collide.
 
@@ -83,10 +92,10 @@ Many keys are `FIRESTORE_*_ROOT` collection roots — they're env-driven so test
 Vitest, single-fork pool (`pool: 'forks'`, `singleFork: true`) so tests share state safely. Test files: `test/**/*.test.ts`. The setup file `test/setup.ts` is loaded globally and:
 
 - Sets `IS_TESTNET=true`.
-- `vi.mock`s `../../config/config`, `firebase-admin`, `../src/util/firebase` (replaced with the in-memory stub at `test/stub/firebase.ts`), `@sendgrid/mail`, `@aws-sdk/client-ses`, `../src/util/cosmos/api`, `../src/util/api/likernft/likePrice`, and `../src/util/fileupload`.
+- `vi.mock`s `firebase-admin`, `../src/util/firebase` (replaced with the in-memory stub at `test/stub/firebase.ts`), `@sendgrid/mail`, `@aws-sdk/client-ses`, `../src/util/cosmos/api`, `../src/util/api/likernft/likePrice`, and `../src/util/fileupload`. It does **not** mock `config/config` — see [Configuration](#configuration--config) for why that has to happen per-file.
 - Resets the in-memory Firestore stub before every test from JSON fixtures in `test/data/` (`user.json`, `subscription.json`, `tx.json`, `mission.json`, `likernft.json`).
 
-When adding new mocks, add them in `test/setup.ts`, not in individual test files. When adding new fixtures, place them in `test/data/` and load them via `test/stub/firebase.ts`.
+When adding new mocks, add them in `test/setup.ts`, not in individual test files — the one exception is `config/config`, which only works per-file (see above). When adding new fixtures, place them in `test/data/` and load them via `test/stub/firebase.ts`.
 
 External network calls in tests (e.g. `kickbox.com`) are expected to fail and don't fail the suite.
 

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -16,48 +16,6 @@ process.env.ALCHEMY_GAS_POLICY_ID = 'test-alchemy-policy-id';
 process.env.ALCHEMY_SPONSORSHIP_WEBHOOK_SECRET = 'test-alchemy-webhook-secret';
 process.env.PLUS_SETTLE_ADMIN_TOKEN = 'test-plus-settle-admin-token';
 
-// Mock config files
-vi.mock('../../config/config', () => ({
-  AIRTABLE_AUTOMATION_TOKEN: 'test-airtable-automation-token',
-  PLUS_READING_SERVICE_TOKEN: 'test-plus-reading-service-token',
-  ALCHEMY_GAS_POLICY_ID: 'test-alchemy-policy-id',
-  ALCHEMY_SPONSORSHIP_WEBHOOK_SECRET: 'test-alchemy-webhook-secret',
-  PLUS_SETTLE_ADMIN_TOKEN: 'test-plus-settle-admin-token',
-  FIREBASE_STORAGE_BUCKET: 'test-bucket',
-  FIRESTORE_USER_ROOT: 'users',
-  FIRESTORE_USER_AUTH_ROOT: 'user-auth',
-  FIRESTORE_SUBSCRIPTION_USER_ROOT: 'subscriptions',
-  FIRESTORE_SUPERLIKE_USER_ROOT: 'superlike',
-  FIRESTORE_TX_ROOT: 'tx',
-  FIRESTORE_IAP_ROOT: 'iap',
-  FIRESTORE_MISSION_ROOT: 'missions',
-  FIRESTORE_PAYOUT_ROOT: 'payout',
-  FIRESTORE_COUPON_ROOT: 'coupon',
-  FIRESTORE_CONFIG_ROOT: 'config',
-  FIRESTORE_OAUTH_CLIENT_ROOT: 'oauth-client',
-  FIRESTORE_LIKER_NFT_ROOT: 'likenft',
-  FIRESTORE_NFT_SUBSCRIPTION_USER_ROOT: 'nft-subscription',
-  FIRESTORE_NFT_FREE_MINT_TX_ROOT: 'nft-free-mint-tx',
-  FIRESTORE_LIKER_NFT_BOOK_CART_ROOT: 'nft-book-cart',
-  FIRESTORE_LIKER_NFT_BOOK_CMS_TAG_ROOT: 'nft-book-cms-tag',
-  FIRESTORE_LIKER_NFT_BOOK_ROOT: 'nft-book',
-  FIRESTORE_LIKER_NFT_BOOK_USER_ROOT: 'nft-book-user',
-  FIRESTORE_LIKER_PLUS_GIFT_CART_ROOT: 'plus-gift-cart',
-  FIRESTORE_LIKE_URL_ROOT: 'like-button',
-  FIRESTORE_ISCN_INFO_ROOT: 'iscn-info',
-  FIRESTORE_ISCN_ARWEAVE_TX_ROOT: 'iscn-arweave-tx',
-  FIRESTORE_ISCN_LIKER_URL_ROOT: 'iscn-like-button',
-  ARWEAVE_SPONSORED_DAILY_UPLOAD_LIMIT: 10,
-  ARWEAVE_SPONSORED_DAILY_BYTES_LIMIT: 100 * 1024 * 1024,
-  ARWEAVE_IRYS_FUND_MULTIPLIER: 2,
-  ARWEAVE_IRYS_DEPOSIT_ADDRESS: '',
-  ARWEAVE_RECONCILE_ADMIN_TOKEN: 'test-arweave-reconcile-token',
-  REVENUECAT_WEBHOOK_AUTHORIZATION: 'test-rc-webhook-secret',
-  REVENUECAT_PLUS_ENTITLEMENT_ID: 'plus',
-  REVENUECAT_PLUS_MONTHLY_PRODUCT_IDS: 'rc_plus_monthly',
-  REVENUECAT_PLUS_YEARLY_PRODUCT_IDS: 'rc_plus_yearly',
-}));
-
 vi.mock('../../config/serviceAccountKey.json', () => ({}));
 
 // Mock firebase-admin


### PR DESCRIPTION
The vi.mock('../../config/config') in test/setup.ts never applied: vi.mock resolves relative to the calling file, so from test/ that specifier points outside the repo, while source files resolve the same string to config/ config.js. Tests have always read the real config; deleting the 40-line mock leaves all 590 green.

AGENTS.md claimed new config keys must be mirrored into that mock, which is why reviewers keep filing it as a bug. Document the actual lever (process.env in setup.ts) instead.