### PR TITLE
[TAS-6164] ✨ Auto-link Magic email logins for legacy v1 accounts

### DIFF
--- a/src/routes/wallet/index.ts
+++ b/src/routes/wallet/index.ts
@@ -11,9 +11,12 @@ import { jwtSign } from '../../util/jwt';
 import {
   findLikeWalletByEVMWallet,
   checkBookUserEVMWallet,
+  isLegacyV1User,
   migrateBookClassId,
+  migrateLegacyUserToEVMWallet,
   migrateLikeWalletToEVMWallet,
 } from '../../util/api/wallet';
+import { isValidEVMAddress } from '../../util/evm';
 import {
   WalletAuthorizeBodySchema,
   WalletEvmMigrateEmailMagicBodySchema,
@@ -164,26 +167,29 @@ router.get('/evm/migrate/user/addr/:likeWallet', validateParams(WalletLikeWallet
 router.post('/evm/migrate/email/magic', validateBody(WalletEvmMigrateEmailMagicBodySchema), async (req, res, next) => {
   try {
     const {
-      wallet: evmWallet,
+      wallet: inputEVMWallet,
       signature,
       message,
     } = req.body;
     const migrationMethod = 'auto';
-    if (!checkAddressValid(evmWallet)) {
+    if (!isValidEVMAddress(inputEVMWallet)) {
       throw new ValidationError('INVALID_WALLET');
     }
     publisher.publish(PUBSUB_TOPIC_MISC, req, {
       logType: 'migrateLikeUserToEVMUserRequested',
-      evmWallet,
+      evmWallet: inputEVMWallet,
       migrationMethod,
     });
     const signed = await checkEVMSignPayload({
       signature,
       message,
-      inputWallet: evmWallet,
+      inputWallet: inputEVMWallet,
       signMethod: 'personal_sign',
       action: 'migrate',
     });
+    // Checksum only after signing: checkEVMSignPayload compares the wallet in the
+    // signed message case-strictly, but stored evmWallet is always EIP-55.
+    const evmWallet = checksumAddress(inputEVMWallet);
     const { email, magicDIDToken } = signed;
     const isEmailVerified = await verifyEmailByMagicDIDToken(email, magicDIDToken);
     if (isEmailVerified) {
@@ -198,56 +204,34 @@ router.post('/evm/migrate/email/magic', validateBody(WalletEvmMigrateEmailMagicB
       if (!userInfo.isEmailVerified) {
         throw new ValidationError('EXISTING_EMAIL_NOT_VERIFIED');
       }
-      const { likeWallet, evmWallet: docEvmWallet } = userInfo;
+      const {
+        user: likerId,
+        likeWallet,
+        cosmosWallet,
+        evmWallet: docEvmWallet,
+      } = userInfo;
       if (docEvmWallet && docEvmWallet !== evmWallet) {
         throw new ValidationError('EVM_WALLET_MISMATCH');
       }
       publisher.publish(PUBSUB_TOPIC_MISC, req, {
         logType: 'migrateLikeUserToEVMUserBegin',
+        likerId,
         likeWallet,
         evmWallet,
         migrationMethod,
       });
-      const {
-        isMigratedBookUser,
-        isMigratedBookOwner,
-        isMigratedLikerId,
-        isMigratedLikerLand,
-        migratedLikerId,
-        migratedLikerLandUser,
-        migrateBookUserError,
-        migrateBookOwnerError,
-        migrateLikerIdError,
-        migrateLikerLandError,
-      } = await migrateLikeWalletToEVMWallet(likeWallet as string, evmWallet, migrationMethod);
+      const result = isLegacyV1User({ likeWallet, cosmosWallet })
+        ? await migrateLegacyUserToEVMWallet(likerId, evmWallet, migrationMethod)
+        : await migrateLikeWalletToEVMWallet(likeWallet as string, evmWallet, migrationMethod);
       publisher.publish(PUBSUB_TOPIC_MISC, req, {
         logType: 'migrateLikeWalletToEVMUserEnd',
+        likerId,
         likeWallet,
         evmWallet,
-        isMigratedBookUser,
-        isMigratedBookOwner,
-        isMigratedLikerId,
-        isMigratedLikerLand,
         migrationMethod,
-        migratedLikerId,
-        migratedLikerLandUser,
-        migrateBookUserError,
-        migrateBookOwnerError,
-        migrateLikerIdError,
-        migrateLikerLandError,
+        ...result,
       });
-      sendValidatedJSON(res, WalletEvmMigrateResponseSchema, {
-        isMigratedBookUser,
-        isMigratedBookOwner,
-        isMigratedLikerId,
-        isMigratedLikerLand,
-        migratedLikerId,
-        migratedLikerLandUser,
-        migrateBookUserError,
-        migrateBookOwnerError,
-        migrateLikerIdError,
-        migrateLikerLandError,
-      });
+      sendValidatedJSON(res, WalletEvmMigrateResponseSchema, result);
     } else {
       throw new ValidationError('INVALID_EMAIL');
     }

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -100,6 +100,10 @@ export interface UserData {
   evmWallet?: string;
   wallet?: string;
 
+  // Set by the EVM migration; migrateTimestamp only on the legacy v1 path.
+  migrateMethod?: 'manual' | 'auto';
+  migrateTimestamp?: Timestamp;
+
   // Auth provider fields
   authCoreUserId?: string;
   magicUserId?: string;

--- a/src/util/api/users/index.ts
+++ b/src/util/api/users/index.ts
@@ -246,6 +246,10 @@ export async function userOrWalletByEmailQuery({
         payload = {
           evmWallet: maskString(docData.evmWallet),
           likeWallet: maskString(docData.likeWallet, { start: 11 }),
+          // Masking hides both preconditions of the magic-email migrate endpoint
+          // (no rival EVM wallet, verified email), so state them explicitly. Not
+          // v1-only: a likeWallet account migrates too, just via another branch.
+          isMigratable: !docData.evmWallet && !!docData.isEmailVerified,
         };
       }
       throw new ValidationError('EMAIL_ALREADY_USED', 400, payload);

--- a/src/util/api/wallet/index.ts
+++ b/src/util/api/wallet/index.ts
@@ -20,6 +20,16 @@ import {
 import { getStripeClient } from '../../stripe';
 import { bookCacheBucket } from '../../gcloudStorage';
 import { updateIntercomUserAttributes } from '../../intercom';
+import type { WalletEvmMigrateResult } from './schemas';
+
+type MigrateMethod = 'manual' | 'auto';
+
+// A v1 Liker ID predates the chain: it holds only the legacy ERC-20 `wallet`
+// field. Both wallets must be absent, or the account belongs on the full
+// likeWallet pipeline instead.
+export function isLegacyV1User(user: { likeWallet?: unknown; cosmosWallet?: unknown }): boolean {
+  return !user.likeWallet && !user.cosmosWallet;
+}
 
 export async function findLikeWalletByEVMWallet(evmWallet: string) {
   const userQuery = await likeNFTBookUserCollection.where('evmWallet', '==', checksumAddress(evmWallet as `0x${string}`)).get();
@@ -196,6 +206,76 @@ async function migrateLikerId(likeWallet:string, evmWallet: string, method: 'man
     console.error(error);
     return { likerId: null, error: (error as Error).message };
   }
+}
+
+async function linkEVMWalletToLikerId(likerId: string, evmWallet: string, method: MigrateMethod = 'manual') {
+  try {
+    // Login and /users/new both query evmWallet in EIP-55 form; a raw-case value
+    // would evade the collision check below and be invisible to login.
+    const checksummedEVMWallet = checksumAddress(evmWallet as `0x${string}`);
+    await db.runTransaction(async (t: admin.firestore.Transaction) => {
+      const userRef = userCollection.doc(likerId);
+      const [userDoc, evmQuery] = await Promise.all([
+        t.get(userRef),
+        // limit(2): the current doc may self-match, so a second holder stays visible.
+        t.get(userCollection.where('evmWallet', '==', checksummedEVMWallet).limit(2)),
+      ]);
+      const userData = userDoc.data();
+      if (!userDoc.exists || !userData) {
+        throw new Error('LIKER_ID_NOT_FOUND');
+      }
+      if (!isLegacyV1User(userData)) {
+        throw new Error('USER_HAS_LIKE_WALLET');
+      }
+      if (evmQuery.docs.some((doc) => doc.id !== likerId)) {
+        throw new Error('EVM_WALLET_ALREADY_EXIST');
+      }
+      if (userData.evmWallet && userData.evmWallet !== checksummedEVMWallet) {
+        throw new Error('EVM_WALLET_NOT_MATCH_USER_RECORD');
+      }
+      t.update(userRef, {
+        evmWallet: checksummedEVMWallet,
+        migrateMethod: method,
+        migrateTimestamp: FieldValue.serverTimestamp(),
+      });
+    });
+
+    await updateIntercomUserAttributes(likerId, {
+      evm_wallet: checksummedEVMWallet,
+    });
+
+    return { likerId, error: null };
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    return { likerId: null, error: (error as Error).message };
+  }
+}
+
+// Nothing is keyed by a like-address for a v1 account, so the book user, book
+// owner and liker.land steps have no records to move: linking the EVM wallet
+// onto the user doc is the whole migration.
+export async function migrateLegacyUserToEVMWallet(
+  likerId: string,
+  evmWallet: string,
+  method: MigrateMethod = 'manual',
+): Promise<WalletEvmMigrateResult> {
+  const {
+    likerId: migratedLikerId,
+    error: migrateLikerIdError,
+  } = await linkEVMWalletToLikerId(likerId, evmWallet, method);
+  return {
+    isMigratedBookUser: false,
+    isMigratedBookOwner: false,
+    isMigratedLikerId: !migrateLikerIdError,
+    isMigratedLikerLand: false,
+    migratedLikerId,
+    migratedLikerLandUser: null,
+    migrateBookUserError: null,
+    migrateBookOwnerError: null,
+    migrateLikerIdError,
+    migrateLikerLandError: null,
+  };
 }
 
 export async function migrateBookClassId(likeClassId: string, evmClassId: string) {
@@ -391,7 +471,11 @@ export async function migrateLikeUserToEVMUser(likeWallet: string, evmWallet: st
   };
 }
 
-export async function migrateLikeWalletToEVMWallet(likeWallet: string, evmWallet: string, method: 'manual' | 'auto' = 'manual') {
+export async function migrateLikeWalletToEVMWallet(
+  likeWallet: string,
+  evmWallet: string,
+  method: MigrateMethod = 'manual',
+): Promise<WalletEvmMigrateResult> {
   const { error: migrateBookUserError } = await migrateBookUser(likeWallet, evmWallet, method);
   if (migrateBookUserError) {
     return {

--- a/src/util/api/wallet/schemas.ts
+++ b/src/util/api/wallet/schemas.ts
@@ -72,6 +72,10 @@ export const WalletEvmMigrateResponseSchema = z.object({
   migrateLikerLandError: z.unknown().nullable(),
 });
 
+// Both migration paths (likeWallet and legacy v1) must return this exact shape;
+// the route forwards it straight to sendValidatedJSON.
+export type WalletEvmMigrateResult = z.infer<typeof WalletEvmMigrateResponseSchema>;
+
 export const WalletEvmMigrateBookResponseSchema = z.object({
   migratedClassIds: z.array(z.string()).optional(),
   error: z.string().nullable().optional(),

--- a/test/data/user.json
+++ b/test/data/user.json
@@ -160,6 +160,22 @@
           "likeWallet": "like1gmailunverified000000000000000000000000"
         },
         {
+          "id": "testv1legacy",
+          "displayName": "testv1legacy",
+          "email": "v1legacy@likecoin.store",
+          "normalizedEmail": "v1legacy@likecoin.store",
+          "wallet": "0x8dF1F7A5B0d9dA4CF3F5B3f3Cc31A5B6e0dE79F2",
+          "isEmailVerified": true
+        },
+        {
+          "id": "testv1legacycheck",
+          "displayName": "testv1legacycheck",
+          "email": "v1legacycheck@likecoin.store",
+          "normalizedEmail": "v1legacycheck@likecoin.store",
+          "wallet": "0x3cD2b9F4E1a7C6D8b5E0F2a3C4d5E6f7A8b9C0d1",
+          "isEmailVerified": true
+        },
+        {
           "id": "testprotonlegacy",
           "displayName": "testprotonlegacy",
           "email": "John.Roe+news@proton.me",

--- a/test/unit/email-normalization.test.ts
+++ b/test/unit/email-normalization.test.ts
@@ -136,4 +136,29 @@ describe('userOrWalletByEmailQuery', () => {
       expect((err as ValidationError).payload).toBeNull();
     }
   });
+
+  it('flags a wallet-less v1 account as migratable', async () => {
+    // testv1legacycheck has neither likeWallet nor evmWallet, so the masked fields
+    // are both empty; isMigratable is the client's only signal to auto-link it.
+    try {
+      await userOrWalletByEmailQuery({ evmWallet: '0xNEW' }, 'v1legacycheck@likecoin.store', true);
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      const { payload } = err as ValidationError;
+      expect(payload.evmWallet).toBeUndefined();
+      expect(payload.likeWallet).toBeUndefined();
+      expect(payload.isMigratable).toBe(true);
+    }
+  });
+
+  it('flags an account that already has an evmWallet as not migratable', async () => {
+    try {
+      await userOrWalletByEmailQuery({ evmWallet: '0xNEW' }, 'testing@likecoin.store', true);
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      expect((err as ValidationError).payload.isMigratable).toBe(false);
+    }
+  });
 });

--- a/test/unit/wallet-migrate-legacy.test.ts
+++ b/test/unit/wallet-migrate-legacy.test.ts
@@ -1,0 +1,108 @@
+import {
+  describe, it, expect, afterEach,
+} from 'vitest';
+import { checksumAddress } from 'viem';
+import { isLegacyV1User, migrateLegacyUserToEVMWallet } from '../../src/util/api/wallet';
+import { FieldValue, userCollection } from '../../src/util/firebase';
+
+// A v1 Liker ID (testv1legacy) predates the chain: it holds only the legacy
+// ERC-20 `wallet` field, with no likeWallet, cosmosWallet or evmWallet.
+// See test/data/user.json.
+const V1_LIKER_ID = 'testv1legacy';
+const V1_LEGACY_WALLET = '0x8dF1F7A5B0d9dA4CF3F5B3f3Cc31A5B6e0dE79F2';
+// Mixed-case on purpose: the link must persist the EIP-55 checksummed form.
+const NEW_EVM_WALLET = '0x1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b';
+const NEW_EVM_WALLET_CHECKSUM = checksumAddress(NEW_EVM_WALLET);
+// Held by the `testing` fixture.
+const TAKEN_EVM_WALLET = '0x4b25758E41f9240C8EB8831cEc7F1a02686387fa';
+
+describe('isLegacyV1User', () => {
+  it('accepts an account with neither chain wallet', () => {
+    expect(isLegacyV1User({})).toBe(true);
+  });
+
+  // cosmosWallet is written independently of likeWallet, so a doc can hold one
+  // without the other; both must veto or the account takes the wrong path.
+  it('rejects an account holding either likeWallet or cosmosWallet', () => {
+    expect(isLegacyV1User({ likeWallet: 'like1abc' })).toBe(false);
+    expect(isLegacyV1User({ cosmosWallet: 'cosmos1abc' })).toBe(false);
+  });
+});
+
+describe('migrateLegacyUserToEVMWallet', () => {
+  // resetTestData() re-requires the cached fixture JSON, so a write to a fixture
+  // doc otherwise outlives its test and leaks into later files. Clear it here so
+  // every case starts from a pristine v1 doc.
+  afterEach(async () => {
+    await userCollection.doc(V1_LIKER_ID).update({
+      evmWallet: FieldValue.delete(),
+      migrateMethod: FieldValue.delete(),
+      migrateTimestamp: FieldValue.delete(),
+    });
+  });
+
+  it('links the EVM wallet onto a v1 Liker ID, checksum-normalized', async () => {
+    const res = await migrateLegacyUserToEVMWallet(V1_LIKER_ID, NEW_EVM_WALLET, 'auto');
+    expect(res.isMigratedLikerId).toBe(true);
+    expect(res.migratedLikerId).toBe(V1_LIKER_ID);
+    expect(res.migrateLikerIdError).toBeNull();
+
+    const doc = await userCollection.doc(V1_LIKER_ID).get();
+    const data = doc.data();
+    // Persisted in EIP-55 form regardless of the input casing, so login (which
+    // queries the checksummed address) can resolve it.
+    expect(data?.evmWallet).toBe(NEW_EVM_WALLET_CHECKSUM);
+    expect(data?.migrateMethod).toBe('auto');
+    // The legacy ERC-20 address is a different keypair and must survive untouched.
+    expect(data?.wallet).toBe(V1_LEGACY_WALLET);
+  });
+
+  it('reports the likeWallet-keyed steps as skipped, not migrated', async () => {
+    const res = await migrateLegacyUserToEVMWallet(V1_LIKER_ID, NEW_EVM_WALLET, 'auto');
+    expect(res.isMigratedBookUser).toBe(false);
+    expect(res.isMigratedBookOwner).toBe(false);
+    expect(res.isMigratedLikerLand).toBe(false);
+    expect(res.migrateBookUserError).toBeNull();
+    expect(res.migrateBookOwnerError).toBeNull();
+    expect(res.migrateLikerLandError).toBeNull();
+    expect(res.migratedLikerLandUser).toBeNull();
+  });
+
+  it('is idempotent when the same EVM wallet is already linked', async () => {
+    await migrateLegacyUserToEVMWallet(V1_LIKER_ID, NEW_EVM_WALLET, 'auto');
+    const res = await migrateLegacyUserToEVMWallet(V1_LIKER_ID, NEW_EVM_WALLET, 'auto');
+    expect(res.isMigratedLikerId).toBe(true);
+  });
+
+  it('refuses an account that has a likeWallet, which needs the full migration', async () => {
+    const res = await migrateLegacyUserToEVMWallet('testgmaillegacy', NEW_EVM_WALLET, 'auto');
+    expect(res.isMigratedLikerId).toBe(false);
+    expect(res.migrateLikerIdError).toBe('USER_HAS_LIKE_WALLET');
+
+    const doc = await userCollection.doc('testgmaillegacy').get();
+    expect(doc.data()?.evmWallet).toBeUndefined();
+  });
+
+  it('refuses an EVM wallet already held by another user', async () => {
+    const res = await migrateLegacyUserToEVMWallet(V1_LIKER_ID, TAKEN_EVM_WALLET, 'auto');
+    expect(res.isMigratedLikerId).toBe(false);
+    expect(res.migrateLikerIdError).toBe('EVM_WALLET_ALREADY_EXIST');
+
+    const doc = await userCollection.doc(V1_LIKER_ID).get();
+    expect(doc.data()?.evmWallet).toBeUndefined();
+  });
+
+  it('refuses a case-variant of a taken wallet (checksum closes the bypass)', async () => {
+    // The lowercase form must still collide with the checksummed record held by
+    // `testing`; without normalization the raw-case query would miss it.
+    const res = await migrateLegacyUserToEVMWallet(V1_LIKER_ID, TAKEN_EVM_WALLET.toLowerCase(), 'auto');
+    expect(res.isMigratedLikerId).toBe(false);
+    expect(res.migrateLikerIdError).toBe('EVM_WALLET_ALREADY_EXIST');
+  });
+
+  it('refuses an unknown Liker ID', async () => {
+    const res = await migrateLegacyUserToEVMWallet('nosuchuser', NEW_EVM_WALLET, 'auto');
+    expect(res.isMigratedLikerId).toBe(false);
+    expect(res.migrateLikerIdError).toBe('LIKER_ID_NOT_FOUND');
+  });
+});


### PR DESCRIPTION
A v1 Liker ID predates the chain and holds only the legacy ERC-20 `wallet` field, so /wallet/evm/migrate/email/magic could not match it: the likeWallet pipeline it fed had no record to move. Add a v1 branch that links the EVM wallet straight onto the Liker ID doc, and surface an isMigratable flag on the EMAIL_ALREADY_USED payload so the client knows a wallet-less account is eligible to auto-link.

Store and query evmWallet in EIP-55 checksummed form so login can resolve it and the uniqueness guard can't be bypassed by casing; widen the guard query to limit(2) so a rival holder is still visible when the account self-matches.