### PR TITLE
✨ 404 book listings held for pending review

### DIFF
--- a/src/routes/likernft/book/store.ts
+++ b/src/routes/likernft/book/store.ts
@@ -247,13 +247,14 @@ router.get('/list', jwtOptionalAuth('read:nftbook'), validateQuery(BookListQuery
     const list = ownedBookInfos.flatMap((b: NFTBookListingInfo) => {
       const {
         isHidden,
+        isPendingReview,
         redirectClassId,
         moderatorWallets = [],
         ownerWallet,
       } = b;
       if (redirectClassId) return [];
       const isAuthorized = checkIsAuthorized({ ownerWallet, moderatorWallets }, req);
-      if (!isAuthorized && isHidden) return [];
+      if (!isAuthorized && (isHidden || isPendingReview)) return [];
       return [filterNFTBookListingInfo(b, isAuthorized)];
     });
     // Use the unfiltered Firestore result for the cursor — filtered-out
@@ -299,11 +300,11 @@ function createDerivedListHandler(filter: 'free' | 'drm-free') {
       const bookInfos = await listFilteredNFTBookInfo(conditions);
       const list = bookInfos.flatMap((b: NFTBookListingInfo) => {
         const {
-          isHidden, redirectClassId, moderatorWallets = [], ownerWallet,
+          isHidden, isPendingReview, redirectClassId, moderatorWallets = [], ownerWallet,
         } = b;
         if (redirectClassId) return [];
         const isAuthorized = checkIsAuthorized({ ownerWallet, moderatorWallets }, req);
-        if (!isAuthorized && isHidden) return [];
+        if (!isAuthorized && (isHidden || isPendingReview)) return [];
         return [filterNFTBookListingInfo(b, isAuthorized)];
       });
       // Use the unfiltered Firestore result for the cursor:
@@ -341,11 +342,11 @@ router.get('/list/popular', jwtOptionalAuth('read:nftbook'), validateQuery(BookP
     });
     const list = bookInfos.flatMap((b: NFTBookListingInfo) => {
       const {
-        isHidden, redirectClassId, moderatorWallets = [], ownerWallet,
+        isHidden, isPendingReview, redirectClassId, moderatorWallets = [], ownerWallet,
       } = b;
       if (redirectClassId) return [];
       const isAuthorized = checkIsAuthorized({ ownerWallet, moderatorWallets }, req);
-      if (!isAuthorized && isHidden) return [];
+      if (!isAuthorized && (isHidden || isPendingReview)) return [];
       return [filterNFTBookListingInfo(b, isAuthorized)];
     });
     // Cursor off the unfiltered Firestore result: filtered-out docs (hidden / redirected)
@@ -471,6 +472,7 @@ router.get('/cms/list', validateQuery(BookCMSTagListQuerySchema), async (req: Qu
     const list = books
       .filter((b) => (
         !b.isHidden
+        && !b.isPendingReview
         && !b.redirectClassId
         && (!isLibraryOnly || b.isPlusReadingEnabled)))
       .map((b) => filterNFTBookListingInfo(b, false));
@@ -501,8 +503,13 @@ router.get(['/:classId', '/class/:classId'], jwtOptionalAuth('read:nftbook'), va
     const {
       ownerWallet,
       moderatorWallets = [],
+      isPendingReview,
     } = bookInfo;
     const isAuthorized = checkIsAuthorized({ ownerWallet, moderatorWallets }, req);
+    if (!isAuthorized && isPendingReview) {
+      res.status(404).send('BOOK_NOT_FOUND');
+      return;
+    }
     const payload = filterNFTBookListingInfo(bookInfo, isAuthorized);
     sendValidatedJSON(res, BookInfoResponseSchema, payload);
   } catch (err) {
@@ -519,10 +526,15 @@ router.get(['/:classId/price/:priceIndex', '/class/:classId/price/:priceIndex'],
       prices = [],
       ownerWallet,
       moderatorWallets = [],
+      isPendingReview,
     } = bookInfo;
+    const isAuthorized = checkIsAuthorized({ ownerWallet, moderatorWallets }, req);
+    if (!isAuthorized && isPendingReview) {
+      res.status(404).send('BOOK_NOT_FOUND');
+      return;
+    }
     const priceInfo = prices[priceIndex];
     if (!priceInfo) throw new ValidationError('PRICE_NOT_FOUND', 404);
-    const isAuthorized = checkIsAuthorized({ ownerWallet, moderatorWallets }, req);
     const { prices: [price] } = filterNFTBookPricesInfo([{
       ...priceInfo,
       index: priceIndex,

--- a/src/routes/slack/book.ts
+++ b/src/routes/slack/book.ts
@@ -29,8 +29,18 @@ async function approveBook(classId: string, action: string, slackUserId: string)
   let approvalUpdate: any = {};
 
   switch (action) {
+    case 'pending_review':
+      approvalUpdate = {
+        isPendingReview: true,
+        isApprovedForSale: false,
+        isApprovedForIndexing: false,
+        isApprovedForAds: false,
+        approvalStatus: 'pending_review',
+      };
+      break;
     case 'approve_with_ads':
       approvalUpdate = {
+        isPendingReview: false,
         isHidden: false,
         isApprovedForSale: true,
         isApprovedForIndexing: true,
@@ -40,6 +50,7 @@ async function approveBook(classId: string, action: string, slackUserId: string)
       break;
     case 'approve_no_ads':
       approvalUpdate = {
+        isPendingReview: false,
         isHidden: false,
         isApprovedForSale: true,
         isApprovedForIndexing: true,
@@ -49,6 +60,7 @@ async function approveBook(classId: string, action: string, slackUserId: string)
       break;
     case 'approve_hidden':
       approvalUpdate = {
+        isPendingReview: false,
         isHidden: true,
         isApprovedForSale: true,
         isApprovedForIndexing: false,
@@ -58,6 +70,7 @@ async function approveBook(classId: string, action: string, slackUserId: string)
       break;
     case 'reject':
       approvalUpdate = {
+        isPendingReview: false,
         isHidden: true,
         isApprovedForSale: false,
         isApprovedForIndexing: false,
@@ -73,6 +86,7 @@ async function approveBook(classId: string, action: string, slackUserId: string)
   await updateAirtablePublicationRecord({
     id: classId,
     isHidden: approvalUpdate.isHidden,
+    isPendingReview: approvalUpdate.isPendingReview,
   });
 
   await Promise.all([
@@ -109,10 +123,10 @@ router.post(
       const slackUserId = req.body.user_id;
       const [classId, action = 'approve_with_ads'] = params;
       if (!classId) {
-        throw new Error('Missing classId. Usage: /book approve <classId> <approve_with_ads|approve_no_ads|reject>');
+        throw new Error('Missing classId. Usage: /book approve <classId> <approve_with_ads|approve_no_ads|approve_hidden|pending_review|reject>');
       }
-      if (action && !['approve_with_ads', 'approve_no_ads', 'approve_hidden', 'reject'].includes(action)) {
-        throw new Error('Invalid action. Must be one of approve_with_ads, approve_no_ads, approve_hidden, reject');
+      if (action && !['approve_with_ads', 'approve_no_ads', 'approve_hidden', 'pending_review', 'reject'].includes(action)) {
+        throw new Error('Invalid action. Must be one of approve_with_ads, approve_no_ads, approve_hidden, pending_review, reject');
       }
       const result = await approveBook(classId, action, slackUserId);
 
@@ -124,13 +138,14 @@ router.post(
     help: ({ res }) => {
       res.json({
         response_type: 'ephemeral',
-        text: `\`/book approve <classId> <approve_with_ads|approve_no_ads|reject>\` Approve or reject a book listing
+        text: `\`/book approve <classId> <approve_with_ads|approve_no_ads|approve_hidden|pending_review|reject>\` Approve or reject a book listing
 
 Examples:
   \`/book approve 0x1234...5678 \` - Approve for listing & ads (default)
   \`/book approve 0x1234...5678  approve_with_ads\` - Approve for listing & ads
   \`/book approve 0x1234...5678  approve_no_ads\` - Approve for listing (no ads)
   \`/book approve 0x1234...5678  approve_hidden\` - Approve but keep hidden (no ads)
+  \`/book approve 0x1234...5678  pending_review\` - Hold for review; 404 to public until approved
   \`/book approve 0x1234...5678  reject\` - Reject/hide listing`,
       });
     },

--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -170,6 +170,9 @@ export interface NFTBookListingInfo {
   genre?: string;
   timestamp?: { toMillis: () => number };
   isHidden?: boolean;
+  // Unlike `isHidden`, which only unlists, this 404s the listing to the public
+  // while it awaits review. Owners and moderators still see it.
+  isPendingReview?: boolean;
   isAdultOnly?: boolean;
   isLikerLandArt?: boolean;
   isApprovedForSale?: boolean;

--- a/src/util/ValidationHelper.ts
+++ b/src/util/ValidationHelper.ts
@@ -576,6 +576,7 @@ export function filterNFTBookListingInfo(
     genre,
     timestamp,
     isHidden,
+    isPendingReview,
     isAdultOnly,
     isApprovedForSale,
     isApprovedForIndexing,
@@ -628,6 +629,7 @@ export function filterNFTBookListingInfo(
     genre,
     timestamp: timestamp?.toMillis(),
     isHidden,
+    isPendingReview,
     isAdultOnly,
     // Approval flags - default to true for backward compatibility with existing books
     isApprovedForSale: isApprovedForSale !== undefined ? isApprovedForSale : true,

--- a/src/util/airtable.ts
+++ b/src/util/airtable.ts
@@ -34,6 +34,7 @@ interface AirtablePublicationRecordParams {
   metadata?: any;
   isDRMFree?: boolean;
   isHidden?: boolean;
+  isPendingReview?: boolean;
   isAdultOnly?: boolean;
   isPlusReadingEnabled?: boolean;
 }
@@ -89,6 +90,7 @@ export async function createAirtablePublicationRecord({
   metadata,
   isDRMFree = false,
   isHidden = false,
+  isPendingReview = false,
   isAdultOnly = false,
   isPlusReadingEnabled = false,
 }: CreateAirtablePublicationRecordParams): Promise<void> {
@@ -161,6 +163,9 @@ export async function createAirtablePublicationRecord({
 
     if (isHidden) {
       fields.Hidden = true;
+    }
+    if (isPendingReview) {
+      fields['Pending Review'] = true;
     }
     if (isAdultOnly) {
       fields['Adult Only'] = true;
@@ -303,6 +308,7 @@ export async function updateAirtablePublicationRecord({
   metadata,
   isDRMFree,
   isHidden,
+  isPendingReview,
   isAdultOnly,
   isPlusReadingEnabled,
 }: UpdateAirtablePublicationRecordParams): Promise<void> {
@@ -376,6 +382,9 @@ export async function updateAirtablePublicationRecord({
 
     if (isHidden !== undefined) {
       fields.Hidden = isHidden;
+    }
+    if (isPendingReview !== undefined) {
+      fields['Pending Review'] = isPendingReview;
     }
     if (isAdultOnly !== undefined) {
       fields['Adult Only'] = isAdultOnly;

--- a/src/util/api/likernft/book/cart.ts
+++ b/src/util/api/likernft/book/cart.ts
@@ -1162,10 +1162,15 @@ export async function formatCartItemsWithInfo(items: CartItem[]) {
         isLikerLandArt,
         chain,
         isApprovedForSale,
+        isPendingReview,
       } = bookInfo;
 
       if (isApprovedForSale === false) {
         throw new ValidationError('BOOK_NOT_APPROVED_FOR_SALE');
+      }
+
+      if (isPendingReview) {
+        throw new ValidationError('NFT_NOT_FOUND');
       }
 
       if (!prices[priceIndex]) throw new ValidationError('NFT_PRICE_NOT_FOUND');

--- a/src/util/api/likernft/book/catalogSource.ts
+++ b/src/util/api/likernft/book/catalogSource.ts
@@ -83,6 +83,7 @@ export async function listCatalogEligibleBooks(): Promise<CatalogBook[]> {
     // and defaults to approved (see ValidationHelper.ts), so we filter only on the explicit false.
     if (
       data.isHidden
+      || data.isPendingReview
       || data.redirectClassId
       || data.isAdultOnly
       || data.isApprovedForAds === false

--- a/src/util/api/likernft/book/index.ts
+++ b/src/util/api/likernft/book/index.ts
@@ -328,6 +328,7 @@ export async function newNftBookInfo(
     isApprovedForIndexing: true,
     isApprovedForAds: (isAdultOnly ? false : isTrustedPublisher),
     approvalStatus: isTrustedPublisher ? 'approved' : 'pending',
+    isPendingReview: false,
     // Seed the popularity sort key: Firestore drops documents missing an `orderBy`
     // field, so an unseeded book would never surface in the popular listing at all.
     plusReadingTotalMs: 0,

--- a/src/util/api/likernft/book/schemas.ts
+++ b/src/util/api/likernft/book/schemas.ts
@@ -394,6 +394,7 @@ export const NFTBookListingInfoFilteredSchema = z.object({
   genre: z.string().optional(),
   timestamp: z.number().optional(),
   isHidden: z.boolean().optional(),
+  isPendingReview: z.boolean().optional(),
   isAdultOnly: z.boolean().optional(),
   sold: z.number().int().optional(),
   pendingNFTCount: z.number().int().optional(),


### PR DESCRIPTION
Add an admin-set isPendingReview flag that makes a book unavailable to the public: the store listing endpoint and the aggregated NFT metadata endpoint 404, the book is dropped from all list/cms/catalog surfaces, and purchase is blocked. Owners and moderators still see the listing. Set it via `/book approve <classId> pending_review`; other approve/reject actions clear it. Synced to Airtable as a Pending Review field.