### PR TITLE
✨ Match arweave tx owner across Cosmos↔EVM migration

### DIFF
--- a/src/routes/arweave/index.ts
+++ b/src/routes/arweave/index.ts
@@ -15,6 +15,7 @@ import { getPublicKey, signData as signArweaveData } from '../../util/arweave/si
 import {
   createNewArweaveTx,
   getArweaveTxInfo,
+  isArweaveTxOwner,
   updateArweaveTxStatus,
   rotateArweaveTxAccessToken,
   resolveArweaveTxKey,
@@ -217,7 +218,7 @@ router.post(
       if (!tx) throw new ValidationError('TX_NOT_FOUND', 404);
       const { ownerWallet, authToken } = tx;
       const userWallet = req.user?.wallet || '';
-      const isAuthed = (ownerWallet && userWallet === ownerWallet)
+      const isAuthed = (await isArweaveTxOwner(userWallet, ownerWallet))
         || (authToken && authToken === token);
       if (!isAuthed) throw new ValidationError('INVALID_TOKEN', 403);
       if (tx.status !== 'pending') throw new ValidationError('TX_ALREADY_REGISTERED', 409);
@@ -299,7 +300,7 @@ router.get(
       } = tx;
       if (isRequireAuth) {
         if (!req.user?.wallet && !token) throw new ValidationError('MISSING_USER', 401);
-        const isUserAuthed = req.user?.wallet === ownerWallet;
+        const isUserAuthed = await isArweaveTxOwner(req.user?.wallet, ownerWallet);
         const isTokenAuthed = token === docToken
           || (ARWEAVE_LINK_INTERNAL_TOKEN && token === ARWEAVE_LINK_INTERNAL_TOKEN)
           || (docAccessToken && token === docAccessToken);
@@ -348,7 +349,7 @@ router.post(
       const tx = await getArweaveTxInfo(txHash);
       if (!tx) throw new ValidationError('TX_NOT_FOUND', 404);
       const { ownerWallet, status } = tx;
-      if (req.user.wallet !== ownerWallet) throw new ValidationError('NOT_OWNER', 403);
+      if (!(await isArweaveTxOwner(req.user.wallet, ownerWallet))) throw new ValidationError('NOT_OWNER', 403);
       if (status !== 'complete') throw new ValidationError('TX_NOT_COMPLETE', 409);
       const accessToken = await rotateArweaveTxAccessToken(txHash);
       sendValidatedJSON(res, ArweaveAccessTokenResponseSchema, { accessToken });

--- a/src/routes/arweave/index.ts
+++ b/src/routes/arweave/index.ts
@@ -218,8 +218,9 @@ router.post(
       if (!tx) throw new ValidationError('TX_NOT_FOUND', 404);
       const { ownerWallet, authToken } = tx;
       const userWallet = req.user?.wallet || '';
-      const isAuthed = (await isArweaveTxOwner(userWallet, ownerWallet))
-        || (authToken && authToken === token);
+      // Token match first: it needs no Firestore read, unlike the owner lookup.
+      const isAuthed = !!(authToken && authToken === token)
+        || (await isArweaveTxOwner(userWallet, ownerWallet));
       if (!isAuthed) throw new ValidationError('INVALID_TOKEN', 403);
       if (tx.status !== 'pending') throw new ValidationError('TX_ALREADY_REGISTERED', 409);
       const accessToken = await updateArweaveTxStatus(txHash, {
@@ -300,11 +301,14 @@ router.get(
       } = tx;
       if (isRequireAuth) {
         if (!req.user?.wallet && !token) throw new ValidationError('MISSING_USER', 401);
-        const isUserAuthed = await isArweaveTxOwner(req.user?.wallet, ownerWallet);
-        const isTokenAuthed = token === docToken
-          || (ARWEAVE_LINK_INTERNAL_TOKEN && token === ARWEAVE_LINK_INTERNAL_TOKEN)
-          || (docAccessToken && token === docAccessToken);
-        if (!isUserAuthed && !isTokenAuthed) throw new ValidationError('INVALID_TOKEN', 403);
+        // Guard on `token`: a doc without `token` would otherwise match a
+        // tokenless request on undefined === undefined and skip auth entirely.
+        // Checked before the owner lookup, which costs a Firestore read.
+        const isTokenAuthed = !!token
+          && [docToken, ARWEAVE_LINK_INTERNAL_TOKEN, docAccessToken].includes(token);
+        if (!isTokenAuthed && !(await isArweaveTxOwner(req.user?.wallet, ownerWallet))) {
+          throw new ValidationError('INVALID_TOKEN', 403);
+        }
       }
       const link = new URL(`${ARWEAVE_GATEWAY}/${arweaveId}`);
       // A browser's */*;q=0.8 satisfies accepts('application/json'), so plain negotiation

--- a/src/util/api/arweave/tx.ts
+++ b/src/util/api/arweave/tx.ts
@@ -2,6 +2,7 @@ import uuidv4 from 'uuid/v4';
 import { FieldValue, iscnArweaveTxCollection } from '../../firebase';
 import { wrapKey, unwrapKey, isKMSEnabled } from '../../kms';
 import { getUserWalletsByWallet } from '../users/getPublicInfo';
+import { ValidationError } from '../../ValidationError';
 import type { ArweaveTxData } from '../../../types/transaction';
 
 export async function createNewArweaveTx(docId: string, {
@@ -46,16 +47,18 @@ export async function isArweaveTxOwner(
   ownerWallet?: string,
 ): Promise<boolean> {
   if (!reqUserWallet || !ownerWallet) return false;
-  if (reqUserWallet === ownerWallet) return true;
+  const target = reqUserWallet.toLowerCase();
+  if (target === ownerWallet.toLowerCase()) return true;
   let wallets: Awaited<ReturnType<typeof getUserWalletsByWallet>>;
   try {
     wallets = await getUserWalletsByWallet(ownerWallet);
-  } catch {
+  } catch (err) {
     // ownerWallet not a resolvable address — treat as no match, not a 400.
-    return false;
+    // Anything else (Firestore failure) must surface rather than read as a 403.
+    if (err instanceof ValidationError) return false;
+    throw err;
   }
   if (!wallets) return false;
-  const target = reqUserWallet.toLowerCase();
   return [wallets.evmWallet, wallets.likeWallet, wallets.cosmosWallet]
     .some((w) => !!w && w.toLowerCase() === target);
 }

--- a/src/util/api/arweave/tx.ts
+++ b/src/util/api/arweave/tx.ts
@@ -1,6 +1,7 @@
 import uuidv4 from 'uuid/v4';
 import { FieldValue, iscnArweaveTxCollection } from '../../firebase';
 import { wrapKey, unwrapKey, isKMSEnabled } from '../../kms';
+import { getUserWalletsByWallet } from '../users/getPublicInfo';
 import type { ArweaveTxData } from '../../../types/transaction';
 
 export async function createNewArweaveTx(docId: string, {
@@ -34,6 +35,29 @@ export async function createNewArweaveTx(docId: string, {
 export async function getArweaveTxInfo(txHash: string): Promise<ArweaveTxData | undefined> {
   const doc = await iscnArweaveTxCollection.doc(txHash).get();
   return doc.data();
+}
+
+// Whether reqUserWallet owns a tx stamped with ownerWallet. Matches directly,
+// or across a Cosmos↔EVM migration: a legacy upload owned by a like1… wallet is
+// still owned by the same identity now authenticating with its migrated evmWallet
+// (or vice versa). The user-record lookup runs only when the direct match fails.
+export async function isArweaveTxOwner(
+  reqUserWallet?: string,
+  ownerWallet?: string,
+): Promise<boolean> {
+  if (!reqUserWallet || !ownerWallet) return false;
+  if (reqUserWallet === ownerWallet) return true;
+  let wallets: Awaited<ReturnType<typeof getUserWalletsByWallet>>;
+  try {
+    wallets = await getUserWalletsByWallet(ownerWallet);
+  } catch {
+    // ownerWallet not a resolvable address — treat as no match, not a 400.
+    return false;
+  }
+  if (!wallets) return false;
+  const target = reqUserWallet.toLowerCase();
+  return [wallets.evmWallet, wallets.likeWallet, wallets.cosmosWallet]
+    .some((w) => !!w && w.toLowerCase() === target);
 }
 
 export async function updateArweaveTxStatus(txHash: string, {

--- a/src/util/api/users/getPublicInfo.ts
+++ b/src/util/api/users/getPublicInfo.ts
@@ -140,8 +140,12 @@ async function resolveUserDocByWallet(
     addr = checksumAddress(addr as `0x${string}`);
   } else if (checkCosmosAddressValid(addr, 'like')) {
     field = 'likeWallet';
+    // Bech32 decoding accepts all-uppercase, but Firestore queries are case-sensitive
+    // and addresses are stored lowercase.
+    addr = addr.toLowerCase();
   } else if (checkCosmosAddressValid(addr, 'cosmos')) {
     field = 'cosmosWallet';
+    addr = addr.toLowerCase();
   } else {
     throw new ValidationError('Invalid address');
   }

--- a/src/util/api/users/getPublicInfo.ts
+++ b/src/util/api/users/getPublicInfo.ts
@@ -128,9 +128,11 @@ export async function getUserAvatar(id: string): Promise<string | null> {
   return avatar || AVATAR_DEFAULT_PATH;
 }
 
-export async function getUserWithCivicLikerPropertiesByWallet(
+// Resolves a live (non-deleted) user doc by any wallet type, checksumming EVM
+// addresses to match how they are stored. Throws on an unrecognised address.
+async function resolveUserDocByWallet(
   walletAddress: string,
-): Promise<UserCivicLikerProperties | null> {
+): Promise<DocumentSnapshot<UserData> | null> {
   let field: 'evmWallet' | 'likeWallet' | 'cosmosWallet';
   let addr = walletAddress;
   if (checkAddressValid(addr)) {
@@ -145,10 +147,28 @@ export async function getUserWithCivicLikerPropertiesByWallet(
   }
   const query = await dbRef.where(field, '==', addr).limit(1).get();
   if (!query.docs.length) return null;
-  const userDoc = query.docs[0];
-  if (!isValidUserDoc(userDoc)) return null;
-  const payload = formatUserCivicLikerProperies(userDoc as DocumentSnapshot<UserData>);
-  return payload;
+  const userDoc = query.docs[0] as DocumentSnapshot<UserData>;
+  return isValidUserDoc(userDoc) ? userDoc : null;
+}
+
+export async function getUserWithCivicLikerPropertiesByWallet(
+  walletAddress: string,
+): Promise<UserCivicLikerProperties | null> {
+  const userDoc = await resolveUserDocByWallet(walletAddress);
+  if (!userDoc) return null;
+  return formatUserCivicLikerProperies(userDoc);
+}
+
+// Lean sibling of getUserWithCivicLikerPropertiesByWallet: returns only the
+// linked wallets, skipping the Civic Liker / Liker Plus computation. For
+// cross-wallet ownership checks.
+export async function getUserWalletsByWallet(
+  walletAddress: string,
+): Promise<Pick<UserData, 'evmWallet' | 'likeWallet' | 'cosmosWallet'> | null> {
+  const userDoc = await resolveUserDocByWallet(walletAddress);
+  if (!userDoc) return null;
+  const { evmWallet, likeWallet, cosmosWallet } = userDoc.data() as UserData;
+  return { evmWallet, likeWallet, cosmosWallet };
 }
 
 export default getUserWithCivicLikerProperties;

--- a/test/api/arweave-link.test.ts
+++ b/test/api/arweave-link.test.ts
@@ -2,11 +2,16 @@ import {
   describe, it, expect, beforeEach,
 } from 'vitest';
 import axiosist from './axiosist';
+import { jwtSign } from './jwt';
+import mockEVMAddress from './address';
+// Both wallets of the same `testing` user, so a cross-wallet match is expected.
+import { testingWallet1, testingLikeWallet1 } from './data';
 import { iscnArweaveTxCollection } from '../../src/util/firebase';
 
 const TX_HASH = '0xarweavelinktest';
 const ARWEAVE_ID = 'test-arweave-id';
 const CONTENT_KEY = Buffer.alloc(32, 1).toString('base64');
+const DOC_TOKEN = 'doc-upload-token';
 
 describe('Arweave link API', () => {
   beforeEach(async () => {
@@ -15,6 +20,7 @@ describe('Arweave link API', () => {
       status: 'complete',
       isRequireAuth: false,
       key: CONTENT_KEY,
+      token: DOC_TOKEN,
     });
   });
 
@@ -78,5 +84,55 @@ describe('Arweave link API', () => {
       .catch((err) => (err as any).response);
 
     expect(res.status).toBe(404);
+  });
+
+  // Ownership must survive a Cosmos↔EVM migration: a legacy upload stamped with
+  // like1… is still owned by the same identity now authenticating with evmWallet.
+  describe('isRequireAuth ownership', () => {
+    const getWithWallet = (wallet: string) => axiosist.get(`/api/arweave/v2/link/${TX_HASH}`, {
+      headers: { Authorization: `Bearer ${jwtSign({ wallet, permissions: ['read:iscn'] })}` },
+    }).catch((err) => (err as any).response);
+
+    beforeEach(async () => {
+      await iscnArweaveTxCollection.doc(TX_HASH).update({
+        isRequireAuth: true,
+        ownerWallet: testingLikeWallet1,
+      });
+    });
+
+    it('accepts the linked evmWallet for a likeWallet-owned tx', async () => {
+      const res = await getWithWallet(testingWallet1);
+
+      expect(res.status).toBe(200);
+      expect(res.data.arweaveId).toBe(ARWEAVE_ID);
+    });
+
+    it('accepts the linked likeWallet for an evmWallet-owned tx', async () => {
+      await iscnArweaveTxCollection.doc(TX_HASH).update({ ownerWallet: testingWallet1 });
+      const res = await getWithWallet(testingLikeWallet1);
+
+      expect(res.status).toBe(200);
+      expect(res.data.arweaveId).toBe(ARWEAVE_ID);
+    });
+
+    it('rejects an unrelated wallet', async () => {
+      const res = await getWithWallet(mockEVMAddress('dead'));
+
+      expect(res.status).toBe(403);
+    });
+
+    it('accepts the upload token in place of wallet auth', async () => {
+      const res = await axiosist.get(`/api/arweave/v2/link/${TX_HASH}?token=${DOC_TOKEN}`)
+        .catch((err) => (err as any).response);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('rejects an unauthenticated request', async () => {
+      const res = await axiosist.get(`/api/arweave/v2/link/${TX_HASH}`)
+        .catch((err) => (err as any).response);
+
+      expect(res.status).toBe(401);
+    });
   });
 });


### PR DESCRIPTION
Legacy uploads stamp ownerWallet with the uploader's like1… wallet, so a migrated owner authenticating with their evmWallet failed the exact-match owner check and was forced onto the token path (surfaced as 'Missing token' in the publish preview).

Add isArweaveTxOwner(), which resolves the owner's linked wallets via a lean getUserWalletsByWallet() lookup and matches the caller against any of them. Wire it into the link, register, and access_token endpoints. The user-record read runs only when the direct wallet match fails, keeping the hot path free.