### PR TITLE
🐛 Default Irys fund multiplier when the config key is missing

### DIFF
--- a/src/util/arweave/signer.ts
+++ b/src/util/arweave/signer.ts
@@ -35,7 +35,9 @@ const EXPECTED_DEPOSIT_ADDRESS = ARWEAVE_IRYS_DEPOSIT_ADDRESS || DEFAULT_IRYS_DE
 // Fund a multiple of a single file's price when topping up, so one stranded credit
 // can't drop the node balance below the next upload's price and 402 it. Floor at 1:
 // a sub-1 multiple would top up below the upload's own price and 402 it immediately.
-const FUND_MULTIPLIER = Math.max(1, ARWEAVE_IRYS_FUND_MULTIPLIER);
+// The `|| 2` also covers the key missing from a deployed config.js: Number(undefined)
+// is NaN, and NaN would otherwise survive Math.max and poison the multiplier.
+const FUND_MULTIPLIER = Math.max(1, Number(ARWEAVE_IRYS_FUND_MULTIPLIER) || 2);
 
 let signer: TypedEthereumSigner | null = null;
 let fundingWalletClient: WalletClient<HttpTransport, Chain, LocalAccount> | undefined;


### PR DESCRIPTION
ARWEAVE_IRYS_FUND_MULTIPLIER landed in 2a3285f7 but the deployed config.js predates it, so the import resolved to undefined and Math.max(1, undefined) made FUND_MULTIPLIER NaN at module load. Every fund() top-up then threw out of BigInt() in scaleBigInt, 500ing /arweave/v2/sign_payment_data once the node balance dipped below an upload's price.

Re-default at the consumer with `|| 2`, matching evm/client.ts and routes/misc/price.ts.