### PR TITLE
✨ Add run-likecoin-api skill to boot and drive the API

### DIFF
--- a/.claude/skills/run-likecoin-api/SKILL.md
+++ b/.claude/skills/run-likecoin-api/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: run-likecoin-api
+description: Build, run, and drive the likecoin-api-public Express server. Use when asked to start the API, boot the server, hit an endpoint, run the test suite, reproduce a route's response, or verify a handler change works against real request/response flow.
+---
+
+REST API backend (Express 5 + TypeScript, Firestore). There is no UI — you drive it
+over HTTP. Use `.claude/skills/run-likecoin-api/driver.mjs`, which has two modes:
+`smoke` (boots the real server and probes it) and `req` (drives one endpoint against
+the in-memory Firestore stub, where handler logic is actually reachable).
+
+All paths below are relative to the repo root.
+
+## The credential problem — read this first
+
+`src/util/firebase.ts:56` calls `admin.initializeApp()` **at import time**. It reads
+`config/serviceAccountKey.json` — a tracked placeholder whose credential fields are all
+empty strings — so on a fresh checkout `initializeApp()` throws and the server crashes
+before Express binds a port:
+
+```
+FirebaseAppError: Service account object must contain a string "project_id" property.
+```
+
+`src/util/firebase.ts:55` guards that whole block behind `if (!process.env.CI)`, and
+`getCollection()` returns `{}` when `CI` is set. **`CI=1` is the only way to boot this
+server without real Google credentials.** That's what CircleCI's `npm start` step relies
+on, and it's what the driver does.
+
+The tradeoff: under `CI=1` there is no database, so any handler that touches Firestore
+returns 500. For handler logic, use `driver.mjs req` instead (next section).
+
+## Prerequisites
+
+Node 24+ (`engines: >=24`). No system packages needed.
+
+```bash
+node -v        # v24.15.0
+npm install
+```
+
+## Build
+
+```bash
+npm run build
+```
+
+`npm run clean` recreates `dist/config` as a **symlink** to `../config` — don't
+replace it with a real directory or compiled `require('../../config/config')` breaks.
+
+## Run (agent path)
+
+### Drive a single endpoint with a working database — `req`
+
+This is the mode you want for verifying a handler change. It runs the request through
+`test/api/axiosist.ts`, which rebuilds the Express app on the in-memory Firestore stub
+seeded from `test/data/*.json`. No credentials, no port, ~3s per call.
+
+```bash
+node .claude/skills/run-likecoin-api/driver.mjs req GET /users/id/testing/min
+```
+```json
+{
+  "status": 200,
+  "data": {
+    "user": "testing",
+    "displayName": "testing",
+    "wallet": "0x4b25758E41f9240C8EB8831cEc7F1a02686387fa",
+    "isCivicLikerTrial": true,
+    "civicLikerSince": 1546272000000
+  }
+}
+```
+
+Authenticated — `--user <id>` and/or `--wallet <addr>` sign a JWT with the test secret:
+
+```bash
+node .claude/skills/run-likecoin-api/driver.mjs req GET /users/self --user testing
+# 200, full user object. Without --user: 401 "LOGIN_NEEDED".
+```
+
+With a body:
+
+```bash
+node .claude/skills/run-likecoin-api/driver.mjs req POST /users/new/check --body '{"user":"testing"}'
+# 400 {"error":"USER_ALREADY_EXIST","alternative":"testing38396"}   (suffix is random)
+```
+
+Pass the **production** path (`/users/...`). The driver adds the `/api` prefix that
+axiosist mounts under — see Gotchas.
+
+Seeded fixture identities live in `test/data/user.json` (`testing`, `testing1`, …),
+plus `subscription.json`, `tx.json`, `mission.json`, `likernft.json`.
+
+### Boot the real server — `smoke`
+
+Proves the process starts, routes are mounted, and middleware works. Firestore is
+absent, so DB-backed routes are expected to 500.
+
+```bash
+node .claude/skills/run-likecoin-api/driver.mjs smoke
+```
+```
+booting: CI=1 IS_TESTNET=true npx tsx src/index.ts
+ok   200  /healthz                     OK
+ok   302  /                            Found. Redirecting to https://api.docs.like.co/
+ok   200  /misc/price                  {"price":0.00203916}
+ok   404  /no-such-route               <!DOCTYPE html> ...
+ok   500  /users/id/testing/min        Internal Server Error  (needs Firestore; 500 is expected under CI=1)
+
+smoke ok
+```
+
+To keep a server up and poke it yourself:
+
+```bash
+CI=1 IS_TESTNET=true npx tsx src/index.ts &
+curl -s http://127.0.0.1:3000/healthz          # OK
+curl -s http://127.0.0.1:3000/misc/price       # {"price":0.00203916}
+pkill -f "tsx src/index.ts"
+```
+
+## Run (human path)
+
+`npm run dev` (tsx watch, testnet) or `npm start` (built `dist/`). **Both crash without
+real credentials** — see the credential problem above. `CI=1 npm start` boots the built
+server the same way `smoke` does. Only useful if you have a populated
+`config/serviceAccountKey.json`.
+
+## Test
+
+```bash
+npm run test        # 48 files, 618 tests, ~4.3s
+npx vitest run test/api/user.test.ts
+npx vitest run -t "Register"
+```
+
+Full CI sequence (CircleCI runs exactly this):
+
+```bash
+npm run lint && npm run build && CI=1 npm start &   # then wget /healthz
+npm run test
+```
+
+## Gotchas
+
+- **`/api` prefix mismatch.** `test/api/axiosist.ts` does `app.use('/api', allRoutes)`,
+  but `src/index.ts` mounts at `/`. So the same handler is `/api/users/self` in tests
+  and `/users/self` in production. `driver.mjs req` takes the production path and adds
+  the prefix, so you never write `/api` yourself — but existing test files do.
+- **Test JWTs are hardcoded.** `test/api/jwt.ts` signs with secret `'likecoin'`,
+  audience and issuer both `rinkeby.like.co`. Nothing in `config/` needs changing.
+- **`req` writes a throwaway `test/api/__driver.test.ts`** and deletes it in a `finally`.
+  The stub is installed via `vi.mock` in `test/setup.ts`, so it only exists inside the
+  vitest runtime — there is no way to drive the stubbed app from a plain node script.
+  If a crash ever leaves the file behind, delete it: it matches `test/**/*.test.ts` and
+  would be swept up by `npm run test` and `npm run lint`.
+- **`/misc/price` hits the live network.** It's the one smoke route that isn't hermetic;
+  it returns a real price and will fail offline.
+- **macOS prints a harmless `objc[...] Class GNotificationCenterDelegate is implemented
+  in both ...libgio-2.0.0.dylib` warning** on every node start, from `canvas` colliding
+  with Homebrew glib. Ignore it; pipe through `grep -v objc` if it's noisy.
+- **`npm run lint` runs `eslint --fix`** — it edits your working tree. Check
+  `git status` after.
+- **`no-console` is an error.** Existing `console.*` calls carry inline
+  `// eslint-disable-next-line no-console`.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `FirebaseAppError: Service account object must contain a string "project_id"` on startup | Set `CI=1`. `config/serviceAccountKey.json` is a tracked placeholder with empty credential fields. |
+| `npm run dev` loops "Failed running 'src/index.ts'. Waiting for file changes" | Same cause — tsx watch retries the crash forever. Kill with `pkill -f "tsx --watch src/index.ts"`. |
+| Route returns 500 under `smoke` / `CI=1` | Expected if it reads Firestore (`getCollection()` returns `{}` under CI). Use `driver.mjs req` instead. |
+| `driver.mjs req` returns `Cannot POST /api/...` 404 | Wrong path or method. Confirm against `grep -rn "router.post" src/routes/<surface>/`. |
+| Handler works via `req` but you need a fixture that doesn't exist | Add it to `test/data/*.json`; `test/stub/firebase.ts` reloads them before every test. |

--- a/.claude/skills/run-likecoin-api/driver.mjs
+++ b/.claude/skills/run-likecoin-api/driver.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * Driver for the likecoin-api-public Express server.
+ *
+ * Two modes, because there are two useful layers:
+ *
+ *   smoke  Boots the real server (src/index.ts) with CI=1 and probes it over
+ *          HTTP. Proves the process starts, routes are mounted, middleware
+ *          works. Firestore is stubbed out to {} under CI, so any handler
+ *          that reads the database returns 500 — that is expected.
+ *
+ *   req    Drives a single endpoint through test/api/axiosist.ts, which
+ *          rebuilds the app on the in-memory Firestore stub seeded from
+ *          test/data/*.json. This is the layer where business logic is
+ *          actually reachable. Implemented by generating a throwaway vitest
+ *          file, because the stub is installed via vi.mock in test/setup.ts
+ *          and only exists inside the vitest runtime.
+ *
+ * Run from the repo root:
+ *   node .claude/skills/run-likecoin-api/driver.mjs smoke
+ *   node .claude/skills/run-likecoin-api/driver.mjs req GET /users/id/testerman/min
+ *   node .claude/skills/run-likecoin-api/driver.mjs req GET /likernft/book/user/plus-reading/report --user testerman
+ *   node .claude/skills/run-likecoin-api/driver.mjs req POST /users/email/verify --body '{"email":"a@b.co"}'
+ */
+
+import { spawn } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const PORT = Number(process.env.PORT || 3000);
+const BASE = `http://127.0.0.1:${PORT}`;
+
+// Paths worth probing on a cold boot. `db` is the marker for "this handler
+// needs Firestore, so 500 under CI=1 is the correct answer, not a failure".
+const SMOKE_ROUTES = [
+  { path: '/healthz', expect: 200 },
+  { path: '/', expect: 302 },
+  { path: '/misc/price', expect: 200 },
+  { path: '/no-such-route', expect: 404 },
+  { path: '/users/id/testing/min', expect: 500, db: true },
+];
+
+function log(...a) { process.stdout.write(`${a.join(' ')}\n`); }
+
+async function waitForHealthz(isDead = () => false, timeoutMs = 60000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (isDead()) return false;
+    try {
+      const res = await fetch(`${BASE}/healthz`);
+      if (res.ok) return true;
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  return false;
+}
+
+async function smoke() {
+  // If anything already answers on the port, the child would die with
+  // EADDRINUSE while we happily probe the stale server. Refuse up front.
+  try {
+    await fetch(`${BASE}/healthz`, { signal: AbortSignal.timeout(1000) });
+    log(`FAIL: something already listens on ${BASE} — kill it first (pkill -f "tsx src/index.ts")`);
+    process.exitCode = 1;
+    return;
+  } catch { /* connection refused = port free, proceed */ }
+
+  log('booting: CI=1 IS_TESTNET=true npx tsx src/index.ts');
+  // CI=1 is load-bearing: src/util/firebase.ts calls admin.initializeApp() at
+  // import time unless it is set, and config/serviceAccountKey.json is a
+  // tracked placeholder whose credential fields are empty strings.
+  const child = spawn('npx', ['tsx', 'src/index.ts'], {
+    cwd: REPO,
+    env: { ...process.env, CI: '1', IS_TESTNET: 'true' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let serverLog = '';
+  child.stdout.on('data', (d) => { serverLog += d; });
+  child.stderr.on('data', (d) => { serverLog += d; });
+  // exitCode stays null on signal deaths, so track exit explicitly.
+  let exited = false;
+  child.on('exit', () => { exited = true; });
+
+  // A dead child can coexist with a passing /healthz if another server already
+  // owns the port (EADDRINUSE) — that would probe the wrong process.
+  const up = await waitForHealthz(() => exited);
+  if (exited || !up) {
+    log(exited
+      ? 'FAIL: server process exited before answering /healthz (port already in use?)'
+      : 'FAIL: server never answered /healthz');
+    log(serverLog);
+    if (!exited) child.kill('SIGKILL');
+    process.exitCode = 1;
+    return;
+  }
+
+  let failed = 0;
+  for (const r of SMOKE_ROUTES) {
+    const res = await fetch(BASE + r.path, { redirect: 'manual' });
+    const body = (await res.text()).replace(/\s+/g, ' ').slice(0, 90);
+    const ok = res.status === r.expect;
+    if (!ok) failed += 1;
+    const note = r.db ? '  (needs Firestore; 500 is expected under CI=1)' : '';
+    log(`${ok ? 'ok  ' : 'FAIL'} ${String(res.status).padEnd(4)} ${r.path.padEnd(28)} ${body}${note}`);
+  }
+
+  child.kill('SIGTERM');
+  await new Promise((resolve) => {
+    if (exited) { resolve(undefined); return; }
+    const t = setTimeout(resolve, 5000);
+    child.on('exit', () => { clearTimeout(t); resolve(undefined); });
+  });
+  if (!exited) child.kill('SIGKILL');
+  log(failed ? `\n${failed} route(s) off expectation` : '\nsmoke ok');
+  if (failed) process.exitCode = 1;
+}
+
+function parseReqArgs(argv) {
+  const [method, path, ...rest] = argv;
+  if (!method || !path) {
+    log('usage: driver.mjs req <METHOD> <path> [--user <id>] [--wallet <addr>] [--body <json>]');
+    log('note: <path> is the production path (/users/...). The driver adds the');
+    log('      /api prefix that test/api/axiosist.ts mounts routes under.');
+    process.exit(1);
+  }
+  const opts = { method: method.toUpperCase(), path };
+  for (let i = 0; i < rest.length; i += 2) {
+    const k = rest[i].replace(/^--/, '');
+    opts[k] = rest[i + 1];
+  }
+  return opts;
+}
+
+async function req(argv) {
+  const o = parseReqArgs(argv);
+  const outDir = mkdtempSync(join(tmpdir(), 'likeapi-driver-'));
+  const outFile = join(outDir, 'result.json');
+  const scratch = join(REPO, 'test/api/__driver.test.ts');
+
+  const claims = [];
+  if (o.user) claims.push(`user: ${JSON.stringify(o.user)}`);
+  if (o.wallet) claims.push(`wallet: ${JSON.stringify(o.wallet)}`);
+  const auth = claims.length ? `jwtSign({ ${claims.join(', ')} })` : 'undefined';
+  const body = o.body ? o.body : 'undefined';
+
+  // The scratch file lives in test/api/ so that ./axiosist and ./jwt resolve
+  // and test/setup.ts (which installs the Firestore stub) applies.
+  writeFileSync(scratch, `import { it } from 'vitest';
+import { writeFileSync } from 'node:fs';
+import axiosist from './axiosist';
+import { jwtSign } from './jwt';
+
+it('driver', async () => {
+  const token = ${auth};
+  const data = ${body};
+  const res = await axiosist.request({
+    method: ${JSON.stringify(o.method)},
+    url: ${JSON.stringify(`/api${o.path}`)},
+    headers: token ? { Authorization: \`Bearer \${token}\` } : {},
+    data,
+  }).catch((err: any) => err.response ?? { status: 0, data: String(err) });
+  writeFileSync(${JSON.stringify(outFile)}, JSON.stringify({ status: res.status, data: res.data }, null, 2));
+});
+`);
+
+  log(`${o.method} /api${o.path}${auth === 'undefined' ? '' : '  (authenticated)'}`);
+  let code;
+  try {
+    code = await new Promise((r) => {
+      const p = spawn('npx', ['vitest', 'run', 'test/api/__driver.test.ts', '--reporter=dot'], {
+        cwd: REPO, stdio: ['ignore', 'ignore', 'inherit'],
+      });
+      p.on('exit', r);
+    });
+  } finally {
+    // Must not survive: it sits in test/**/*.test.ts, so a leftover copy
+    // would be picked up by `npm run test` and `npm run lint`.
+    rmSync(scratch, { force: true });
+  }
+  if (existsSync(outFile)) {
+    log(readFileSync(outFile, 'utf8'));
+  } else {
+    log(`no result captured (vitest exited ${code})`);
+    process.exitCode = 1;
+  }
+  rmSync(outDir, { recursive: true, force: true });
+}
+
+const [mode, ...rest] = process.argv.slice(2);
+if (mode === 'smoke') await smoke();
+else if (mode === 'req') await req(rest);
+else {
+  log('usage: driver.mjs smoke');
+  log('       driver.mjs req <METHOD> <path> [--user <id>] [--wallet <addr>] [--body <json>]');
+  process.exitCode = 1;
+}


### PR DESCRIPTION
The server crash-loops on a fresh checkout because firebase.ts calls initializeApp() at import time against a gitignored, placeholder serviceAccountKey.json. Capture the CI=1 workaround (the only credential-free boot path, also used by CircleCI) and the axiosist stub layer where handler logic is reachable.

driver.mjs has two modes: `smoke` probes the real CI=1 server, `req` drives a single endpoint against the in-memory Firestore stub seeded from test/data.