### PR TITLE
♻️ Fund Irys pass-through instead of racy per-file top-ups

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -70,9 +70,6 @@ config.ARWEAVE_SPONSORED_DAILY_BYTES_LIMIT = 100 * 1024 * 1024; // 100MB
 // Cloud KMS cryptoKey resource name used to wrap content keys at rest in
 // Firestore. Empty = passthrough (dev/test store plaintext); prod sets this.
 config.ARWEAVE_KEY_KMS_NAME = process.env.ARWEAVE_KEY_KMS_NAME || '';
-// Fund this multiple of a single file's price when topping up the Irys node balance,
-// leaving a cushion so one stranded credit can't 402 the next upload.
-config.ARWEAVE_IRYS_FUND_MULTIPLIER = Number(process.env.ARWEAVE_IRYS_FUND_MULTIPLIER) || 2;
 // Optional pin for the Irys base-eth deposit address; asserted against /info. Empty
 // falls back to the built-in per-network default in the signer.
 config.ARWEAVE_IRYS_DEPOSIT_ADDRESS = process.env.ARWEAVE_IRYS_DEPOSIT_ADDRESS || '';

--- a/src/routes/arweave/index.ts
+++ b/src/routes/arweave/index.ts
@@ -148,7 +148,8 @@ router.post(
             isSponsored: true,
             sponsoredETH: ETH,
           });
-          await fundUploadIfNeeded(uploadId, ETH);
+          // Sponsored uploads carry no payment to pass through; the standing Irys
+          // balance buffer covers them.
         } catch (err) {
           await rollbackQuota(wallet, fileSize, ETH).catch((e) => {
             // eslint-disable-next-line no-console
@@ -158,7 +159,7 @@ router.post(
         }
       } else {
         uploadId = txHash;
-        await checkArweaveTxV2({
+        const { paidETH } = await checkArweaveTxV2({
           fileSize, ipfsHash, txHash, ETH, txToken,
         });
         try {
@@ -176,7 +177,7 @@ router.post(
           }
           throw error;
         }
-        await fundUploadIfNeeded(uploadId, ETH);
+        fundUploadIfNeeded(uploadId, paidETH);
       }
 
       // TODO: verify signatureData match filesize if possible

--- a/src/util/api/arweave/funding.ts
+++ b/src/util/api/arweave/funding.ts
@@ -12,17 +12,21 @@ export interface ReconcileResult {
   error?: string;
 }
 
-// Top up Irys for this upload, persisting the funding tx on the doc before notify so
-// a stranded credit is replayable, then marking it credited once notify succeeds.
-// No-op when the balance cushion already covers the upload (fund returns null).
-export async function fundUploadIfNeeded(uploadId: string, ETH: string): Promise<void> {
-  if (!ETH || ETH === '0') return;
-  const fundingTxHash = await fund(ETH, {
-    onSent: (h) => setArweaveTxFundingSent(uploadId, { fundingTxHash: h, fundingETH: ETH }),
-  });
-  // Funding + notify already succeeded; marking credited is best-effort since
-  // reconcile re-notifies idempotently and marks it later if this write fails.
-  if (fundingTxHash) await markArweaveTxFundingCredited(uploadId).catch(() => undefined);
+// Pass-through funding: forward the user's payment into the Irys balance in the background;
+// a standing buffer covers this upload, so nothing waits on confirmation. fundingStatus:'sent'
+// persists before notify so reconcile can replay; sponsored uploads (no paidETH) skip this.
+export function fundUploadIfNeeded(uploadId: string, paidETH?: string): void {
+  if (!paidETH || paidETH === '0') return;
+  fund(paidETH, {
+    onSent: (h) => setArweaveTxFundingSent(uploadId, { fundingTxHash: h, fundingETH: paidETH }),
+  })
+    .then(() => markArweaveTxFundingCredited(uploadId).catch(() => undefined))
+    .catch((err) => {
+      // Deposit send/notify failed. The buffer still covers uploads; the funding tx (if
+      // broadcast) stays fundingStatus:'sent' for reconcile to replay. Log so it's visible.
+      // eslint-disable-next-line no-console
+      console.error(`Irys pass-through funding failed for ${uploadId}:`, (err as Error).message);
+    });
 }
 
 // Replay upload docs whose Irys funding was sent but never confirmed credited.

--- a/src/util/api/arweave/index.ts
+++ b/src/util/api/arweave/index.ts
@@ -77,7 +77,8 @@ export async function checkArweaveTxV2({
       if (fileSize > ARWEAVE_MAX_SIZE_V2) {
         throw new ValidationError('FILE_SIZE_LIMIT_EXCEEDED');
       }
-      break;
+      // The verified on-chain payment, forwarded into Irys as pass-through funding.
+      return { paidETH: formatEther(value) };
     }
     default:
       throw new ValidationError('INVALID_TX_TOKEN');

--- a/src/util/arweave/signer.ts
+++ b/src/util/arweave/signer.ts
@@ -10,12 +10,9 @@ import {
 import { privateKeyToAccount } from 'viem/accounts';
 
 import { BUNDLR_MATIC_WALLET_PRIVATE_KEY } from '../../../config/secret';
-import {
-  ARWEAVE_IRYS_FUND_MULTIPLIER,
-  ARWEAVE_IRYS_DEPOSIT_ADDRESS,
-} from '../../../config/config';
+import { ARWEAVE_IRYS_DEPOSIT_ADDRESS } from '../../../config/config';
 import { getEVMClient, createEVMWalletClient } from '../evm/client';
-import { sleep, scaleBigInt } from '../misc';
+import { sleep } from '../misc';
 import { IS_TESTNET } from '../../constant';
 
 // Irys node the base-eth balance/upload settles against. We talk to it over REST
@@ -32,19 +29,11 @@ const DEFAULT_IRYS_DEPOSIT_ADDRESS = IS_TESTNET
   : '0x62459D34409ABA55b85DD28284cc4e57e0C8ADea';
 const EXPECTED_DEPOSIT_ADDRESS = ARWEAVE_IRYS_DEPOSIT_ADDRESS || DEFAULT_IRYS_DEPOSIT_ADDRESS;
 
-// Fund a multiple of a single file's price when topping up, so one stranded credit
-// can't drop the node balance below the next upload's price and 402 it. Floor at 1:
-// a sub-1 multiple would top up below the upload's own price and 402 it immediately.
-// The `|| 2` also covers the key missing from a deployed config.js: Number(undefined)
-// is NaN, and NaN would otherwise survive Math.max and poison the multiplier.
-const FUND_MULTIPLIER = Math.max(1, Number(ARWEAVE_IRYS_FUND_MULTIPLIER) || 2);
-
 let signer: TypedEthereumSigner | null = null;
 let fundingWalletClient: WalletClient<HttpTransport, Chain, LocalAccount> | undefined;
 let depositAddress: string | undefined;
 
-// Serialize funding ops so concurrent uploads don't race the funding wallet nonce,
-// and so each queued top-up re-checks the balance after the previous credit lands.
+// Serialize funding ops so concurrent uploads don't race the funding wallet nonce.
 let fundingLock: Promise<unknown> = Promise.resolve();
 
 function normalizePrivateKey(key: string): `0x${string}` {
@@ -109,16 +98,6 @@ export async function getPrice(bytes: number): Promise<bigint> {
   return BigInt(String(data).trim().replace(/^"|"$/g, '').split('.')[0]);
 }
 
-// Node-credited balance of our funding wallet in atomic units (wei).
-async function getLoadedBalance(): Promise<bigint> {
-  const account = getFundingWalletClient().account.address;
-  const { data } = await axios.get(`${IRYS_NODE_ENDPOINT}/account/balance/${IRYS_TOKEN}`, {
-    params: { address: account },
-  });
-  const raw = (data && typeof data === 'object') ? (data.balance ?? '0') : data;
-  return BigInt(String(raw).split('.')[0] || '0');
-}
-
 // Notify the indexer that `txHash` funded the node, retrying since the credit is
 // what strands. Idempotent: a re-notify of an already-credited tx is treated as
 // success (the sweep/reconcile relies on this).
@@ -145,53 +124,49 @@ export async function notifyIrys(txHash: string): Promise<void> {
 }
 
 // Send a no-calldata ETH transfer (sidesteps the SDK getFee()/createTx() gas-timing
-// bug), wait for 2 confirmations, persist via onSent, then notify the node.
+// bug), persist via onSent right after broadcast, then confirm and notify the node.
 async function performFunding(
-  requiredWei: bigint,
-  topUpWei: bigint,
+  depositWei: bigint,
   onSent?: (txHash: string) => Promise<void> | void,
-): Promise<string | null> {
-  // A top-up queued ahead of us may have already credited enough cushion.
-  const balance = await getLoadedBalance();
-  if (balance >= requiredWei) return null;
+): Promise<string> {
   const walletClient = getFundingWalletClient();
   const to = await getIrysDepositAddress();
   const txHash = await walletClient.sendTransaction({
     to: to as `0x${string}`,
-    value: topUpWei,
+    value: depositWei,
   });
-  await getEVMClient().waitForTransactionReceipt({ hash: txHash, confirmations: 2 });
+  // Persist before the confirmation wait: funds have already left the wallet, so a
+  // crash here must still leave a replayable record for reconcile.
+  let persistError: unknown;
   if (onSent) {
     try {
       await onSent(txHash);
     } catch (err) {
-      // Persist failed, so reconcile can't find this deposit. Notify now (best
-      // effort) to credit it immediately, then surface the persistence error.
-      await notifyIrys(txHash).catch(() => undefined);
-      throw err;
+      persistError = err;
     }
+  }
+  await getEVMClient().waitForTransactionReceipt({ hash: txHash, confirmations: 2 });
+  if (persistError) {
+    // Persist failed, so reconcile can't find this deposit. Notify now (best
+    // effort) to credit it immediately, then surface the persistence error.
+    await notifyIrys(txHash).catch(() => undefined);
+    throw persistError;
   }
   await notifyIrys(txHash);
   return txHash;
 }
 
-// Top up the Irys node balance to cover `requiredAmount` ETH, funding FUND_MULTIPLIER×
-// the price as a cushion. `onSent` fires after the send confirms but before the indexer
-// notify, so callers can durably persist the funding tx id (persist-before-notify).
+// Forward `depositAmount` ETH (a user's upload payment) into the Irys node balance —
+// pass-through funding that refills the standing buffer covering uploads. `onSent`
+// fires right after broadcast so callers can durably persist the funding tx id.
 export async function fund(
-  requiredAmount: string,
+  depositAmount: string,
   { onSent }: {
     onSent?: (txHash: string) => Promise<void> | void;
   } = {},
-): Promise<string | null> {
-  const fundAmountWei = parseEther(requiredAmount);
-  const currentBalance = await getLoadedBalance();
-
-  // Cushion already covers this upload — skip funding to keep the tx (and stranding) count down.
-  if (currentBalance >= fundAmountWei) return null;
-
-  const topUpWei = scaleBigInt(fundAmountWei, FUND_MULTIPLIER);
-  const run = fundingLock.then(() => performFunding(fundAmountWei, topUpWei, onSent));
+): Promise<string> {
+  const depositWei = parseEther(depositAmount);
+  const run = fundingLock.then(() => performFunding(depositWei, onSent));
   // Keep the lock chained regardless of this send's outcome.
   fundingLock = run.catch(() => undefined);
   return run;


### PR DESCRIPTION
fund() checked the node balance and skipped when it covered the current file. Under a batch, concurrent uploads each read the same balance, each judged it sufficient, all skipped, then all drained — 402ing the later ones. That check-then-act on a shared balance was the race.

Remove the balance check entirely: every BASEETH upload now forwards the user's verified on-chain payment (checkArweaveTxV2 returns it) straight into the Irys balance, in the background so the request no longer waits on a confirmation. A standing balance buffer, kept topped operationally, covers the actual upload; the deposit refills it. Sponsored uploads carry no payment and are covered by the buffer alone.

Per-upload durability (fundingStatus:'sent'→'credited') is unchanged, so a stranded background deposit stays replayable by the reconcile job — which must be scheduled now that deposits are non-awaited. Drops the now-dead FUND_MULTIPLIER / scaleBigInt cushion logic and getLoadedBalance.