### PR TITLE
🐛 Store user session timestamps as Firestore Timestamp

### DIFF
--- a/src/routes/users/getInfo.ts
+++ b/src/routes/users/getInfo.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import {
   userCollection as dbRef,
+  FieldValue,
 } from '../../util/firebase';
 import { jwtAuth } from '../../middleware/jwt';
 import { validateParams } from '../../middleware/validate';
@@ -33,7 +34,8 @@ router.get('/self', jwtAuth('read'), async (req, res, next) => {
       await dbRef.doc(username).collection('session').doc(req.user.jti).set({
         lastAccessedUserAgent: req.headers['user-agent'] || 'unknown',
         lastAccessedIP: req.headers['x-real-ip'] || req.ip,
-        lastAccessedTs: Date.now(),
+        lastAccessedTimestamp: FieldValue.serverTimestamp(),
+        lastAccessedTs: FieldValue.delete(),
       }, { merge: true });
     } else {
       res.sendStatus(404);

--- a/src/util/api/users/index.ts
+++ b/src/util/api/users/index.ts
@@ -15,6 +15,7 @@ import {
 import {
   userCollection as dbRef,
   configCollection,
+  FieldValue,
 } from '../../firebase';
 import { ValidationError } from '../../ValidationError';
 import { jwtSign } from '../../jwt';
@@ -76,10 +77,10 @@ export async function setAuthCookies(req, res, { user, platform }) {
   await dbRef.doc(user).collection('session').doc(jwtid).create({
     lastAccessedUserAgent: req.headers['user-agent'] || 'unknown',
     lastAccessedIP: req.headers['x-real-ip'] || req.ip,
-    lastAccessedTs: Date.now(),
+    lastAccessedTimestamp: FieldValue.serverTimestamp(),
     jwtid,
     buttonJwtId,
-    ts: Date.now(),
+    timestamp: FieldValue.serverTimestamp(),
   });
 }
 


### PR DESCRIPTION
Session docs wrote Date.now() numbers, so the fields could not back a Firestore TTL policy or timestamp queries. Rename ts/lastAccessedTs to timestamp/lastAccessedTimestamp per the *Ts-is-millis convention, and retire the stale number field when refreshing legacy docs.