### PR TITLE
✨ Return description in book purchase commission data

### DIFF
--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -94,6 +94,7 @@ export interface BookPurchaseCommission {
   amountTotal: number;
   amount: number;
   currency: string;
+  description?: string;
   buyerEmail?: string;
   timestamp?: { toMillis: () => number };
 }

--- a/src/util/ValidationHelper.ts
+++ b/src/util/ValidationHelper.ts
@@ -400,6 +400,7 @@ export function filterBookPurchaseCommission({
   amountTotal,
   amount,
   currency,
+  description,
   buyerEmail,
   timestamp,
 }: BookPurchaseCommission, { includeBuyerEmail = false } = {}): BookPurchaseCommissionFiltered {
@@ -415,6 +416,7 @@ export function filterBookPurchaseCommission({
     amountTotal,
     amount,
     currency,
+    description,
     ...(includeBuyerEmail && buyerEmail ? { buyerEmail } : {}),
     timestamp: timestamp?.toMillis(),
   };

--- a/src/util/api/likernft/book/schemas.ts
+++ b/src/util/api/likernft/book/schemas.ts
@@ -460,6 +460,8 @@ export const BookPurchaseCommissionFilteredSchema = z.object({
   amountTotal: z.number(),
   amount: z.number(),
   currency: z.string(),
+  // Backfilled commission docs may have no classId, only a description.
+  description: z.string().optional(),
   buyerEmail: z.string().optional(),
   timestamp: z.number().optional(),
 });


### PR DESCRIPTION
Backfilled commission docs may carry only a description and no classId, so expose it through the filter and response schema.