### PR TITLE
✨ Add GCS-direct upload path for protected ebooks

### DIFF
--- a/src/routes/arweave/index.ts
+++ b/src/routes/arweave/index.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import uuidv4 from 'uuid/v4';
 import {
+  ARWEAVE_MAX_SIZE_V2,
   checkArweaveTxV2,
   estimateUploadToArweaveV2,
   pushArweaveSingleFileToIPFS,
@@ -14,19 +15,30 @@ import {
 import { getPublicKey, signData as signArweaveData } from '../../util/arweave/signer';
 import {
   createNewArweaveTx,
+  createNewGcsUploadTx,
   getArweaveTxInfo,
   isArweaveTxOwner,
+  markGcsTxCompleted,
   updateArweaveTxStatus,
   rotateArweaveTxAccessToken,
   resolveArweaveTxKey,
 } from '../../util/api/arweave/tx';
-import { getRemainingQuota, checkAndReserveQuota, rollbackQuota } from '../../util/api/arweave/quota';
+import { getRemainingQuota, withReservedQuota } from '../../util/api/arweave/quota';
 import { reconcilePendingIrysFunding, fundUploadIfNeeded } from '../../util/api/arweave/funding';
-import { ingestProtectedContent } from '../../util/api/arweave/ingest';
-import { getProtectedContentUri } from '../../util/gcloudStorage';
+import {
+  deleteStagedObject,
+  getStagedUploadSignedUrl,
+  ingestProtectedContent,
+  promoteStagedObject,
+  verifyStagedObject,
+} from '../../util/api/arweave/ingest';
+import { getProtectedContentUri, isEbookProtectedBucketEnabled } from '../../util/gcloudStorage';
 import {
   ArweaveEstimateBodySchema,
   ArweaveEstimateResponseSchema,
+  ArweaveGcsFinalizeResponseSchema,
+  ArweaveGcsUploadInitBodySchema,
+  ArweaveGcsUploadInitResponseSchema,
   ArweaveRegisterBodySchema,
   ArweaveRegisterResponseSchema,
   ArweaveSignPaymentBodySchema,
@@ -45,6 +57,10 @@ import { sendValidatedJSON } from '../../util/ValidationHelper';
 import { ValidationError } from '../../util/ValidationError';
 
 const router = Router();
+
+function getArweaveLinkV2Url(txHash: string): string {
+  return `https://${API_HOSTNAME}/arweave/v2/link/${txHash}`;
+}
 
 router.get(
   '/v2/public_key',
@@ -138,10 +154,9 @@ router.post(
 
       if (isSponsored) {
         const { wallet } = req.user!;
-        await checkAndReserveQuota(wallet, fileSize, ETH);
-        try {
-          uploadId = `sponsored-${uuidv4()}`;
-          token = await createNewArweaveTx(uploadId, {
+        uploadId = `sponsored-${uuidv4()}`;
+        token = await withReservedQuota(wallet, fileSize, ETH, async () => {
+          const newToken = await createNewArweaveTx(uploadId, {
             ipfsHash,
             fileSize,
             ownerWallet: wallet,
@@ -150,13 +165,8 @@ router.post(
           });
           // Sponsored uploads carry no payment to pass through; the standing Irys
           // balance buffer covers them.
-        } catch (err) {
-          await rollbackQuota(wallet, fileSize, ETH).catch((e) => {
-            // eslint-disable-next-line no-console
-            console.error('Failed to rollback quota', e);
-          });
-          throw err;
-        }
+          return newToken;
+        });
       } else {
         uploadId = txHash;
         const { paidETH } = await checkArweaveTxV2({
@@ -232,7 +242,7 @@ router.post(
         fileSHA256,
       });
       sendValidatedJSON(res, ArweaveRegisterResponseSchema, {
-        link: `https://${API_HOSTNAME}/arweave/v2/link/${txHash}`,
+        link: getArweaveLinkV2Url(txHash),
         token,
         accessToken,
         isRequireAuth,
@@ -285,6 +295,88 @@ router.post(
   },
 );
 
+// GCS-direct upload (ADR 0001 Phase 3, no-Arweave path): protected books put
+// plaintext straight into the private CMEK bucket via a signed resumable URL.
+// Inert until EBOOK_PROTECTED_BUCKET is configured — that env is the
+// kill-switch, so the endpoints ship dark.
+router.post(
+  '/v2/gcs/upload_init',
+  jwtAuth('write:iscn'),
+  validateBody(ArweaveGcsUploadInitBodySchema),
+  async (req, res, next) => {
+    try {
+      if (!isEbookProtectedBucketEnabled()) throw new ValidationError('PROTECTED_BUCKET_NOT_CONFIGURED', 501);
+      const {
+        fileSize, fileSHA256, contentType, fileName,
+      } = req.body;
+      if (fileSize > ARWEAVE_MAX_SIZE_V2) throw new ValidationError('FILE_SIZE_LIMIT_EXCEEDED');
+      const { wallet } = req.user;
+      const id = `gcs-${uuidv4()}`;
+      // GCS-direct skips the Arweave fee entirely, so the sponsored-upload
+      // quota is all that stands between write:iscn and unlimited free
+      // private storage.
+      const uploadUrl = await withReservedQuota(wallet, fileSize, '0', async () => {
+        await createNewGcsUploadTx(id, {
+          fileSize, fileSHA256, contentType, fileName, ownerWallet: wallet,
+        });
+        return getStagedUploadSignedUrl(id, contentType);
+      });
+      sendValidatedJSON(res, ArweaveGcsUploadInitResponseSchema, { id, uploadUrl });
+      publisher.publish(PUBSUB_TOPIC_MISC, req, {
+        logType: 'arweaveGcsUploadInitV2',
+        wallet,
+        txHash: id,
+        fileSize,
+        contentType,
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.post(
+  '/v2/gcs/finalize/:txHash',
+  jwtAuth('write:iscn'),
+  validateParams(ArweaveTxHashParamsSchema),
+  async (req, res, next) => {
+    try {
+      if (!isEbookProtectedBucketEnabled()) throw new ValidationError('PROTECTED_BUCKET_NOT_CONFIGURED', 501);
+      const { txHash } = req.params as Record<string, string>;
+      const tx = await getArweaveTxInfo(txHash);
+      if (!tx) throw new ValidationError('TX_NOT_FOUND', 404);
+      if (tx.source !== 'gcs') throw new ValidationError('NOT_GCS_UPLOAD', 400);
+      if (!(await isArweaveTxOwner(req.user.wallet, tx.ownerWallet))) throw new ValidationError('NOT_OWNER', 403);
+      if (tx.status !== 'pending') throw new ValidationError('TX_ALREADY_REGISTERED', 409);
+      const { computedSHA256 } = await verifyStagedObject(txHash, {
+        fileSize: tx.fileSize,
+        fileSHA256: tx.fileSHA256,
+      });
+      const contentBucketPath = await promoteStagedObject(txHash, {
+        contentType: tx.contentType || 'application/octet-stream',
+        fileSHA256: computedSHA256,
+      });
+      await markGcsTxCompleted(txHash, { contentBucketPath });
+      sendValidatedJSON(res, ArweaveGcsFinalizeResponseSchema, {
+        id: txHash,
+        link: getArweaveLinkV2Url(txHash),
+      });
+      // Best-effort and self-swallowing, so it stays off the response path;
+      // only the mark-complete-before-delete ordering matters.
+      deleteStagedObject(txHash);
+      publisher.publish(PUBSUB_TOPIC_MISC, req, {
+        logType: 'arweaveGcsFinalizeV2',
+        wallet: req.user.wallet,
+        txHash,
+        contentBucketPath,
+        fileSHA256: computedSHA256,
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
 router.get(
   '/v2/link/:txHash',
   jwtOptionalAuth('read:iscn'),
@@ -311,7 +403,10 @@ router.get(
           throw new ValidationError('INVALID_TOKEN', 403);
         }
       }
-      const link = new URL(`${ARWEAVE_GATEWAY}/${arweaveId}`);
+      // GCS-direct docs have no arweaveId: interpolating undefined would mint
+      // a syntactically valid gateway/undefined URL that every consumer down
+      // to the ebook-cors cache key would silently accept.
+      const link = arweaveId ? new URL(`${ARWEAVE_GATEWAY}/${arweaveId}`) : null;
       // A browser's */*;q=0.8 satisfies accepts('application/json'), so plain negotiation
       // hands it the key below. Take the JSON branch only when JSON outranks HTML; every
       // programmatic caller (*/*, no header, axios, explicit JSON) still lands there.
@@ -320,7 +415,7 @@ router.get(
         // Referer chain and the gateway's access logs. Only the JSON branch may carry it
         // (ebook-cors reads it back off `link`).
         const key = await resolveArweaveTxKey(tx, txHash);
-        if (key) {
+        if (key && link) {
           link.searchParams.set('key', key);
         }
         // Advertise the private-bucket plaintext copy (ADR 0001 Phase 3) so
@@ -331,11 +426,13 @@ router.get(
           arweaveId,
           txHash,
           key,
-          link: link.toString(),
+          ...(link ? { link: link.toString() } : {}),
           ...(contentUri ? { contentUri, contentType: tx.contentType } : {}),
         });
         return;
       }
+      // No public copy exists to redirect a browser to.
+      if (!link) throw new ValidationError('NO_PUBLIC_COPY', 404);
       res.redirect(link.toString());
     } catch (error) {
       next(error);

--- a/src/types/transaction.d.ts
+++ b/src/types/transaction.d.ts
@@ -30,6 +30,8 @@ export interface ArweaveTxData {
   txHash?: string;
   iscnId?: string;
   status?: string;
+  source?: 'gcs'; // set only by GCS-direct uploads; absent = Arweave
+  fileName?: string;
   ts?: number;
   token?: string;
   ipfsHash?: string;

--- a/src/util/api/arweave/ingest.ts
+++ b/src/util/api/arweave/ingest.ts
@@ -3,7 +3,12 @@ import { Transform } from 'stream';
 import { pipeline } from 'stream/promises';
 import { ARWEAVE_GATEWAYS } from '../../../constant';
 import { fetchStreamWithFallback } from '../../fetchStream';
-import { getEbookProtectedBucket, isEbookProtectedBucketEnabled } from '../../gcloudStorage';
+import {
+  getEbookProtectedBucket,
+  getProtectedUploadSignedUrl,
+  isEbookProtectedBucketEnabled,
+} from '../../gcloudStorage';
+import { ValidationError } from '../../ValidationError';
 import { ARWEAVE_MAX_SIZE_V2 } from './index';
 import { markArweaveTxIngested } from './tx';
 
@@ -87,6 +92,96 @@ function createHashTransform(hash: crypto.Hash): Transform {
   });
 }
 
+// txHash doubles as the object name; callers only ever mint an on-chain hash,
+// sponsored-<uuid> or gcs-<uuid>, so reject anything that could traverse paths
+// or collide with the staging prefix. Every staging-path composition goes
+// through here so all call sites share the same defense.
+function stagedObjectPath(txHash: string): string {
+  if (!/^[A-Za-z0-9_-]+$/.test(txHash)) throw new ValidationError('INVALID_TX_HASH');
+  return `${STAGING_PREFIX}${txHash}`;
+}
+
+// Staging-layout knowledge stays in this module: routes mint the id, this
+// composes the object path the browser's resumable upload writes to.
+export function getStagedUploadSignedUrl(
+  txHash: string,
+  contentType: string,
+): Promise<string> {
+  return getProtectedUploadSignedUrl(stagedObjectPath(txHash), contentType);
+}
+
+/**
+ * Verify a client-staged object (GCS-direct flow) against the size and
+ * plaintext hash declared at upload_init. The signed URL alone bounds neither,
+ * so both checks run here before the object can be promoted. Mismatches leave
+ * staging in place — the age-1 lifecycle rule sweeps it.
+ */
+export async function verifyStagedObject(txHash: string, {
+  fileSize,
+  fileSHA256,
+}: {
+  fileSize?: number;
+  fileSHA256?: string;
+}): Promise<{ computedSHA256: string }> {
+  const file = getEbookProtectedBucket().file(stagedObjectPath(txHash));
+  let stagedSize: number;
+  try {
+    const [metadata] = await file.getMetadata();
+    stagedSize = Number(metadata.size);
+  } catch (error) {
+    if ((error as { code?: number }).code === 404) {
+      throw new ValidationError('STAGED_FILE_NOT_FOUND', 404);
+    }
+    throw error;
+  }
+  if (fileSize && stagedSize !== fileSize) {
+    throw new ValidationError('FILE_SIZE_MISMATCH');
+  }
+  const hash = crypto.createHash('sha256');
+  for await (const chunk of file.createReadStream()) hash.update(chunk);
+  const computedSHA256 = hash.digest('hex');
+  if (fileSHA256 && fileSHA256.toLowerCase() !== computedSHA256) {
+    throw new ValidationError('PLAINTEXT_HASH_MISMATCH');
+  }
+  return { computedSHA256 };
+}
+
+// Promote a fully-verified staged object to its final key-free path, stamping
+// provenance metadata. Never deletes staging — callers own that cleanup, since
+// the legacy ingest sweeps it in a finally while finalize deletes on success.
+export async function promoteStagedObject(txHash: string, {
+  contentType,
+  fileSHA256,
+  arweaveId,
+  ipfsHash,
+}: {
+  contentType: string;
+  fileSHA256: string;
+  arweaveId?: string;
+  ipfsHash?: string;
+}): Promise<string> {
+  const bucket = getEbookProtectedBucket();
+  const contentBucketPath = txHash;
+  await bucket.file(stagedObjectPath(txHash)).copy(bucket.file(contentBucketPath), {
+    contentType,
+    metadata: {
+      ...(arweaveId ? { arweaveId } : {}),
+      ...(ipfsHash ? { ipfsHash } : {}),
+      fileSHA256,
+    },
+  });
+  return contentBucketPath;
+}
+
+// Best-effort staging cleanup after a successful promote; a failure is
+// swallowed because the staging lifecycle rule sweeps leftovers anyway.
+export async function deleteStagedObject(txHash: string): Promise<void> {
+  await getEbookProtectedBucket()
+    .file(stagedObjectPath(txHash))
+    .delete({ ignoreNotFound: true })
+    .catch(() => undefined);
+}
+
 /**
  * Ingest a protected upload into the private CMEK bucket (ADR 0001 Phase 3),
  * storing plaintext-at-rest under a key-free path. No-op when the bucket is
@@ -107,16 +202,13 @@ export async function ingestProtectedContent(txHash: string, {
   fileSHA256?: string;
 }): Promise<{ contentBucketPath: string; fileSHA256: string } | null> {
   if (!isEbookProtectedBucketEnabled() || !arweaveId || !key) return null;
-  // txHash is the object name; callers only ever mint an on-chain hash or a
-  // sponsored-<uuid>, so reject anything that could collide with STAGING_PREFIX.
-  if (!/^[A-Za-z0-9_-]+$/.test(txHash)) throw new Error('INVALID_TX_HASH');
   // Ciphertext is plaintext + 28 bytes; fileSize may be either, so pad 1MB.
   const maxContentLength = (fileSize || ARWEAVE_MAX_SIZE_V2) + (1024 * 1024);
   // Throws INVALID_CONTENT_KEY before any network or storage work happens.
   const decrypt = createGcmDecryptTransform(key);
   const hash = crypto.createHash('sha256');
   const bucket = getEbookProtectedBucket();
-  const stagingFile = bucket.file(`${STAGING_PREFIX}${txHash}`);
+  const stagingFile = bucket.file(stagedObjectPath(txHash));
   const { stream, contentType: fetchedContentType } = await fetchStreamWithFallback(
     ARWEAVE_GATEWAYS.map((gateway) => `${gateway}${arweaveId}`),
     { timeout: DOWNLOAD_TIMEOUT_MS, maxContentLength },
@@ -133,14 +225,11 @@ export async function ingestProtectedContent(txHash: string, {
     if (fileSHA256 && fileSHA256.toLowerCase() !== computedSHA256) {
       throw new Error('PLAINTEXT_HASH_MISMATCH');
     }
-    const contentBucketPath = txHash;
-    await stagingFile.copy(bucket.file(contentBucketPath), {
+    const contentBucketPath = await promoteStagedObject(txHash, {
       contentType,
-      metadata: {
-        arweaveId,
-        ...(ipfsHash ? { ipfsHash } : {}),
-        fileSHA256: computedSHA256,
-      },
+      fileSHA256: computedSHA256,
+      arweaveId,
+      ipfsHash,
     });
     await markArweaveTxIngested(txHash, {
       contentBucketPath,

--- a/src/util/api/arweave/quota.ts
+++ b/src/util/api/arweave/quota.ts
@@ -108,3 +108,23 @@ export async function rollbackQuota(
     }, { merge: true });
   });
 }
+
+// Reserve quota, run fn, and roll the reservation back (best-effort) when fn
+// throws. The reserve/rollback pairing lives here so handlers cannot forget it.
+export async function withReservedQuota<T>(
+  wallet: string,
+  fileSize: number,
+  ethCost: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  await checkAndReserveQuota(wallet, fileSize, ethCost);
+  try {
+    return await fn();
+  } catch (err) {
+    await rollbackQuota(wallet, fileSize, ethCost).catch((e) => {
+      // eslint-disable-next-line no-console
+      console.error('Failed to rollback quota', e);
+    });
+    throw err;
+  }
+}

--- a/src/util/api/arweave/schemas.ts
+++ b/src/util/api/arweave/schemas.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+const Sha256HexSchema = z.string().regex(/^[0-9a-f]{64}$/i);
+
 export const ArweaveEstimateBodySchema = z.object({
   fileSize: z.coerce.number().int().positive(),
   ipfsHash: z.string().optional(),
@@ -19,11 +21,30 @@ export const ArweaveRegisterBodySchema = z.object({
   token: z.string().optional(),
   key: z.string().optional(),
   isRequireAuth: z.boolean().optional(),
-  fileSHA256: z.string().regex(/^[0-9a-f]{64}$/i).optional(),
+  fileSHA256: Sha256HexSchema.optional(),
 });
 
 export const ArweaveTxHashParamsSchema = z.object({
   txHash: z.string().min(1),
+});
+
+// GCS-direct upload (ADR 0001 Phase 3, no-Arweave path). The protected tier
+// only ever holds ebooks, so contentType is a closed set.
+export const ArweaveGcsUploadInitBodySchema = z.object({
+  fileSize: z.coerce.number().int().positive(),
+  fileSHA256: Sha256HexSchema,
+  contentType: z.enum(['application/epub+zip', 'application/pdf']),
+  fileName: z.string().min(1).max(256).optional(),
+});
+
+export const ArweaveGcsUploadInitResponseSchema = z.object({
+  id: z.string(),
+  uploadUrl: z.string().url(),
+});
+
+export const ArweaveGcsFinalizeResponseSchema = z.object({
+  id: z.string(),
+  link: z.string().url(),
 });
 
 export const ArweaveEstimateResponseSchema = z.object({
@@ -59,7 +80,9 @@ export const ArweaveLinkResponseSchema = z.object({
   arweaveId: z.string().optional(),
   txHash: z.string().optional(),
   key: z.string().optional(),
-  link: z.string(),
+  // Absent for GCS-direct docs, which have no public Arweave copy; consumers
+  // (ebook-cors parseNFTMetadataURL) already guard on `if (data.link)`.
+  link: z.string().optional(),
   contentUri: z.string().optional(),
   contentType: z.string().optional(),
 });

--- a/src/util/api/arweave/tx.ts
+++ b/src/util/api/arweave/tx.ts
@@ -33,6 +33,54 @@ export async function createNewArweaveTx(docId: string, {
   return token;
 }
 
+// GCS-direct upload doc (ADR 0001 Phase 3, no-Arweave path): no content key
+// ever exists, and no legacy `token` — the flow is JWT-owner-gated end to end.
+// fileSHA256 is the client-declared plaintext anchor finalize verifies against.
+export async function createNewGcsUploadTx(docId: string, {
+  fileSize,
+  fileSHA256,
+  contentType,
+  fileName,
+  ownerWallet,
+}: {
+  fileSize: number;
+  fileSHA256: string;
+  contentType: string;
+  fileName?: string;
+  ownerWallet: string;
+}): Promise<void> {
+  const data: ArweaveTxData = {
+    source: 'gcs',
+    status: 'pending',
+    fileSize,
+    fileSHA256: fileSHA256.toLowerCase(),
+    contentType,
+    ...(fileName ? { fileName } : {}),
+    ownerWallet,
+    timestamp: FieldValue.serverTimestamp(),
+    lastUpdateTimestamp: FieldValue.serverTimestamp(),
+  };
+  await iscnArweaveTxCollection.doc(docId).create(data);
+}
+
+// Complete a GCS-direct upload: the ingest markers plus the lifecycle fields
+// legacy docs get from updateArweaveTxStatus() at register (status,
+// isRequireAuth, accessToken) — this flow never calls register, and without
+// isRequireAuth the link endpoint would serve the doc unauthenticated.
+export async function markGcsTxCompleted(txHash: string, {
+  contentBucketPath,
+}: {
+  contentBucketPath: string;
+}): Promise<void> {
+  await iscnArweaveTxCollection.doc(txHash).update({
+    status: 'complete',
+    isRequireAuth: true,
+    accessToken: uuidv4(),
+    contentBucketPath,
+    lastUpdateTimestamp: FieldValue.serverTimestamp(),
+  });
+}
+
 export async function getArweaveTxInfo(txHash: string): Promise<ArweaveTxData | undefined> {
   const doc = await iscnArweaveTxCollection.doc(txHash).get();
   return doc.data();

--- a/src/util/gcloudStorage.ts
+++ b/src/util/gcloudStorage.ts
@@ -30,4 +30,24 @@ export function getEbookProtectedBucket(): Bucket {
   return ebookProtectedBucket;
 }
 
+// TTL only covers the resumable-session initiation POST; the session URI GCS
+// hands back stays valid on its own (~1 week) for the actual byte PUTs.
+const PROTECTED_UPLOAD_URL_TTL_MS = 15 * 60 * 1000;
+
+// v4 signed URL letting the publisher browser start a resumable upload of one
+// specific object with a pinned content type. Single-path scope: the URL can
+// only ever create/replace `objectPath`, nothing else in the bucket.
+export async function getProtectedUploadSignedUrl(
+  objectPath: string,
+  contentType: string,
+): Promise<string> {
+  const [url] = await getEbookProtectedBucket().file(objectPath).getSignedUrl({
+    version: 'v4',
+    action: 'resumable',
+    expires: Date.now() + PROTECTED_UPLOAD_URL_TTL_MS,
+    contentType,
+  });
+  return url;
+}
+
 export default storage;


### PR DESCRIPTION
- /arweave/v2/gcs/upload_init + finalize: browser uploads plaintext via a single-object signed resumable URL into the private CMEK bucket, then finalize verifies size + SHA256 and promotes to the key-free path
- Ships dark: 501 until EBOOK_PROTECTED_BUCKET is configured; sponsored quota still gates the free storage
- GCS-direct docs have no Arweave copy: /v2/link serves contentUri only and 404s instead of minting a gateway/undefined URL
- withReservedQuota pairs reserve/rollback so handlers cannot forget it