### PR TITLE
🐛 Reserve Irys funding nonces from the shared counter

### DIFF
--- a/src/util/arweave/signer.ts
+++ b/src/util/arweave/signer.ts
@@ -12,6 +12,7 @@ import { privateKeyToAccount } from 'viem/accounts';
 import { BUNDLR_MATIC_WALLET_PRIVATE_KEY } from '../../../config/secret';
 import { ARWEAVE_IRYS_DEPOSIT_ADDRESS } from '../../../config/config';
 import { getEVMClient, createEVMWalletClient } from '../evm/client';
+import { sendTransactionWithNonce } from '../evm/tx';
 import { sleep } from '../misc';
 import { IS_TESTNET } from '../../constant';
 
@@ -33,7 +34,8 @@ let signer: TypedEthereumSigner | null = null;
 let fundingWalletClient: WalletClient<HttpTransport, Chain, LocalAccount> | undefined;
 let depositAddress: string | undefined;
 
-// Serialize funding ops so concurrent uploads don't race the funding wallet nonce.
+// Serialize funding ops within this process to keep the deposit count down under a
+// burst. Nonce ordering is not this lock's job — every replica runs its own copy.
 let fundingLock: Promise<unknown> = Promise.resolve();
 
 function normalizePrivateKey(key: string): `0x${string}` {
@@ -131,7 +133,7 @@ async function performFunding(
 ): Promise<string> {
   const walletClient = getFundingWalletClient();
   const to = await getIrysDepositAddress();
-  const txHash = await walletClient.sendTransaction({
+  const txHash = await sendTransactionWithNonce(walletClient, {
     to: to as `0x${string}`,
     value: depositWei,
   });

--- a/src/util/evm/tx.ts
+++ b/src/util/evm/tx.ts
@@ -1,4 +1,7 @@
 import {
+  type Chain,
+  type HttpTransport,
+  type LocalAccount,
   type WriteContractParameters,
   type WalletClient,
   encodeFunctionData,
@@ -14,23 +17,14 @@ import { PUBSUB_TOPIC_MISC } from '../../constant';
 // the incident; 10 may fire on the busiest bursts but catches runaway early.
 const NONCE_DRIFT_ALERT_THRESHOLD = 10;
 
-export async function sendWriteContractWithNonce(
-  walletClient: WalletClient,
-  params: WriteContractParameters,
-) {
-  const publicClient = getEVMClient();
-  let res;
-  if (!walletClient.account) {
-    throw new Error('Wallet client does not have account');
-  }
-  const { address } = walletClient.account;
-  const [transactionCount] = await Promise.all([
-    publicClient.getTransactionCount({
-      address,
-    }),
-    await publicClient.simulateContract(params as SimulateContractParameters),
-  ]);
-  const counterRef = txLogRef.doc(`!counter_${address}`);
+function getNonceCounterRef(address: string) {
+  return txLogRef.doc(`!counter_${address}`);
+}
+
+// Every pod signing for the same wallet reserves here, so concurrent senders can't
+// be handed the same nonce by a plain eth_getTransactionCount read.
+async function reserveNonce(address: string, transactionCount: number): Promise<number> {
+  const counterRef = getNonceCounterRef(address);
   const pendingNonce = await db.runTransaction(async (t: admin.firestore.Transaction) => {
     const d = await t.get(counterRef);
     const stored = d.data()?.value as number | undefined;
@@ -52,51 +46,130 @@ export async function sendWriteContractWithNonce(
       drift,
     }));
   }
+  return pendingNonce;
+}
 
+// Advance the counter tip past a consumed nonce, unless a concurrent reservation
+// already moved further. Best-effort: the tx is on the wire by the time this runs, so
+// a failure here must not surface as a send failure — the confirmed-nonce floor in
+// reserveNonce reclaims the counter anyway.
+async function commitNonce(address: string, nonce: number): Promise<void> {
+  const counterRef = getNonceCounterRef(address);
+  await db.runTransaction((t: admin.firestore.Transaction) => t.get(counterRef).then((d) => {
+    const data = d.data();
+    if (data && nonce + 1 > (data.value as number)) {
+      t.update(counterRef, {
+        value: nonce + 1,
+      });
+    }
+  }))
+    // eslint-disable-next-line no-console
+    .catch((err) => console.error('Failed to commit nonce', err));
+}
+
+// Roll back a reservation whose tx never broadcast so it isn't left a permanent gap.
+// Tip check avoids erasing a gap a concurrent send moved past.
+async function rollbackNonce(address: string, nonce: number): Promise<void> {
+  const counterRef = getNonceCounterRef(address);
+  await db.runTransaction((t: admin.firestore.Transaction) => t.get(counterRef)
+    .then((d) => {
+      const data = d.data();
+      if (data && (data.value as number) === nonce + 1) {
+        t.update(counterRef, { value: nonce });
+      }
+    }))
+    // Best-effort: never let a rollback failure mask the original send error.
+    // eslint-disable-next-line no-console
+    .catch((rollbackErr) => console.error('Failed to roll back nonce', rollbackErr));
+}
+
+// Sign and broadcast `request` on an already-reserved `nonce`, then settle the counter.
+// Callers reserve rather than this helper so they keep the nonce for their own logging.
+async function broadcastOnReservedNonce(
+  walletClient: WalletClient,
+  request: Record<string, any>,
+  nonce: number,
+): Promise<{ hash: `0x${string}`; serializedTransaction: `0x${string}` }> {
+  const { account } = walletClient;
+  if (!account) {
+    throw new Error('Wallet client does not have account');
+  }
   let didBroadcast = false;
   try {
-    const {
-      address: toAddress,
-      abi,
-      functionName,
-      args,
-      account,
-      ...otherParams
-    } = params;
-    if (!account) {
-      throw new Error('Account is not provided');
+    const prepared = await walletClient.prepareTransactionRequest(
+      { ...request, account, nonce } as any,
+    );
+    const serializedTransaction = await walletClient
+      .signTransaction({ ...prepared, account } as any);
+    const hash = await walletClient.sendRawTransaction({ serializedTransaction });
+    // The tx is now on the wire, so the reserved nonce is consumed even if anything
+    // below fails. Never roll it back from here on.
+    didBroadcast = true;
+    await commitNonce(account.address, nonce);
+    if (!hash) {
+      throw new Error('Transaction hash is not returned');
     }
-    const request = await walletClient.prepareTransactionRequest({
+    return { hash, serializedTransaction };
+  } catch (err) {
+    // Roll back the reservation on a pre-broadcast failure so it isn't left a permanent
+    // gap; once broadcast the nonce is consumed (reuse clashes with the pending tx).
+    if (!didBroadcast) await rollbackNonce(account.address, nonce);
+    throw err;
+  }
+}
+
+// Plain value transfer (no calldata), returning the hash as soon as it is on the wire
+// so callers can persist it before confirming.
+export async function sendTransactionWithNonce(
+  walletClient: WalletClient<HttpTransport, Chain, LocalAccount>,
+  { to, value }: { to: `0x${string}`; value: bigint },
+): Promise<`0x${string}`> {
+  const { address } = walletClient.account;
+  const transactionCount = await getEVMClient().getTransactionCount({ address });
+  const nonce = await reserveNonce(address, transactionCount);
+  const { hash } = await broadcastOnReservedNonce(walletClient, { to, value }, nonce);
+  return hash;
+}
+
+export async function sendWriteContractWithNonce(
+  walletClient: WalletClient,
+  params: WriteContractParameters,
+) {
+  const publicClient = getEVMClient();
+  let res;
+  if (!walletClient.account) {
+    throw new Error('Wallet client does not have account');
+  }
+  const { address } = walletClient.account;
+  const {
+    address: toAddress,
+    abi,
+    functionName,
+    args,
+    account,
+    ...otherParams
+  } = params;
+  if (!account) {
+    throw new Error('Account is not provided');
+  }
+  const [transactionCount] = await Promise.all([
+    publicClient.getTransactionCount({
+      address,
+    }),
+    publicClient.simulateContract(params as SimulateContractParameters),
+  ]);
+  const pendingNonce = await reserveNonce(address, transactionCount);
+
+  try {
+    const { hash, serializedTransaction } = await broadcastOnReservedNonce(walletClient, {
       ...otherParams,
-      account: walletClient.account,
       to: toAddress,
-      nonce: pendingNonce,
       data: encodeFunctionData({
         abi,
         functionName,
         args,
       }),
-    });
-    const serializedTransaction = await walletClient
-      .signTransaction({
-        ...request,
-        account: walletClient.account,
-      });
-    const hash = await walletClient.sendRawTransaction({ serializedTransaction });
-    // The tx is now on the wire, so the reserved nonce is consumed even if we
-    // never see a receipt below. Never roll it back from here on.
-    didBroadcast = true;
-    await db.runTransaction((t: admin.firestore.Transaction) => t.get(counterRef).then((d) => {
-      const data = d.data();
-      if (data && pendingNonce + 1 > (data.value as number)) {
-        t.update(counterRef, {
-          value: pendingNonce + 1,
-        });
-      }
-    }));
-    if (!hash) {
-      throw new Error('Transaction hash is not returned');
-    }
+    }, pendingNonce);
     res = await publicClient.waitForTransactionReceipt({
       hash,
       confirmations: 2, // 1 extra confirmation to be safe
@@ -109,21 +182,6 @@ export async function sendWriteContractWithNonce(
       nonce: pendingNonce,
     };
   } catch (err) {
-    // Roll back the reserved nonce on a pre-broadcast failure so it isn't left a
-    // permanent gap; skip once broadcast since the nonce is consumed (reuse clashes
-    // with the pending tx). Tip check avoids erasing a gap a concurrent send moved past.
-    if (!didBroadcast) {
-      await db.runTransaction((t: admin.firestore.Transaction) => t.get(counterRef)
-        .then((d) => {
-          const data = d.data();
-          if (data && (data.value as number) === pendingNonce + 1) {
-            t.update(counterRef, { value: pendingNonce });
-          }
-        }))
-        // Best-effort: never let a rollback failure mask the original send error.
-        // eslint-disable-next-line no-console
-        .catch((rollbackErr) => console.error('Failed to roll back nonce', rollbackErr));
-    }
     await publisher.publish(PUBSUB_TOPIC_MISC, null, {
       logType: 'eventCosmosError',
       fromWallet: address,

--- a/test/stub/firebase.ts
+++ b/test/stub/firebase.ts
@@ -424,7 +424,9 @@ function runTransaction(updateFunc: (transaction: any) => Promise<any>): Promise
   return updateFunc({
     get: (ref: any) => ref.get(),
     create: (ref: any, data: any) => ref.create(data),
-    set: (ref: any, data: any, config = {}) => ref.create(data, config),
+    // Real Transaction.set writes over an existing doc (and honours merge);
+    // only create() rejects one.
+    set: (ref: any, data: any, config = {}) => ref.set(data, config),
     update: (ref: any, data: any) => ref.update(data),
     delete: (ref: any) => ref.delete(),
   });

--- a/test/unit/evm-nonce.test.ts
+++ b/test/unit/evm-nonce.test.ts
@@ -1,0 +1,86 @@
+import {
+  describe, expect, it, vi, beforeEach,
+} from 'vitest';
+
+const getTransactionCount = vi.fn();
+
+vi.mock('../../src/util/evm/client', () => ({
+  getEVMClient: () => ({ getTransactionCount }),
+  createEVMWalletClient: vi.fn(),
+  getEVMWalletClient: vi.fn(),
+  getEVMWalletAccount: vi.fn(),
+  evmChain: {},
+}));
+
+// eslint-disable-next-line import/first
+import { sendTransactionWithNonce } from '../../src/util/evm/tx';
+// eslint-disable-next-line import/first
+import { db, txCollection } from '../../src/util/firebase';
+
+const ADDRESS = '0x2DF219F258f33217dA9b4c29992eA3696dF9e5CC';
+const TO = '0x62459D34409ABA55b85DD28284cc4e57e0C8ADea';
+
+function counterRef() {
+  return txCollection.doc(`!counter_${ADDRESS}`);
+}
+
+function createWalletClient(sendRawTransaction: () => Promise<string>) {
+  return {
+    account: { address: ADDRESS },
+    prepareTransactionRequest: vi.fn(async (req) => req),
+    signTransaction: vi.fn(async () => '0xsigned'),
+    sendRawTransaction: vi.fn(sendRawTransaction),
+  } as any;
+}
+
+async function getStoredNonce(): Promise<number | undefined> {
+  return ((await counterRef().get()).data() as any)?.value;
+}
+
+describe('sendTransactionWithNonce', () => {
+  beforeEach(async () => {
+    getTransactionCount.mockResolvedValue(100);
+    // The stub's tx collection is JSON-backed and survives resetTestData, so drop
+    // any counter a previous test left behind.
+    if (await getStoredNonce() !== undefined) await counterRef().delete();
+  });
+
+  it('reserves from the shared counter so a stale on-chain count is not reused', async () => {
+    const requests: any[] = [];
+    const walletClient = createWalletClient(async () => '0xhash');
+    walletClient.prepareTransactionRequest = vi.fn(async (req) => {
+      requests.push(req);
+      return req;
+    });
+
+    // The on-chain count stays at 100 across both sends, as it does while the first
+    // tx is still unconfirmed — only the shared counter separates the two nonces.
+    await sendTransactionWithNonce(walletClient, { to: TO, value: 1n });
+    await sendTransactionWithNonce(walletClient, { to: TO, value: 1n });
+
+    expect(requests.map((r) => r.nonce)).toEqual([100, 101]);
+    expect(await getStoredNonce()).toBe(102);
+  });
+
+  it('rolls the counter back when the send never broadcasts', async () => {
+    const walletClient = createWalletClient(async () => { throw new Error('RPC_DOWN'); });
+
+    await expect(sendTransactionWithNonce(walletClient, { to: TO, value: 1n }))
+      .rejects.toThrow('RPC_DOWN');
+    expect(await getStoredNonce()).toBe(100);
+  });
+
+  it('returns the hash even when the post-broadcast counter write fails', async () => {
+    const walletClient = createWalletClient(async () => '0xhash');
+    const runTransaction = db.runTransaction.bind(db);
+    vi.spyOn(db, 'runTransaction')
+      .mockImplementationOnce((fn: any) => runTransaction(fn)) // reserve
+      .mockImplementationOnce(async () => { throw new Error('FIRESTORE_DOWN'); }); // commit
+
+    // The funds are already on the wire, so a counter write failure must not
+    // surface as a send failure and strand the hash.
+    await expect(sendTransactionWithNonce(walletClient, { to: TO, value: 1n }))
+      .resolves.toBe('0xhash');
+    vi.mocked(db.runTransaction).mockRestore();
+  });
+});


### PR DESCRIPTION
performFunding called walletClient.sendTransaction, which reads the pending nonce per process. That was survivable while funding was a rare cushion top-up, but pass-through funding sends a tx for every paid upload, and the deployment runs 2 replicas — a burst hands both pods the same nonce and one send dies with a nonce clash, silently, into a background console.error.

Route it through the Firestore counter that already serialises the NFT wallet's sends. Extracting reserve/commit/rollback out of sendWriteContractWithNonce left both senders repeating the same broadcast-then-settle skeleton, so that lives in broadcastOnReservedNonce too; commitNonce swallows its own failure now (the tx is on the wire by then, and the confirmed-nonce floor reclaims the counter regardless), which also stops a post-broadcast Firestore blip throwing out of the write path with the hash already gone.

The stub mapped Transaction.set to create, so every set-on-existing doc threw Document already exists and no test could reserve twice.