### PR TITLE
✨ Add unique reader counts to Plus reading settle response

### DIFF
--- a/src/util/api/plus/schemas.ts
+++ b/src/util/api/plus/schemas.ts
@@ -337,6 +337,9 @@ export const PlusSettleResponseSchema = z.object({
   totalReadingTimeMs: z.number(),
   totalTTSTimeMs: z.number(),
   bookCount: z.number(),
+  // Unique library readers in the period. Non-library/free-book reads spawn no reader
+  // docs, so this undercounts vs publisher engagement stats.
+  readerCount: z.number(),
   paidCount: z.number(),
   pendingCount: z.number(),
   paidCents: z.number(),
@@ -346,6 +349,9 @@ export const PlusSettleResponseSchema = z.object({
     amountCents: z.number(),
     readingTimeMs: z.number(),
     ttsTimeMs: z.number(),
+    // Per-book unique readers; a reader of N books counts in each, so these can sum
+    // past the top-level readerCount.
+    readerCount: z.number(),
   })),
 });
 

--- a/src/util/api/plus/settleJob.ts
+++ b/src/util/api/plus/settleJob.ts
@@ -296,6 +296,31 @@ export async function settlePlusReadingPeriod({
   const bookUsages: BookUsage[] = [...usageByClass.values()]
     .filter((b) => b.readingTimeMs > 0 || b.ttsTimeMs > 0);
 
+  // Unique library readers, from the per-reader grain under each day rollup in the window
+  // (ID-only listings, no doc reads). Reader docs exist only for payout-eligible usage,
+  // so this undercounts vs publisher engagement stats that include non-library reads.
+  // A zero-library-time rollup can't have reader docs (ingest gates the reader write on
+  // library time), so skip its listing round trip.
+  const readerDayDocs = usageSnap.docs.filter((doc) => {
+    const data = doc.data() || {};
+    return (data.readingTimeMs || 0) > 0 || (data.ttsTimeMs || 0) > 0;
+  });
+  const readerLists = await mapInChunks(readerDayDocs, async (doc) => ({
+    classId: doc.ref.parent.parent?.id || '',
+    refs: await doc.ref.collection('readers').listDocuments(),
+  }));
+  const readersByClass = new Map<string, Set<string>>();
+  const allReaders = new Set<string>();
+  readerLists.forEach(({ classId, refs }) => {
+    if (!classId) return;
+    const readers = readersByClass.get(classId) || new Set<string>();
+    refs.forEach(({ id }) => {
+      readers.add(id);
+      allReaders.add(id);
+    });
+    readersByClass.set(classId, readers);
+  });
+
   const totals = bookUsages.reduce(
     (acc, b) => ({
       readingTimeMs: acc.readingTimeMs + b.readingTimeMs,
@@ -308,10 +333,14 @@ export async function settlePlusReadingPeriod({
   // Round each book down: per-book rounding then never sums past the pool (under the
   // pool modes), so we can't overpay from the platform balance. The sub-cent dust just
   // stays unallocated. Sub-cent allocations floor to 0 and are skipped below.
-  const books: Array<BookUsage & { amountCents: number }> = bookUsages.map((book) => ({
-    ...book,
-    amountCents: Math.floor(allocateBookUSD(rates, book) * 100),
-  }));
+  // A reader of N books counts once per book, so per-book readerCounts can sum past
+  // the summary's unique readerCount.
+  const books: Array<BookUsage & { amountCents: number; readerCount: number }> = bookUsages
+    .map((book) => ({
+      ...book,
+      amountCents: Math.floor(allocateBookUSD(rates, book) * 100),
+      readerCount: readersByClass.get(book.classId)?.size || 0,
+    }));
   const payableBooks = books.filter((b) => b.amountCents > 0);
   const bookDataByClassId = await getBookDataByClassId(payableBooks.map((b) => b.classId));
 
@@ -387,6 +416,7 @@ export async function settlePlusReadingPeriod({
     totalReadingTimeMs: totals.readingTimeMs,
     totalTTSTimeMs: totals.ttsTimeMs,
     bookCount: books.length,
+    readerCount: allReaders.size,
     paidCount,
     pendingCount,
     paidCents,

--- a/test/stub/firebase.ts
+++ b/test/stub/firebase.ts
@@ -329,6 +329,8 @@ function createCollection(data: StubData[]): any {
   return {
     where: (field: string, op: string, value: any) => collectionWhere(data, field, op, value),
     doc: (id: string) => collectionDoc(data, id),
+    // ID-only listing, mirroring CollectionReference#listDocuments (refs, no doc reads).
+    listDocuments: () => Promise.resolve(data.map((d) => ({ id: d.id }))),
     get: () => {
       const docs = querySnapshotDocs(data, data);
       return Promise.resolve({
@@ -491,12 +493,24 @@ function createDb(): Firestore {
       // Build a chainable query that keeps the parentId tagging through where() so a filtered
       // collection-group snapshot still resolves doc.ref.parent.parent.id (real Firestore does).
       const makeQuery = (rows: Array<{ d: StubData; parentId: string }>): any => {
-        const docs = rows.map(({ d, parentId }) => ({
-          id: d.id,
-          data: () => docData(d),
-          exists: true,
-          ref: { parent: { parent: { id: parentId } } },
-        }));
+        const docs = rows.map((row) => {
+          const { d, parentId } = row;
+          return {
+            id: d.id,
+            data: () => docData(d),
+            exists: true,
+            ref: {
+              parent: { parent: { id: parentId } },
+              // Settlement descends from a plusUsage group doc into its readers grain.
+              // Lazily attach like collectionDoc does, so writes through this ref persist.
+              collection: (collectionId: string) => {
+                if (!d.collection) d.collection = {};
+                if (!d.collection[collectionId]) d.collection[collectionId] = [];
+                return createCollection(d.collection[collectionId]);
+              },
+            },
+          };
+        });
         return {
           get: () => Promise.resolve({
             size: docs.length,

--- a/test/unit/plus-settle.test.ts
+++ b/test/unit/plus-settle.test.ts
@@ -6,6 +6,9 @@ import {
   computePlusReadingRates,
   splitAmountToWallets,
 } from '../../src/util/api/plus/settle';
+import { settlePlusReadingPeriod } from '../../src/util/api/plus/settleJob';
+import { PlusSettleResponseSchema } from '../../src/util/api/plus/schemas';
+import { likeNFTBookCollection } from '../../src/util/firebase';
 
 const min = (n: number) => n * ONE_MINUTE_IN_MS;
 const sumCents = (parts: Array<{ amountCents: number }>) => parts
@@ -173,5 +176,51 @@ describe('splitAmountToWallets', () => {
   it('returns empty when there is nothing to split or no weight', () => {
     expect(splitAmountToWallets(0, { a: 1 })).toEqual([]);
     expect(splitAmountToWallets(100, {})).toEqual([]);
+  });
+});
+
+describe('settlePlusReadingPeriod readerCount', () => {
+  // Seeds a book with one plusUsage day rollup and its per-reader grain. The stub's
+  // doc() resolves the stored object at call time, so re-fetch after each set() before
+  // descending into a subcollection.
+  async function seedBookUsageDay(
+    classId: string,
+    dayId: string,
+    readingTimeMs: number,
+    readers: string[],
+  ) {
+    // Date-only ISO strings parse as UTC midnight — the dayMs the settle range filters on.
+    const dayMs = Date.parse(dayId);
+    const bookDocRef = likeNFTBookCollection.doc(classId);
+    if (!(await bookDocRef.get()).exists) {
+      await bookDocRef.set({ classId, ownerWallet: '0xowner' });
+    }
+    const usageCol = likeNFTBookCollection.doc(classId).collection('plusUsage');
+    await usageCol.doc(dayId).set({ readingTimeMs, ttsTimeMs: 0, dayMs });
+    await Promise.all(readers.map((wallet) => usageCol.doc(dayId).collection('readers')
+      .doc(wallet).set({ readingTimeMs, ttsTimeMs: 0 })));
+  }
+
+  it('counts unique library readers per book and across the period', async () => {
+    // book1: reader A on two days (dedup within a book), + B on the second day.
+    await seedBookUsageDay('0xbook1', '2026-01-05', min(10), ['0xreaderA']);
+    await seedBookUsageDay('0xbook1', '2026-01-06', min(20), ['0xreaderA', '0xreaderB']);
+    // book2: reader B again (dedup across books in the summary).
+    await seedBookUsageDay('0xbook2', '2026-01-07', min(5), ['0xreaderB']);
+    // Outside the period — reader C must not leak into January's counts.
+    await seedBookUsageDay('0xbook1', '2025-12-31', min(15), ['0xreaderC']);
+
+    const result = await settlePlusReadingPeriod({ periodId: '2026-01', dryRun: true });
+
+    expect(result.readerCount).toBe(2); // A + B, C excluded, B counted once
+    const byClass = Object.fromEntries(result.books.map((b) => [b.classId, b]));
+    expect(byClass['0xbook1'].readerCount).toBe(2);
+    expect(byClass['0xbook2'].readerCount).toBe(1);
+
+    // Lockstep guard: sendValidatedJSON strips fields the schema doesn't know about,
+    // so the counts must survive a schema parse to actually reach the response.
+    const parsed = PlusSettleResponseSchema.parse({ success: true, ...result });
+    expect(parsed.readerCount).toBe(2);
+    expect(parsed.books.find((b) => b.classId === '0xbook1')?.readerCount).toBe(2);
   });
 });


### PR DESCRIPTION
Union the per-reader grain under each day rollup (ID-only listings, skipping zero-library rollups) into a summary readerCount and per-book readerCounts, persisted with the period summary.