### PR TITLE
✨ Confirm Plus tier upgrades via Stripe-hosted portal flow

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -46,6 +46,10 @@ config.LIKER_PLUS_BOOK_PROMO_COUPON_CODE = '';
 config.LIKER_PLUS_CIVIC_PRODUCT_ID = '';
 config.LIKER_PLUS_CIVIC_MONTHLY_PRICE_ID = '';
 config.LIKER_PLUS_CIVIC_YEARLY_PRICE_ID = '';
+// Billing Portal configuration (bpc_*) for the paid tier-upgrade confirm flow.
+// Must list the Plus/Civic prices under subscription_update.products with
+// proration_behavior 'always_invoice'. Empty disables the portal upgrade flow.
+config.LIKER_PLUS_UPGRADE_PORTAL_CONFIG_ID = '';
 
 // RevenueCat (mobile IAP) — bridges App/Play Store Plus subscriptions.
 config.REVENUECAT_WEBHOOK_AUTHORIZATION = process.env.REVENUECAT_WEBHOOK_AUTHORIZATION || ''; // shared secret set in RC dashboard's webhook Authorization header

--- a/src/routes/likernft/fiat/stripe.ts
+++ b/src/routes/likernft/fiat/stripe.ts
@@ -80,7 +80,7 @@ router.post('/webhook', express.raw({ type: 'application/json' }), async (req, r
       }
       case 'customer.subscription.updated': {
         const subscription: Stripe.Subscription = event.data.object;
-        await processStripeSubscriptionStatusUpdate(subscription);
+        await processStripeSubscriptionStatusUpdate(subscription, req);
         break;
       }
       default: {

--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import type Stripe from 'stripe';
 import { checksumAddress, isAddress } from 'viem';
 import type { z } from 'zod';
 import { jwtAuth, jwtOptionalAuth } from '../../middleware/jwt';
@@ -16,6 +17,7 @@ import {
   PlusNewBodySchema,
   PlusNewQuerySchema,
   PlusNewResponseSchema,
+  PlusPortalBodySchema,
   PlusPortalResponseSchema,
   PlusPriceBodySchema,
   PlusReadingUsageBodySchema,
@@ -37,14 +39,17 @@ import { getBookUserInfo, getBookUserInfoFromWallet, getBookUserInfoFromLikerId 
 import type { NFTBookUserData } from '../../types/book';
 import { getStripeClient } from '../../util/stripe';
 import {
-  BOOK3_HOSTNAME, PLUS_MONTHLY_PRICE, PLUS_YEARLY_PRICE, PUBSUB_TOPIC_MISC,
-  SUPPORTED_PLUS_CURRENCIES,
+  BOOK3_HOSTNAME, PLUS_MONTHLY_PRICE, PLUS_YEARLY_PRICE,
+  PUBSUB_TOPIC_MISC, SUPPORTED_PLUS_CURRENCIES,
 } from '../../constant';
 import type { LikerPlusTier, SupportedPlusCurrency } from '../../constant';
 import { convertUSDPriceToCurrency } from '../../util/pricing';
 import {
+  comparePlusTiers,
   createNewPlusCheckoutSession,
+  createPlusUpgradePortalSession,
   getPlusTierUSDPrice,
+  stripeIntervalToPlusPeriod,
   updateSubscriptionPeriod,
   type PlusPeriod,
 } from '../../util/api/plus';
@@ -441,6 +446,33 @@ router.post('/gift/:cartId/claim', jwtAuth('write:plus'), validateParams(PlusCar
   }
 });
 
+// Shared guards for the plan-change endpoints (/price and /portal
+// upgrade_confirm): resolve the caller's current plan from an already-fetched
+// user record and reject no-op changes. Error strings are API surface the
+// client may match on; keep them in one place.
+function resolveCurrentPlusPlanOrThrow(
+  likerUser: Awaited<ReturnType<typeof getUserWithCivicLikerPropertiesByWallet>>,
+  { period, tier }: { period: PlusPeriod; tier?: LikerPlusTier },
+) {
+  if (!likerUser?.likerPlus) {
+    throw new ValidationError('No Liker Plus subscription found for this user.', 404);
+  }
+  const { subscriptionId, period: existingPeriod } = likerUser.likerPlus;
+  if (!subscriptionId) {
+    throw new ValidationError('No subscription found for this user.', 404);
+  }
+  // Pre-Civic records have no tier; they are Plus.
+  const existingTier: LikerPlusTier = likerUser.likerPlus.tier || 'plus';
+  const targetTier: LikerPlusTier = tier || existingTier;
+  if (existingPeriod && period === stripeIntervalToPlusPeriod(existingPeriod)
+    && targetTier === existingTier) {
+    throw new ValidationError('Subscription plan is already set to this value.', 400);
+  }
+  return {
+    subscriptionId, existingPeriod, existingTier, targetTier,
+  };
+}
+
 router.post('/price', jwtAuth('write:plus'), validateBody(PlusPriceBodySchema), async (req, res, next) => {
   const {
     period,
@@ -454,19 +486,9 @@ router.post('/price', jwtAuth('write:plus'), validateBody(PlusPriceBodySchema), 
     }
     const { wallet } = req.user;
     const userInfo = await getUserWithCivicLikerPropertiesByWallet(wallet);
-    if (!userInfo?.likerPlus) {
-      throw new ValidationError('No Liker Plus subscription found for this user.', 404);
-    }
-    const { subscriptionId, period: existingPeriod } = userInfo.likerPlus;
-    if (!subscriptionId) {
-      throw new ValidationError('No subscription found for this user.', 404);
-    }
-    // Pre-Civic records have no tier; they are Plus.
-    const existingTier: LikerPlusTier = userInfo.likerPlus.tier || 'plus';
-    const targetTier: LikerPlusTier = tier || existingTier;
-    if (period === `${existingPeriod}ly` && targetTier === existingTier) {
-      throw new ValidationError('Subscription plan is already set to this value.', 400);
-    }
+    const {
+      subscriptionId, existingPeriod, existingTier, targetTier,
+    } = resolveCurrentPlusPlanOrThrow(userInfo, { period, tier });
     await updateSubscriptionPeriod(subscriptionId, period, {
       tier: targetTier,
       giftClassId,
@@ -678,11 +700,12 @@ router.get('/voices', async (req, res, next) => {
   }
 });
 
-router.post('/portal', jwtAuth('write:plus'), async (req, res, next) => {
+router.post('/portal', jwtAuth('write:plus'), validateBody(PlusPortalBodySchema), async (req, res, next) => {
   try {
+    const { flow, period, tier } = req.body || {};
     const { wallet } = req.user;
     const userInfo = await getBookUserInfoFromWallet(wallet);
-    const { bookUserInfo } = userInfo || {};
+    const { bookUserInfo, likerUserInfo } = userInfo || {};
     const customerId = bookUserInfo?.stripeCustomerId;
     if (!customerId) {
       publisher.publish(PUBSUB_TOPIC_MISC, req, {
@@ -691,16 +714,42 @@ router.post('/portal', jwtAuth('write:plus'), async (req, res, next) => {
       });
       throw new ValidationError('No Stripe customer ID found for this user. Please subscribe first.', 400);
     }
-    const session = await getStripeClient().billingPortal.sessions.create({
-      customer: customerId,
-      return_url: `https://${BOOK3_HOSTNAME}/account?action=billing-return`,
-    });
+    let session: Stripe.BillingPortal.Session;
+    let paymentId: string | undefined;
+    if (flow === 'upgrade_confirm') {
+      const { subscriptionId, existingTier } = resolveCurrentPlusPlanOrThrow(
+        likerUserInfo,
+        { period, tier },
+      );
+      // Confirm-flow is for paid upgrades only; downgrades credit at renewal
+      // and are self-served from the portal homepage instead.
+      if (comparePlusTiers(tier, existingTier) < 0) {
+        throw new ValidationError('Only tier upgrades are supported by this flow.', 400);
+      }
+      ({ session, paymentId } = await createPlusUpgradePortalSession({
+        customerId,
+        subscriptionId,
+        tier,
+        period,
+      }));
+    } else {
+      session = await getStripeClient().billingPortal.sessions.create({
+        customer: customerId,
+        return_url: `https://${BOOK3_HOSTNAME}/account?action=billing-return`,
+      });
+    }
 
     publisher.publish(PUBSUB_TOPIC_MISC, req, {
       logType: 'PlusBillingPortalSessionCreated',
       sessionId: session.id,
       wallet,
       customerId,
+      flow,
+      period,
+      tier,
+      // Embedded in the success return URL as the analytics transaction id;
+      // logged here so the conversion can be correlated server-side.
+      paymentId,
     });
 
     sendValidatedJSON(res, PlusPortalResponseSchema, {

--- a/src/util/api/plus/index.ts
+++ b/src/util/api/plus/index.ts
@@ -2,7 +2,7 @@ import type Stripe from 'stripe';
 import { v4 as uuidv4 } from 'uuid';
 import type { LikerPlusSubscriptionStatus, UserCivicLikerProperties } from '../../../types/user';
 
-import { getPlusPageURL, getPlusSuccessPageURL } from '../../liker-land';
+import { getPlusPageURL, getPlusSuccessPageURL, getPlusUpgradeSuccessPageURL } from '../../liker-land';
 import {
   ONE_DAY_IN_MS,
   LIKER_PLUS_TIERS,
@@ -35,6 +35,7 @@ import {
   LIKER_PLUS_CIVIC_PRODUCT_ID,
   LIKER_PLUS_TRIAL_CONVERSION_RATE,
   LIKER_PLUS_LTV,
+  LIKER_PLUS_UPGRADE_PORTAL_CONFIG_ID,
 } from '../../../../config/config';
 import { getUserWithCivicLikerPropertiesByWallet } from '../users/getPublicInfo';
 import {
@@ -58,6 +59,26 @@ export function getPlusPriceId(tier: LikerPlusTier, period: PlusPeriod): string 
     return period === 'yearly' ? LIKER_PLUS_CIVIC_YEARLY_PRICE_ID : LIKER_PLUS_CIVIC_MONTHLY_PRICE_ID;
   }
   return period === 'yearly' ? LIKER_PLUS_YEARLY_PRICE_ID : LIKER_PLUS_MONTHLY_PRICE_ID;
+}
+
+// Map a Stripe product id to its Plus tier; null for non-Plus products. The
+// non-empty guard on the Civic id keeps an unconfigured deployment (both ids
+// '') from ever tier-matching a foreign product.
+export function derivePlusTierFromProductId(productId?: string | null): LikerPlusTier | null {
+  if (productId === LIKER_PLUS_PRODUCT_ID) return 'plus';
+  if (LIKER_PLUS_CIVIC_PRODUCT_ID && productId === LIKER_PLUS_CIVIC_PRODUCT_ID) return 'civic';
+  return null;
+}
+
+// Stripe bills in interval units ('month'/'year'); the API's public plan
+// vocabulary is PlusPeriod ('monthly'/'yearly'). Convert at the boundary.
+export function stripeIntervalToPlusPeriod(interval?: string): PlusPeriod {
+  return interval === 'year' ? 'yearly' : 'monthly';
+}
+
+// LIKER_PLUS_TIERS is ordered lowest to highest; positive means a is above b.
+export function comparePlusTiers(a: LikerPlusTier, b: LikerPlusTier): number {
+  return LIKER_PLUS_TIERS.indexOf(a) - LIKER_PLUS_TIERS.indexOf(b);
 }
 
 // The Plus-tier USD price for a Stripe plan interval. Civic funds the reading
@@ -255,14 +276,8 @@ async function resolvePlusInvoiceContext(
     status,
   } = subscription;
   const productId = item.price.product as string;
-  // The non-empty guard on the Civic id keeps an unconfigured deployment (both
-  // ids '') from ever tier-matching a foreign product.
-  let tier: LikerPlusTier;
-  if (productId === LIKER_PLUS_PRODUCT_ID) {
-    tier = 'plus';
-  } else if (LIKER_PLUS_CIVIC_PRODUCT_ID && productId === LIKER_PLUS_CIVIC_PRODUCT_ID) {
-    tier = 'civic';
-  } else {
+  const tier = derivePlusTierFromProductId(productId);
+  if (!tier) {
     // eslint-disable-next-line no-console
     console.warn(`Unexpected product ID in stripe subscription: ${productId} ${subscription}`);
     return null;
@@ -1516,6 +1531,7 @@ const STRIPE_TO_SUBSCRIPTION_STATUS: Partial<Record<
 
 export async function processStripeSubscriptionStatusUpdate(
   subscription: Stripe.Subscription,
+  req?: Express.Request,
 ) {
   const { status } = subscription;
   const { evmWallet, likeWallet } = subscription.metadata || {};
@@ -1535,10 +1551,43 @@ export async function processStripeSubscriptionStatusUpdate(
   }
   const user = await getUserWithCivicLikerPropertiesByWallet(evmWallet || likeWallet);
   if (!user) return;
-  if (user.likerPlus?.subscriptionStatus === subscriptionStatus) return;
-  await userCollection.doc(user.user).update({
-    'likerPlus.subscriptionStatus': subscriptionStatus,
-  });
+  const userUpdate: Record<string, unknown> = {};
+  if (user.likerPlus?.subscriptionStatus !== subscriptionStatus) {
+    userUpdate['likerPlus.subscriptionStatus'] = subscriptionStatus;
+  }
+  // Mirror tier/period from the live subscription item so a plan change applied
+  // outside /plus/price (Billing Portal confirm flow, Stripe Dashboard) flips
+  // the entitlement without waiting on its invoice.paid, which may lag payment
+  // authentication. invoice.paid stays the money-side source of truth (accrual,
+  // shared-member seats, analytics). Only the record this subscription owns.
+  const item = subscription.items.data[0];
+  const tier = derivePlusTierFromProductId(item?.price.product as string);
+  const period = item?.plan.interval;
+  const previousTier: LikerPlusTier = user.likerPlus?.tier || 'plus';
+  const previousPeriod = user.likerPlus?.period;
+  const isPlanChanged = !!(tier && period)
+    && user.likerPlus?.subscriptionId === subscription.id
+    && (tier !== previousTier || period !== previousPeriod);
+  if (isPlanChanged) {
+    userUpdate['likerPlus.tier'] = tier;
+    userUpdate['likerPlus.period'] = period;
+  }
+  if (!Object.keys(userUpdate).length) return;
+  await userCollection.doc(user.user).update(userUpdate);
+  if (isPlanChanged) {
+    // `source` lets analytics dedupe against the /plus/price route, which logs
+    // the same logType up front for changes it applies itself.
+    publisher.publish(PUBSUB_TOPIC_MISC, req ?? null, {
+      logType: 'PlusSubscriptionPlanUpdated',
+      source: 'stripe-webhook',
+      subscriptionId: subscription.id,
+      period: stripeIntervalToPlusPeriod(period),
+      tier,
+      previousPeriod,
+      previousTier,
+      wallet: evmWallet || likeWallet,
+    });
+  }
 }
 
 export async function updateSubscriptionPeriod(
@@ -1566,7 +1615,7 @@ export async function updateSubscriptionPeriod(
   // which would make every switch look like an upgrade and force an invoice.
   const previousTier: LikerPlusTier = LIKER_PLUS_TIERS
     .includes(metadata.tier as LikerPlusTier) ? metadata.tier as LikerPlusTier : 'plus';
-  const isTierUpgrade = LIKER_PLUS_TIERS.indexOf(tier) > LIKER_PLUS_TIERS.indexOf(previousTier);
+  const isTierUpgrade = comparePlusTiers(tier, previousTier) > 0;
   metadata.tier = tier;
   if (giftClassId) metadata.giftClassId = giftClassId;
   if (giftPriceIndex) metadata.giftPriceIndex = giftPriceIndex;
@@ -1597,4 +1646,71 @@ export async function updateSubscriptionPeriod(
     subscriptionId,
     updatePayload,
   );
+}
+
+// Stripe-hosted confirmation for a paid tier/period upgrade: a Billing Portal
+// deep link (subscription_update_confirm) shows the member the exact prorated
+// charge and the card on file, and runs 3DS on-session, before the update is
+// applied — unlike updateSubscriptionPeriod, which charges off-session with no
+// confirmation. The dedicated portal configuration pins proration to
+// 'always_invoice' so the upgrade invoices immediately and invoice.paid flips
+// likerPlus.tier promptly. Returns the session plus a generated paymentId that
+// the success page uses as its analytics transaction id.
+export async function createPlusUpgradePortalSession({
+  customerId,
+  subscriptionId,
+  tier,
+  period,
+}: {
+  customerId: string;
+  subscriptionId: string;
+  tier: LikerPlusTier;
+  period: PlusPeriod;
+}): Promise<{ session: Stripe.BillingPortal.Session; paymentId: string }> {
+  if (!LIKER_PLUS_UPGRADE_PORTAL_CONFIG_ID) {
+    throw new ValidationError('UPGRADE_PORTAL_NOT_AVAILABLE', 400);
+  }
+  const priceId = getPlusPriceId(tier, period);
+  if (!priceId) {
+    throw new ValidationError('CIVIC_TIER_NOT_AVAILABLE', 400);
+  }
+  const stripe = getStripeClient();
+  const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+  // Trials are blocked (the web gates them too): the portal would apply the
+  // configuration's trial_update_behavior instead of the /plus/price trial
+  // handling (trial_end now, no proration, cycle reset).
+  if (subscription.status === 'trialing') {
+    throw new ValidationError('Cannot upgrade a trial subscription.', 400);
+  }
+  const item = subscription.items.data[0];
+  if (!item) {
+    throw new ValidationError('No subscription item found.', 400);
+  }
+  const paymentId = uuidv4();
+  const session = await stripe.billingPortal.sessions.create({
+    customer: customerId,
+    configuration: LIKER_PLUS_UPGRADE_PORTAL_CONFIG_ID,
+    // "Go back" from the portal must land on the pricing page, not a charge.
+    return_url: getPlusPageURL({ plan: period }),
+    flow_data: {
+      type: 'subscription_update_confirm',
+      subscription_update_confirm: {
+        subscription: subscriptionId,
+        items: [
+          {
+            id: item.id,
+            price: priceId,
+            quantity: 1,
+          },
+        ],
+      },
+      after_completion: {
+        type: 'redirect',
+        redirect: {
+          return_url: getPlusUpgradeSuccessPageURL({ period, tier, paymentId }),
+        },
+      },
+    },
+  });
+  return { session, paymentId };
 }

--- a/src/util/api/plus/schemas.ts
+++ b/src/util/api/plus/schemas.ts
@@ -38,6 +38,23 @@ export const PlusPriceBodySchema = z.object({
   giftPriceIndex: GiftPriceIndexSchema.optional(),
 });
 
+// POST /plus/portal body. An empty body opens the portal homepage (manage /
+// cancel). The `upgrade_confirm` flow instead deep-links a Stripe-hosted
+// confirmation of a specific tier/period change, so the member sees the
+// prorated charge (and passes 3DS on-session) before the update applies.
+// A union (not optional fields) so an upgrade_confirm request missing its
+// period/tier is a 400, never a silent fall-through to the portal homepage.
+// The homepage variant is optional because a bodyless POST (the plain portal
+// call sends none) reaches Express 5 with req.body undefined, not {}.
+export const PlusPortalBodySchema = z.union([
+  z.object({
+    flow: z.literal('upgrade_confirm'),
+    period: z.enum(['monthly', 'yearly']),
+    tier: z.enum(LIKER_PLUS_TIERS),
+  }),
+  z.object({ flow: z.undefined() }).optional(),
+]);
+
 export const PlusGiftNewBodySchema = TrackingFieldsSchema.extend({
   coupon: z.string().optional(),
   giftInfo: BookGiftInfoBodySchema,

--- a/src/util/liker-land.ts
+++ b/src/util/liker-land.ts
@@ -446,6 +446,30 @@ export const getPlusSuccessPageURL = ({
   return `${getBook3URL(`/plus/success?${qs}`, { language })}&session_id={CHECKOUT_SESSION_ID}`;
 };
 
+// Post-confirmation redirect for the Billing Portal tier-upgrade flow.
+// Deliberately NOT `redirect=1` (getPlusSuccessPageURL): the success page keys
+// gift-cart handling off that flag, and an in-place upgrade must not re-open a
+// pre-existing gift cart. `via=portal` triggers the conversion logging instead.
+export const getPlusUpgradeSuccessPageURL = ({
+  period,
+  tier,
+  paymentId,
+  language,
+}: {
+  period: string;
+  tier: string;
+  paymentId: string;
+  language?: string;
+}): string => {
+  const qs = new URLSearchParams({
+    via: 'portal',
+    period,
+    tier,
+    payment_id: paymentId,
+  }).toString();
+  return getBook3URL(`/plus/success?${qs}`, { language });
+};
+
 export const getPlusGiftPageURL = ({
   period,
   cartId,

--- a/test/unit/plus-upgrade-portal.test.ts
+++ b/test/unit/plus-upgrade-portal.test.ts
@@ -1,0 +1,227 @@
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest';
+
+const {
+  mockRetrieve, mockPortalSessionCreate, mockUserDocUpdate, mockPublish, mockGetUserByWallet,
+} = vi.hoisted(() => ({
+  mockRetrieve: vi.fn(),
+  mockPortalSessionCreate: vi.fn(),
+  mockUserDocUpdate: vi.fn(),
+  mockPublish: vi.fn(),
+  mockGetUserByWallet: vi.fn(),
+}));
+
+vi.mock('../../src/util/stripe', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    getStripeClient: () => ({
+      subscriptions: { retrieve: mockRetrieve },
+      billingPortal: { sessions: { create: mockPortalSessionCreate } },
+    }),
+  };
+});
+
+// Layer on the global in-memory stub (test/setup.ts), not importOriginal —
+// the real src/util/firebase would initialize firebase-admin and crash.
+vi.mock('../../src/util/firebase', async () => {
+  const stub = await import('../stub/firebase');
+  return {
+    ...stub,
+    userCollection: { doc: () => ({ update: mockUserDocUpdate }) },
+  };
+});
+
+vi.mock('../../src/util/gcloudPub', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    default: { publish: mockPublish },
+  };
+});
+
+vi.mock('../../src/util/api/users/getPublicInfo', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    getUserWithCivicLikerPropertiesByWallet: mockGetUserByWallet,
+  };
+});
+
+// Give the flow resolvable ids by mutating the real config singleton (rather
+// than mocking config/config, whose object form turns it into a strict-ESM
+// module and breaks the many consumers that read keys config.js leaves unset).
+// eslint-disable-next-line import/first, import/no-relative-packages
+import config from '../../config/config';
+
+const cfg = config as Record<string, unknown>;
+cfg.LIKER_PLUS_MONTHLY_PRICE_ID = 'price_plus_monthly';
+cfg.LIKER_PLUS_YEARLY_PRICE_ID = 'price_plus_yearly';
+cfg.LIKER_PLUS_CIVIC_MONTHLY_PRICE_ID = 'price_civic_monthly';
+cfg.LIKER_PLUS_CIVIC_YEARLY_PRICE_ID = 'price_civic_yearly';
+cfg.LIKER_PLUS_PRODUCT_ID = 'prod_plus';
+cfg.LIKER_PLUS_CIVIC_PRODUCT_ID = 'prod_civic';
+cfg.LIKER_PLUS_UPGRADE_PORTAL_CONFIG_ID = 'bpc_test_config';
+
+// eslint-disable-next-line import/first
+const {
+  createPlusUpgradePortalSession,
+  processStripeSubscriptionStatusUpdate,
+} = await import('../../src/util/api/plus');
+
+// eslint-disable-next-line import/first
+const { PlusPortalBodySchema } = await import('../../src/util/api/plus/schemas');
+
+const SUB_ID = 'sub_test';
+
+describe('PlusPortalBodySchema', () => {
+  it('accepts an absent or empty body as the homepage variant', () => {
+    // A bodyless POST reaches Express 5 with req.body undefined, not {}.
+    expect(PlusPortalBodySchema.safeParse(undefined).success).toBe(true);
+    expect(PlusPortalBodySchema.safeParse({}).success).toBe(true);
+  });
+
+  it('rejects upgrade_confirm missing period/tier instead of falling through', () => {
+    expect(PlusPortalBodySchema.safeParse({ flow: 'upgrade_confirm' }).success).toBe(false);
+    expect(PlusPortalBodySchema.safeParse({ flow: 'upgrade_confirm', period: 'monthly' }).success).toBe(false);
+  });
+
+  it('accepts a fully specified upgrade_confirm body', () => {
+    expect(PlusPortalBodySchema.safeParse({
+      flow: 'upgrade_confirm', period: 'monthly', tier: 'civic',
+    }).success).toBe(true);
+  });
+});
+
+describe('createPlusUpgradePortalSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a pinned subscription_update_confirm portal session', async () => {
+    mockRetrieve.mockResolvedValue({
+      id: SUB_ID,
+      status: 'active',
+      items: { data: [{ id: 'si_test' }] },
+    });
+    mockPortalSessionCreate.mockResolvedValue({
+      id: 'bps_test',
+      url: 'https://billing.stripe.com/session/test',
+    });
+    const { session, paymentId } = await createPlusUpgradePortalSession({
+      customerId: 'cus_test',
+      subscriptionId: SUB_ID,
+      tier: 'civic',
+      period: 'monthly',
+    });
+    expect(session.id).toBe('bps_test');
+    const [payload] = mockPortalSessionCreate.mock.calls[0];
+    expect(payload.customer).toBe('cus_test');
+    expect(payload.configuration).toBe('bpc_test_config');
+    expect(payload.flow_data.type).toBe('subscription_update_confirm');
+    expect(payload.flow_data.subscription_update_confirm).toEqual({
+      subscription: SUB_ID,
+      items: [{ id: 'si_test', price: 'price_civic_monthly', quantity: 1 }],
+    });
+    // via=portal, not redirect=1 — rationale in getPlusUpgradeSuccessPageURL.
+    const returnURL = payload.flow_data.after_completion.redirect.return_url;
+    expect(returnURL).toContain('via=portal');
+    expect(returnURL).toContain('period=monthly');
+    expect(returnURL).toContain('tier=civic');
+    expect(returnURL).toContain(`payment_id=${paymentId}`);
+  });
+
+  it('rejects trialing subscriptions', async () => {
+    mockRetrieve.mockResolvedValue({
+      id: SUB_ID,
+      status: 'trialing',
+      items: { data: [{ id: 'si_test' }] },
+    });
+    await expect(createPlusUpgradePortalSession({
+      customerId: 'cus_test',
+      subscriptionId: SUB_ID,
+      tier: 'civic',
+      period: 'monthly',
+    })).rejects.toThrow('Cannot upgrade a trial subscription.');
+    expect(mockPortalSessionCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('processStripeSubscriptionStatusUpdate plan mirror', () => {
+  function makeSubscription({
+    productId = 'prod_civic',
+    interval = 'month',
+    status = 'active',
+  } = {}) {
+    return {
+      id: SUB_ID,
+      status,
+      metadata: { evmWallet: '0xabc' },
+      items: { data: [{ id: 'si_test', price: { product: productId }, plan: { interval } }] },
+    } as never;
+  }
+
+  function seedUser(likerPlus: Record<string, unknown>) {
+    mockGetUserByWallet.mockResolvedValue({ user: 'testuser', likerPlus });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('mirrors a tier change applied outside /plus/price and logs it', async () => {
+    seedUser({
+      subscriptionId: SUB_ID, tier: 'plus', period: 'month', subscriptionStatus: 'active',
+    });
+    await processStripeSubscriptionStatusUpdate(makeSubscription());
+    expect(mockUserDocUpdate).toHaveBeenCalledWith({
+      'likerPlus.tier': 'civic',
+      'likerPlus.period': 'month',
+    });
+    const [, , log] = mockPublish.mock.calls[0];
+    expect(log).toMatchObject({
+      logType: 'PlusSubscriptionPlanUpdated',
+      subscriptionId: SUB_ID,
+      tier: 'civic',
+      previousTier: 'plus',
+      period: 'monthly',
+    });
+  });
+
+  it('is a no-op when status and plan are unchanged', async () => {
+    seedUser({
+      subscriptionId: SUB_ID, tier: 'civic', period: 'month', subscriptionStatus: 'active',
+    });
+    await processStripeSubscriptionStatusUpdate(makeSubscription());
+    expect(mockUserDocUpdate).not.toHaveBeenCalled();
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+
+  it('does not mirror plan from a subscription the record does not own', async () => {
+    seedUser({
+      subscriptionId: 'sub_other', tier: 'plus', period: 'month', subscriptionStatus: 'active',
+    });
+    await processStripeSubscriptionStatusUpdate(makeSubscription());
+    expect(mockUserDocUpdate).not.toHaveBeenCalled();
+  });
+
+  it('still writes a bare status change without a plan change', async () => {
+    seedUser({
+      subscriptionId: SUB_ID, tier: 'civic', period: 'month', subscriptionStatus: 'active',
+    });
+    await processStripeSubscriptionStatusUpdate(makeSubscription({ status: 'past_due' }));
+    expect(mockUserDocUpdate).toHaveBeenCalledWith({
+      'likerPlus.subscriptionStatus': 'past_due',
+    });
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+
+  it('treats a record with no tier as Plus (no spurious mirror)', async () => {
+    seedUser({
+      subscriptionId: SUB_ID, period: 'month', subscriptionStatus: 'active',
+    });
+    await processStripeSubscriptionStatusUpdate(makeSubscription({ productId: 'prod_plus' }));
+    expect(mockUserDocUpdate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Deep-link POST /plus/portal to a Billing Portal subscription_update_confirm session so Plus→Civic upgrades show the prorated charge and card on file, and run 3DS on-session, instead of one-click charging off-session — cutting chargeback and CS risk on the 10× tier jump. The subscription.updated webhook now mirrors tier/period changes applied outside /plus/price so the entitlement doesn't wait on invoice.paid.