### PR TITLE
🔥 Drop liker.land domain references from URLs and wallet migration

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -135,8 +135,6 @@ config.APP_SERVER = 'likecoin-api-public';
 
 config.CMC_API_CACHE_S = 300;
 
-config.LIKER_LAND_GET_WALLET_SECRET = '';
-
 config.AIRTABLE_API_KEY = process.env.AIRTABLE_API_KEY;
 config.AIRTABLE_BASE_ID = '';
 config.AIRTABLE_AUTOMATION_TOKEN = process.env.AIRTABLE_AUTOMATION_TOKEN;

--- a/src/constant/index.ts
+++ b/src/constant/index.ts
@@ -21,8 +21,6 @@ export const INTERNAL_HOSTNAME = `${HOST}:${PORT}`;
 
 export const API_HOSTNAME = IS_TESTNET ? 'api.rinkeby.like.co' : 'api.like.co';
 
-export const LIKER_LAND_HOSTNAME = IS_TESTNET ? 'rinkeby.liker.land' : 'liker.land';
-
 export const NFT_BOOKSTORE_HOSTNAME = IS_TESTNET ? 'publish.sepolia.3ook.com' : 'publish.3ook.com';
 
 export const API_EXTERNAL_HOSTNAME = process.env.API_EXTERNAL_HOSTNAME || `api.${EXTERNAL_HOSTNAME}`;

--- a/src/routes/likernft/book/purchase.ts
+++ b/src/routes/likernft/book/purchase.ts
@@ -9,7 +9,6 @@ import {
 } from '../../../util/firebase';
 import publisher from '../../../util/gcloudPub';
 import {
-  LIKER_LAND_HOSTNAME,
   PUBSUB_TOPIC_MISC,
   SUPPORTED_PLUS_CURRENCIES,
   ONE_DAY_IN_MS,
@@ -420,7 +419,7 @@ router.get(['/:classId/new', '/class/:classId/new'], jwtOptionalAuth('read:nftbo
     if ((err as Error).message === 'OUT_OF_STOCK') {
       // eslint-disable-next-line no-console
       console.error(`OUT_OF_STOCK: ${classId}`);
-      res.redirect(`https://${LIKER_LAND_HOSTNAME}/nft/class/${classId}`);
+      res.redirect(getBook3NFTClassPageURL({ classId }));
     } else {
       next(err);
     }

--- a/src/util/api/wallet/index.ts
+++ b/src/util/api/wallet/index.ts
@@ -11,7 +11,6 @@ import {
   likeNFTBookUserCollection,
   userCollection,
 } from '../../firebase';
-import { migrateLikerLandEVMWallet } from '../../liker-land';
 import {
   createStripeProductFromNFTBookPrice,
   getAuthorNameFromMetadata,
@@ -252,9 +251,9 @@ async function linkEVMWalletToLikerId(likerId: string, evmWallet: string, method
   }
 }
 
-// Nothing is keyed by a like-address for a v1 account, so the book user, book
-// owner and liker.land steps have no records to move: linking the EVM wallet
-// onto the user doc is the whole migration.
+// Nothing is keyed by a like-address for a v1 account, so the book user and
+// book owner steps have no records to move: linking the EVM wallet onto the
+// user doc is the whole migration.
 export async function migrateLegacyUserToEVMWallet(
   likerId: string,
   evmWallet: string,
@@ -461,23 +460,21 @@ export async function migrateLikeWalletToEVMWallet(
   const [
     { error: migrateBookOwnerError },
     { error: migrateLikerIdError, likerId },
-    { error: migrateLikerLandError, user: likerLandUser },
   ] = await Promise.all([
     migrateBookOwner(likeWallet, evmWallet),
     migrateLikerId(likeWallet, evmWallet, method),
-    migrateLikerLandEVMWallet(likeWallet, evmWallet),
   ]);
   return {
     isMigratedBookUser: !migrateBookUserError,
     isMigratedBookOwner: !migrateBookOwnerError,
     isMigratedLikerId: !migrateLikerIdError,
-    isMigratedLikerLand: !migrateLikerLandError,
+    isMigratedLikerLand: false,
     migratedLikerId: likerId,
-    migratedLikerLandUser: likerLandUser,
+    migratedLikerLandUser: null,
     migrateBookUserError,
     migrateBookOwnerError,
     migrateLikerIdError,
-    migrateLikerLandError,
+    migrateLikerLandError: null,
   };
 }
 

--- a/src/util/api/wallet/schemas.ts
+++ b/src/util/api/wallet/schemas.ts
@@ -49,14 +49,11 @@ export const WalletEvmMigrateResponseSchema = z.object({
   isMigratedBookUser: z.boolean(),
   isMigratedBookOwner: z.boolean(),
   isMigratedLikerId: z.boolean(),
+  // The liker.land step no longer runs: the three LikerLand fields below are
+  // frozen at false/null/null, kept so existing clients keep parsing.
+  // Nullable fields here are always null, never undefined.
   isMigratedLikerLand: z.boolean(),
-  // migrateLikeWalletToEVMWallet returns null (not undefined) for absent values,
-  // and migrateLikerLandError is an untyped axios response body.
   migratedLikerId: z.string().nullable(),
-  // Allowlist the safe fields of the raw liker-land migrate response so
-  // sendValidatedJSON strips any other (potentially PII) fields it returns.
-  // Fields are lenient and non-object bodies coerce to null since the
-  // upstream shape is not guaranteed (never re-trigger the 500).
   migratedLikerLandUser: z.preprocess(
     (value) => (value && typeof value === 'object' && !Array.isArray(value) ? value : null),
     z.object({

--- a/src/util/liker-land.ts
+++ b/src/util/liker-land.ts
@@ -1,12 +1,7 @@
-import axios, { AxiosError } from 'axios';
 import {
-  LIKER_LAND_HOSTNAME,
   BOOK3_HOSTNAME,
   BOOK3_CART_PAGES,
 } from '../constant';
-import {
-  LIKER_LAND_GET_WALLET_SECRET,
-} from '../../config/config';
 
 export const getBook3URL = (path = '', { language = 'zh' }: { language?: string } = {}): string => {
   const locale = language.startsWith('zh') ? '' : 'en';
@@ -564,27 +559,3 @@ export const getSharedMemberClaimURL = ({
   const qs = new URLSearchParams({ giver: giverLikerId, invite: inviteId, token }).toString();
   return `https://${BOOK3_HOSTNAME}/shared/claim?${qs}`;
 };
-
-export async function migrateLikerLandEVMWallet(likeWallet: string, evmWallet: string) {
-  try {
-    const { data } = await axios.post(`https://${LIKER_LAND_HOSTNAME}/api/v2/users/wallet/evm/migrate`, {
-      evmWallet,
-    }, {
-      headers: { 'x-likerland-api-key': LIKER_LAND_GET_WALLET_SECRET },
-      params: { wallet: likeWallet },
-    });
-    return { user: data, error: null };
-  } catch (error) {
-    if (axios.isAxiosError(error)) {
-      const axiosError = error as AxiosError;
-      const errorBody = axiosError.response?.data;
-      const errorMessage = errorBody || error.message;
-      // eslint-disable-next-line no-console
-      console.error(`Error migrating Liker Land EVM wallet: ${errorMessage}`);
-      return { user: null, error: errorMessage };
-    }
-    // eslint-disable-next-line no-console
-    console.error(error);
-    return { user: null, error: (error as Error).message };
-  }
-}

--- a/src/util/slack.ts
+++ b/src/util/slack.ts
@@ -4,8 +4,8 @@ import { getBook3NFTClassPageURL } from './liker-land';
 import { getNFTBookStoreSendPageURL } from './api/likernft/book';
 import {
   BOOK3_HOSTNAME,
+  EXTERNAL_HOSTNAME,
   IS_TESTNET,
-  LIKER_LAND_HOSTNAME,
 } from '../constant';
 import {
   NFT_BOOK_LISTING_NOTIFICATION_WEBHOOK,
@@ -193,7 +193,7 @@ export async function sendPlusSubscriptionSlackNotification({
     } else {
       subscriptionType = 'Plus subscription renewal';
     }
-    const userLink = userId ? `<https://${LIKER_LAND_HOSTNAME}/${userId}|${userId}>` : 'N/A';
+    const userLink = userId ? `<https://${EXTERNAL_HOSTNAME}/${userId}|${userId}>` : 'N/A';
     const stripeEnvironment = IS_TESTNET ? 'test' : '';
     const customerLink = stripeCustomerId ? `<https://dashboard.stripe.com/${stripeEnvironment}/customers/${stripeCustomerId}|${stripeCustomerId}>` : 'N/A';
     // Only Stripe ids resolve to a Stripe dashboard URL. Other providers (e.g.
@@ -308,13 +308,7 @@ export function getSlackAttachmentFromError(errMessage) {
 
 function formatValueRecursively(key, value, depth = 0): string {
   const indent = '  '.repeat(depth);
-  switch (key) {
-    case 'evmWallet':
-      return `<https://${BOOK3_HOSTNAME}/shelf/${value}|${value}>`;
-    case 'likeWallet':
-      return `<https://${LIKER_LAND_HOSTNAME}/${value}|${value}>`;
-    default:
-  }
+  if (key === 'evmWallet') return `<https://${BOOK3_HOSTNAME}/shelf/${value}|${value}>`;
   switch (typeof value) {
     case 'object': {
       if (Array.isArray(value)) {
@@ -377,7 +371,8 @@ export function formatTransactionDetailsForBlockKit(data) {
     wallet, txHash,
   } = data;
 
-  const text = `*Payment ID*\n<https://dashboard.stripe.com/test/search?query=${paymentId}|${paymentId}>\n\n*Class ID*\n<https://liker.land/nft/class/${classId}|${classId}>\n\n*Session ID*\n\`${sessionId}\`\n\n*Claim Token*\n\`${claimToken}\``;
+  const classLink = getBook3NFTClassPageURL({ classId });
+  const text = `*Payment ID*\n<https://dashboard.stripe.com/test/search?query=${paymentId}|${paymentId}>\n\n*Class ID*\n<${classLink}|${classId}>\n\n*Session ID*\n\`${sessionId}\`\n\n*Claim Token*\n\`${claimToken}\``;
 
   const fields = [
     {
@@ -405,7 +400,7 @@ export function formatTransactionDetailsForBlockKit(data) {
   if (wallet) {
     fields.push({
       type: 'mrkdwn',
-      text: `*Wallet*\n<https://liker.land/${wallet}|${wallet}>`,
+      text: `*Wallet*\n\`${wallet}\``,
     });
   }
   if (txHash) {

--- a/test/unit/response-schemas.test.ts
+++ b/test/unit/response-schemas.test.ts
@@ -146,7 +146,7 @@ describe('Response schema ↔ legacy data alignment', () => {
       isMigratedBookUser: true,
       isMigratedBookOwner: true,
       isMigratedLikerId: true,
-      isMigratedLikerLand: true,
+      isMigratedLikerLand: false,
       migratedLikerId: 'liker-1',
       migrateBookUserError: null,
       migrateBookOwnerError: null,
@@ -155,8 +155,8 @@ describe('Response schema ↔ legacy data alignment', () => {
     };
 
     it('strips extra (potentially PII) keys from the raw liker-land user object', () => {
-      // migratedLikerLandUser is the raw liker-land migrate body (commit 49dfbddd);
-      // only the allowlisted fields should survive.
+      // Producers now always send null, but the allowlist stays: only these
+      // fields may survive if the field is ever fed an upstream body again.
       const parsed = WalletEvmMigrateResponseSchema.parse({
         ...base,
         migratedLikerLandUser: {
@@ -185,7 +185,7 @@ describe('Response schema ↔ legacy data alignment', () => {
     });
 
     it('coerces a non-object upstream body to null instead of 500ing', () => {
-      // liker-land could 200 with an empty string / array body; must not throw.
+      // A non-object body must coerce, not throw (the 500 this once caused).
       const S = WalletEvmMigrateResponseSchema;
       expect(S.parse({ ...base, migratedLikerLandUser: '' }).migratedLikerLandUser).toBeNull();
       expect(S.parse({ ...base, migratedLikerLandUser: [] }).migratedLikerLandUser).toBeNull();

--- a/test/unit/wallet-migrate-evm.test.ts
+++ b/test/unit/wallet-migrate-evm.test.ts
@@ -1,0 +1,31 @@
+import {
+  describe, it, expect, afterEach,
+} from 'vitest';
+import { checksumAddress } from 'viem';
+import { migrateLikeWalletToEVMWallet } from '../../src/util/api/wallet';
+import { FieldValue, userCollection } from '../../src/util/firebase';
+
+// Held by the `testinglikeuser` fixture. See test/data/user.json.
+const LIKER_ID = 'testinglikeuser';
+const LIKE_WALLET = 'like187290tx4vj6npyl7fdfgdvxr2n9d5qyevrgdww';
+const NEW_EVM_WALLET = checksumAddress('0x2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c');
+
+describe('migrateLikeWalletToEVMWallet', () => {
+  // resetTestData() re-requires the cached fixture JSON, so a write to a fixture
+  // doc otherwise outlives its test and leaks into later files.
+  afterEach(async () => {
+    await userCollection.doc(LIKER_ID).update({
+      evmWallet: FieldValue.delete(),
+      migrateMethod: FieldValue.delete(),
+      migrateTimestamp: FieldValue.delete(),
+    });
+  });
+
+  it('reports the liker.land step as never attempted', async () => {
+    const res = await migrateLikeWalletToEVMWallet(LIKE_WALLET, NEW_EVM_WALLET, 'auto');
+    expect(res.isMigratedLikerId).toBe(true);
+    expect(res.isMigratedLikerLand).toBe(false);
+    expect(res.migratedLikerLandUser).toBeNull();
+    expect(res.migrateLikerLandError).toBeNull();
+  });
+});


### PR DESCRIPTION
liker.land is being retired in favour of 3ook.com, which does not serve /api/v2/users/wallet/evm/migrate, so migrateLikerLandEVMWallet is removed rather than repointed.

Its three response fields stay frozen at false/null/null instead of being deleted: the Go migration-backend and the migration UI both parse them, and the UI's zod schema requires the keys. Nothing reads the values, and the legacy v1 path already returned false for them.

LIKER_LAND_HOSTNAME is retired — class links go through getBook3NFTClassPageURL, the Liker ID link points at like.co, and bare wallet addresses render as plain text. The email sender and locale signatures still carry the brand and are left for a follow-up.