### PR TITLE
✨ Surface the store owning a RevenueCat Plus subscription

### DIFF
--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -1,7 +1,7 @@
 import type { Timestamp } from '@google-cloud/firestore';
 import type { StoredLocale } from '../locales';
 import type { LikerPlusTier } from '../constant';
-import type { LIKER_PLUS_PROVIDERS, LIKER_PLUS_SUBSCRIPTION_STATUSES } from '../util/api/users/schemas';
+import type { LIKER_PLUS_PROVIDERS, LIKER_PLUS_STORES, LIKER_PLUS_SUBSCRIPTION_STATUSES } from '../util/api/users/schemas';
 
 export interface CivicLikerData {
   currentPeriodStart: number;
@@ -14,6 +14,8 @@ export interface CivicLikerData {
 export type LikerPlusSubscriptionStatus = typeof LIKER_PLUS_SUBSCRIPTION_STATUSES[number];
 
 export type LikerPlusProvider = typeof LIKER_PLUS_PROVIDERS[number];
+
+export type LikerPlusStore = typeof LIKER_PLUS_STORES[number];
 
 export interface LikerPlusData {
   currentPeriodStart: number;
@@ -179,6 +181,7 @@ export interface UserCivicLikerProperties extends UserData {
   likerPlusPeriod?: string;
   likerPlusTier?: LikerPlusTier;
   likerPlusProvider?: LikerPlusProvider;
+  likerPlusStore?: LikerPlusStore;
   likerPlusSubscriptionStatus?: LikerPlusSubscriptionStatus;
   plusAffiliateFrom?: string;
 }

--- a/src/util/ValidationHelper.ts
+++ b/src/util/ValidationHelper.ts
@@ -108,6 +108,7 @@ export function filterUserData(u: UserCivicLikerProperties): UserDataFiltered {
     likerPlusPeriod,
     likerPlusTier,
     likerPlusProvider,
+    likerPlusStore,
     likerPlusSubscriptionStatus,
     plusAffiliateFrom,
     locale,
@@ -142,6 +143,7 @@ export function filterUserData(u: UserCivicLikerProperties): UserDataFiltered {
     likerPlusPeriod,
     likerPlusTier,
     likerPlusProvider,
+    likerPlusStore,
     likerPlusSubscriptionStatus,
     plusAffiliateFrom,
     locale,
@@ -205,6 +207,7 @@ export function filterUserDataScoped(
     output.likerPlusPeriod = user.likerPlusPeriod;
     output.likerPlusTier = user.likerPlusTier;
     output.likerPlusProvider = user.likerPlusProvider;
+    output.likerPlusStore = user.likerPlusStore;
     output.likerPlusSubscriptionStatus = user.likerPlusSubscriptionStatus;
     output.plusAffiliateFrom = user.plusAffiliateFrom;
   }

--- a/src/util/api/users/getPublicInfo.ts
+++ b/src/util/api/users/getPublicInfo.ts
@@ -20,6 +20,7 @@ import type {
   UserData,
   UserCivicLikerProperties,
 } from '../../../types/user';
+import { RC_STORE_TO_LIKER_PLUS_STORE } from './schemas';
 
 function isValidUserDoc(userDoc: DocumentSnapshot<UserData> | undefined): boolean {
   if (!userDoc || !userDoc.exists) {
@@ -95,6 +96,9 @@ export function formatUserCivicLikerProperies(
       payload.likerPlusProvider = 'stripe';
     } else if (likerPlus.provider === 'revenuecat') {
       payload.likerPlusProvider = 'revenuecat';
+      // Lets the client tell an in-app upgrade it can charge from one that would
+      // stack a second subscription on the other platform's store.
+      payload.likerPlusStore = RC_STORE_TO_LIKER_PLUS_STORE[likerPlus.store ?? ''];
     }
     const now = Date.now();
     const renewalLast = end + SUBSCRIPTION_GRACE_PERIOD;

--- a/src/util/api/users/schemas.ts
+++ b/src/util/api/users/schemas.ts
@@ -1,13 +1,26 @@
 import { z } from 'zod';
 import { storedLocales } from '../../../locales';
 import { LIKER_PLUS_TIERS } from '../../../constant';
+import type { LikerPlusStore } from '../../../types/user';
 
 export const LIKER_PLUS_SUBSCRIPTION_STATUSES = ['active', 'past_due', 'canceled'] as const;
 // Billing system owning the record; 'shared' is a seat granted by a Civic-tier
 // giver (see plus/sharedMember.ts). LikerPlusProvider is derived from this.
 export const LIKER_PLUS_PROVIDERS = ['stripe', 'revenuecat', 'shared'] as const;
+// Store owning a 'revenuecat' record. Only the two the app ships on; RevenueCat's
+// other stores (Amazon, promotional, web billing) map to undefined rather than
+// guessing, which the client reads as "unknown" and treats permissively.
+export const LIKER_PLUS_STORES = ['app_store', 'play_store'] as const;
+// `| undefined` is load-bearing: noUncheckedIndexedAccess is off, so a plain
+// Record would type the unmapped-store lookup below as always-present.
+export const RC_STORE_TO_LIKER_PLUS_STORE: Record<string, LikerPlusStore | undefined> = {
+  APP_STORE: 'app_store',
+  MAC_APP_STORE: 'app_store',
+  PLAY_STORE: 'play_store',
+};
 const LikerPlusSubscriptionStatusSchema = z.enum(LIKER_PLUS_SUBSCRIPTION_STATUSES);
 const LikerPlusProviderSchema = z.enum(LIKER_PLUS_PROVIDERS);
+const LikerPlusStoreSchema = z.enum(LIKER_PLUS_STORES);
 const LikerPlusTierSchema = z.enum(LIKER_PLUS_TIERS);
 // Response locale reflects stored data, which includes legacy codes (e.g. 'cn').
 // Input locale is guarded against supportedLocales separately.
@@ -148,6 +161,7 @@ export const UserDataFilteredResponseSchema = z.object({
   likerPlusPeriod: z.string().optional(),
   likerPlusTier: LikerPlusTierSchema.optional(),
   likerPlusProvider: LikerPlusProviderSchema.optional(),
+  likerPlusStore: LikerPlusStoreSchema.optional(),
   likerPlusSubscriptionStatus: LikerPlusSubscriptionStatusSchema.optional(),
   plusAffiliateFrom: z.string().optional(),
   locale: LocaleSchema.optional(),
@@ -158,6 +172,7 @@ export const UserDataScopedResponseSchema = UserDataMinResponseSchema.extend({
   likerPlusPeriod: z.string().optional(),
   likerPlusTier: LikerPlusTierSchema.optional(),
   likerPlusProvider: LikerPlusProviderSchema.optional(),
+  likerPlusStore: LikerPlusStoreSchema.optional(),
   likerPlusSubscriptionStatus: LikerPlusSubscriptionStatusSchema.optional(),
   plusAffiliateFrom: z.string().optional(),
   isCivicLikerRenewalPeriod: z.boolean().optional(),

--- a/test/unit/user-liker-plus-store.test.ts
+++ b/test/unit/user-liker-plus-store.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import type { DocumentSnapshot } from '@google-cloud/firestore';
+
+import { formatUserCivicLikerProperies } from '../../src/util/api/users/getPublicInfo';
+import {
+  LIKER_PLUS_STORES,
+  RC_STORE_TO_LIKER_PLUS_STORE,
+  UserDataScopedResponseSchema,
+} from '../../src/util/api/users/schemas';
+import { filterUserDataScoped } from '../../src/util/ValidationHelper';
+import { ONE_DAY_IN_MS } from '../../src/constant';
+import type { LikerPlusData, LikerPlusStore, UserData } from '../../src/types/user';
+
+const NOW = Date.now();
+
+function makeUserDoc(likerPlus: Partial<LikerPlusData>): DocumentSnapshot<UserData> {
+  return {
+    id: 'testuser',
+    exists: true,
+    data: () => ({
+      user: 'testuser',
+      likerPlus: {
+        since: NOW - ONE_DAY_IN_MS,
+        currentPeriodStart: NOW - ONE_DAY_IN_MS,
+        currentPeriodEnd: NOW + 30 * ONE_DAY_IN_MS,
+        period: 'month',
+        tier: 'plus',
+        ...likerPlus,
+      },
+    }),
+  } as unknown as DocumentSnapshot<UserData>;
+}
+
+describe('likerPlusStore (RevenueCat store → public store)', () => {
+  const CASES: Array<[string | undefined, LikerPlusStore | undefined]> = [
+    ['APP_STORE', 'app_store'],
+    ['MAC_APP_STORE', 'app_store'],
+    ['PLAY_STORE', 'play_store'],
+    ['AMAZON', undefined],
+    ['PROMOTIONAL', undefined],
+    ['RC_BILLING', undefined],
+    [undefined, undefined],
+  ];
+
+  CASES.forEach(([store, expected]) => {
+    it(`maps store ${store ?? '(absent)'} to ${expected ?? 'undefined'}`, () => {
+      const payload = formatUserCivicLikerProperies(
+        makeUserDoc({ provider: 'revenuecat', store }),
+      );
+      expect(payload.likerPlusProvider).toBe('revenuecat');
+      expect(payload.likerPlusStore).toBe(expected);
+    });
+  });
+
+  it('never sets a store for non-RevenueCat providers', () => {
+    const stripe = formatUserCivicLikerProperies(
+      makeUserDoc({ provider: 'stripe', subscriptionId: 'sub_test', store: 'APP_STORE' }),
+    );
+    expect(stripe.likerPlusProvider).toBe('stripe');
+    expect(stripe.likerPlusStore).toBeUndefined();
+
+    const shared = formatUserCivicLikerProperies(
+      makeUserDoc({ provider: 'shared', grantedBy: 'giver', store: 'PLAY_STORE' }),
+    );
+    expect(shared.likerPlusProvider).toBe('shared');
+    expect(shared.likerPlusStore).toBeUndefined();
+  });
+
+  it('surfaces the store in the read:plus scoped response', () => {
+    const payload = formatUserCivicLikerProperies(
+      makeUserDoc({ provider: 'revenuecat', store: 'PLAY_STORE' }),
+    );
+    const scoped = filterUserDataScoped(payload, ['read:plus']);
+    expect(scoped.likerPlusStore).toBe('play_store');
+    const result = UserDataScopedResponseSchema.safeParse(scoped);
+    expect(result.error?.issues ?? []).toEqual([]);
+  });
+
+  it('omits the store when read:plus is not granted', () => {
+    const payload = formatUserCivicLikerProperies(
+      makeUserDoc({ provider: 'revenuecat', store: 'APP_STORE' }),
+    );
+    expect(filterUserDataScoped(payload, []).likerPlusStore).toBeUndefined();
+  });
+
+  // Catches a typo'd or newly added mapping value, which the response schema
+  // would reject as a 500 rather than surface as a client-readable store. The
+  // table above can't cover this — it only knows the keys hardcoded into it.
+  it('only maps to values the response schema declares', () => {
+    Object.values(RC_STORE_TO_LIKER_PLUS_STORE)
+      .filter((value) => value !== undefined)
+      .forEach((value) => {
+        expect(LIKER_PLUS_STORES).toContain(value);
+      });
+  });
+});


### PR DESCRIPTION
The RevenueCat webhook already persists likerPlus.store, but the profile response never exposed it, so clients couldn't tell an App Store subscription from a Play one — both read as provider 'revenuecat'. 3ook.com needs the distinction to avoid offering an in-app tier upgrade that would stack a second subscription on the other platform's store.

Normalize to app_store/play_store at the read site, leaving RevenueCat's lenient webhook schema alone; stores the apps can't purchase from map to undefined rather than guessing.