### PR TITLE
✨ Advertise whether the arweave link is a usable public copy

### DIFF
--- a/src/routes/arweave/index.ts
+++ b/src/routes/arweave/index.ts
@@ -22,6 +22,7 @@ import {
   updateArweaveTxStatus,
   rotateArweaveTxAccessToken,
   resolveArweaveTxKey,
+  isArweaveTxEncrypted,
 } from '../../util/api/arweave/tx';
 import { getRemainingQuota, withReservedQuota } from '../../util/api/arweave/quota';
 import { reconcilePendingIrysFunding, fundUploadIfNeeded } from '../../util/api/arweave/funding';
@@ -422,10 +423,15 @@ router.get(
         // readers with bucket access can go GCS-first; key + link remain the
         // fallback. contentType rides along so they can skip a metadata call.
         const contentUri = getProtectedContentUri(tx.contentBucketPath);
+        // A KMS-written doc read with KMS off resolves no key, so `link` still
+        // goes out but serves ciphertext; only this route can tell that apart
+        // from a genuinely unencrypted doc (see schemas.ts).
+        const hasPublicCopy = !!link && (!isArweaveTxEncrypted(tx) || !!key);
         sendValidatedJSON(res, ArweaveLinkResponseSchema, {
           arweaveId,
           txHash,
           key,
+          hasPublicCopy,
           ...(link ? { link: link.toString() } : {}),
           ...(contentUri ? { contentUri, contentType: tx.contentType } : {}),
         });

--- a/src/util/api/arweave/schemas.ts
+++ b/src/util/api/arweave/schemas.ts
@@ -83,11 +83,10 @@ export const ArweaveLinkResponseSchema = z.object({
   // Absent for GCS-direct docs, which have no public Arweave copy; consumers
   // (ebook-cors parseNFTMetadataURL) already guard on `if (data.link)`.
   link: z.string().optional(),
-  // True iff `link` alone serves readable content, which `!!link` cannot tell:
-  // an encrypted doc whose key failed to resolve still has one. Consumers read a
-  // false as "there is no fallback" — ebook-cors lets a protected bucket read
-  // fail loudly rather than degrade to serving ciphertext as a book.
-  hasPublicCopy: z.boolean(),
+  // True iff `link` alone serves readable content (not just present).
+  // Encrypted docs without a resolved key still have a `link` but serve ciphertext;
+  // consumers use false to avoid falling back to ciphertext.
+  hasPublicCopy: z.boolean()
   contentUri: z.string().optional(),
   contentType: z.string().optional(),
 });

--- a/src/util/api/arweave/schemas.ts
+++ b/src/util/api/arweave/schemas.ts
@@ -83,6 +83,11 @@ export const ArweaveLinkResponseSchema = z.object({
   // Absent for GCS-direct docs, which have no public Arweave copy; consumers
   // (ebook-cors parseNFTMetadataURL) already guard on `if (data.link)`.
   link: z.string().optional(),
+  // True iff `link` alone serves readable content, which `!!link` cannot tell:
+  // an encrypted doc whose key failed to resolve still has one. Consumers read a
+  // false as "there is no fallback" — ebook-cors lets a protected bucket read
+  // fail loudly rather than degrade to serving ciphertext as a book.
+  hasPublicCopy: z.boolean(),
   contentUri: z.string().optional(),
   contentType: z.string().optional(),
 });

--- a/src/util/api/arweave/tx.ts
+++ b/src/util/api/arweave/tx.ts
@@ -178,6 +178,13 @@ export async function resolveArweaveTxKey(
   return tx.key || '';
 }
 
+// Kept beside resolveArweaveTxKey so the pair of key-bearing fields is named in
+// one place: a copy that missed a newly added field would report an encrypted
+// doc as plaintext, and callers use that to decide whether ciphertext is safe.
+export function isArweaveTxEncrypted(tx: ArweaveTxData): boolean {
+  return !!(tx.encryptedKey || tx.key);
+}
+
 // Persist the funding top-up tx on the upload doc BEFORE notifying the Irys indexer,
 // so a crash/5xx between send and notify still leaves a replayable record.
 export async function setArweaveTxFundingSent(docId: string, {

--- a/test/api/arweave-link.test.ts
+++ b/test/api/arweave-link.test.ts
@@ -14,6 +14,10 @@ const CONTENT_KEY = Buffer.alloc(32, 1).toString('base64');
 const DOC_TOKEN = 'doc-upload-token';
 
 describe('Arweave link API', () => {
+  const getLink = (txHash: string, config = {}) => axiosist
+    .get(`/api/arweave/v2/link/${txHash}`, config)
+    .catch((err) => (err as any).response);
+
   beforeEach(async () => {
     await iscnArweaveTxCollection.doc(TX_HASH).set({
       arweaveId: ARWEAVE_ID,
@@ -25,8 +29,7 @@ describe('Arweave link API', () => {
   });
 
   it('returns key and gateway link for a registered tx', async () => {
-    const res = await axiosist.get(`/api/arweave/v2/link/${TX_HASH}`)
-      .catch((err) => (err as any).response);
+    const res = await getLink(TX_HASH);
 
     expect(res.status).toBe(200);
     expect(res.data.arweaveId).toBe(ARWEAVE_ID);
@@ -34,6 +37,55 @@ describe('Arweave link API', () => {
     expect(res.data.key).toBe(CONTENT_KEY);
     expect(res.data.link).toContain(ARWEAVE_ID);
     expect(res.data.link).toContain(`key=${encodeURIComponent(CONTENT_KEY)}`);
+    expect(res.data.hasPublicCopy).toBe(true);
+  });
+
+  // Each case seeds its own doc — the stub's set() appends rather than replaces,
+  // so a doc the shared beforeEach touched cannot be reshaped in place.
+  describe('hasPublicCopy', () => {
+    const seed = async (txHash: string, doc: Record<string, unknown>) => {
+      await iscnArweaveTxCollection.doc(txHash).set({
+        status: 'complete',
+        isRequireAuth: false,
+        ...doc,
+      });
+    };
+
+    it('is false when an encrypted doc has no resolvable key', async () => {
+      // A KMS-written doc read with KMS off: resolveArweaveTxKey yields '' and
+      // the link goes out without a key, so it serves only ciphertext.
+      const txHash = '0xarweavelinkwrapped';
+      await seed(txHash, { arweaveId: ARWEAVE_ID, encryptedKey: 'wrapped' });
+      const res = await getLink(txHash);
+
+      expect(res.status).toBe(200);
+      expect(res.data.link).toContain(ARWEAVE_ID);
+      expect(res.data.link).not.toContain('key=');
+      expect(res.data.hasPublicCopy).toBe(false);
+    });
+
+    it('is true for an unencrypted doc, which needs no key', async () => {
+      const txHash = '0xarweavelinkplain';
+      await seed(txHash, { arweaveId: ARWEAVE_ID });
+      const res = await getLink(txHash);
+
+      expect(res.status).toBe(200);
+      expect(res.data.hasPublicCopy).toBe(true);
+    });
+
+    it('is false for a GCS-direct doc, which has no link to fall back to', async () => {
+      const txHash = '0xarweavelinkgcs';
+      await seed(txHash, {
+        source: 'gcs',
+        contentBucketPath: txHash,
+        contentType: 'application/epub+zip',
+      });
+      const res = await getLink(txHash);
+
+      expect(res.status).toBe(200);
+      expect(res.data.link).toBeUndefined();
+      expect(res.data.hasPublicCopy).toBe(false);
+    });
   });
 
   it('omits contentUri when the protected bucket is not configured', async () => {
@@ -43,8 +95,7 @@ describe('Arweave link API', () => {
       contentBucketPath: TX_HASH,
       contentType: 'application/epub+zip',
     });
-    const res = await axiosist.get(`/api/arweave/v2/link/${TX_HASH}`)
-      .catch((err) => (err as any).response);
+    const res = await getLink(TX_HASH);
 
     expect(res.status).toBe(200);
     expect(res.data.contentUri).toBeUndefined();
@@ -56,10 +107,10 @@ describe('Arweave link API', () => {
   // leaks it to history, the Referer chain and the gateway's logs. Real Accept header:
   // the */* in it satisfies accepts('application/json') on its own.
   it('never hands the key to a browser navigation', async () => {
-    const res = await axiosist.get(`/api/arweave/v2/link/${TX_HASH}`, {
+    const res = await getLink(TX_HASH, {
       headers: { Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' },
       maxRedirects: 0,
-    }).catch((err) => (err as any).response);
+    });
 
     expect(res.status).toBe(302);
     expect(res.headers.location).toContain(ARWEAVE_ID);
@@ -70,9 +121,9 @@ describe('Arweave link API', () => {
   // axios (like ebook-cors) sends `application/json, text/plain, */*` — JSON outranks
   // HTML, so the programmatic caller must keep getting the key.
   it('still serves JSON with the key to an axios-style caller', async () => {
-    const res = await axiosist.get(`/api/arweave/v2/link/${TX_HASH}`, {
+    const res = await getLink(TX_HASH, {
       headers: { Accept: 'application/json, text/plain, */*' },
-    }).catch((err) => (err as any).response);
+    });
 
     expect(res.status).toBe(200);
     expect(res.data.key).toBe(CONTENT_KEY);
@@ -80,8 +131,7 @@ describe('Arweave link API', () => {
   });
 
   it('returns 404 for an unknown tx', async () => {
-    const res = await axiosist.get('/api/arweave/v2/link/0xunknown')
-      .catch((err) => (err as any).response);
+    const res = await getLink('0xunknown');
 
     expect(res.status).toBe(404);
   });
@@ -89,9 +139,9 @@ describe('Arweave link API', () => {
   // Ownership must survive a Cosmos↔EVM migration: a legacy upload stamped with
   // like1… is still owned by the same identity now authenticating with evmWallet.
   describe('isRequireAuth ownership', () => {
-    const getWithWallet = (wallet: string) => axiosist.get(`/api/arweave/v2/link/${TX_HASH}`, {
+    const getWithWallet = (wallet: string) => getLink(TX_HASH, {
       headers: { Authorization: `Bearer ${jwtSign({ wallet, permissions: ['read:iscn'] })}` },
-    }).catch((err) => (err as any).response);
+    });
 
     beforeEach(async () => {
       await iscnArweaveTxCollection.doc(TX_HASH).update({
@@ -122,15 +172,13 @@ describe('Arweave link API', () => {
     });
 
     it('accepts the upload token in place of wallet auth', async () => {
-      const res = await axiosist.get(`/api/arweave/v2/link/${TX_HASH}?token=${DOC_TOKEN}`)
-        .catch((err) => (err as any).response);
+      const res = await getLink(TX_HASH, { params: { token: DOC_TOKEN } });
 
       expect(res.status).toBe(200);
     });
 
     it('rejects an unauthenticated request', async () => {
-      const res = await axiosist.get(`/api/arweave/v2/link/${TX_HASH}`)
-        .catch((err) => (err as any).response);
+      const res = await getLink(TX_HASH);
 
       expect(res.status).toBe(401);
     });


### PR DESCRIPTION
Consumers had to infer "is there a fallback copy?" from the response shape, and neither available signal is sound. `!!link` cannot see that an encrypted doc's key failed to resolve: a KMS-written doc read with KMS off resolves to '' and the link goes out with no key=, which is byte-identical to a genuinely unencrypted doc but serves ciphertext. Only this route can tell those apart, so state it as `hasPublicCopy` rather than making callers guess.

ebook-cors gates its protected-bucket fallback on this, where guessing wrong means handing a reader ciphertext or a JSON body as a book.

Extract isArweaveTxEncrypted next to resolveArweaveTxKey so the pair of key-bearing fields is named once — a stale copy would report an encrypted doc as plaintext, which is exactly the case this flag exists to catch.