### PR TITLE
🐛 Keep Plus through RevenueCat transfers and foreign expirations

### DIFF
--- a/src/util/api/plus/revenuecat.ts
+++ b/src/util/api/plus/revenuecat.ts
@@ -775,10 +775,9 @@ async function handleBillingIssue(
   });
 }
 
-// Movable only if RevenueCat owns the record (Stripe-owned and shared-granted ones
-// follow their own lifecycles) and it still confers access — a lapsed record grants
-// the destination nothing. isSandboxLockedOut stops a sandbox event copying a live
-// production subscription onto a second account.
+// Movable only if RevenueCat owns the record and it still confers access.
+// Stripe-owned/shared-granted records follow their own lifecycles, and
+// isSandboxLockedOut prevents sandbox events copying a live prod subscription.
 function isTransferableLikerPlus(
   likerPlus: LikerPlusData | undefined,
   isSandbox: boolean,

--- a/src/util/api/plus/revenuecat.ts
+++ b/src/util/api/plus/revenuecat.ts
@@ -191,6 +191,21 @@ function isSandboxLockedOut(isSandbox: boolean, likerPlus?: LikerPlusData): bool
   return hasLivePlusAccess(likerPlus);
 }
 
+// A terminal event only speaks for the subscription it names, but `likerPlus` is one
+// flat record per user — without this, an unrelated entitlement's expiry collapses a
+// live paid record. Falls through when either side lacks the field (legacy records).
+function isForOtherSubscription(event: RevenueCatEvent, likerPlus: LikerPlusData): boolean {
+  if (event.original_transaction_id && likerPlus.originalTransactionId) {
+    return event.original_transaction_id !== likerPlus.originalTransactionId;
+  }
+  // Promotional grants may carry no original_transaction_id, so fall back to the
+  // originating store: a 'PROMOTIONAL' expiry cannot terminate an 'APP_STORE' record.
+  if (event.store && likerPlus.store) {
+    return event.store !== likerPlus.store;
+  }
+  return false;
+}
+
 const GRANT_EVENT_TYPES = new Set([
   'INITIAL_PURCHASE',
   'RENEWAL',
@@ -198,6 +213,18 @@ const GRANT_EVENT_TYPES = new Set([
   'PRODUCT_CHANGE',
   'SUBSCRIPTION_EXTENDED',
 ]);
+
+// Mirror of clearIntercomPlusFlags, for paths that hand a record to a Liker ID.
+async function setIntercomPlusFlags(
+  likerId: string,
+  { isTrial, tier }: { isTrial: boolean; tier: LikerPlusTier },
+) {
+  await updateIntercomUserAttributes(likerId, {
+    is_liker_plus: true,
+    is_liker_plus_trial: isTrial,
+    liker_plus_tier: tier,
+  });
+}
 
 async function handleGrant(
   event: RevenueCatEvent,
@@ -473,11 +500,7 @@ async function handleGrant(
     }
   }
 
-  await updateIntercomUserAttributes(likerId, {
-    is_liker_plus: true,
-    is_liker_plus_trial: isTrial,
-    liker_plus_tier: tier,
-  });
+  await setIntercomPlusFlags(likerId, { isTrial, tier });
   if (isInitial) {
     await sendIntercomEvent({
       userId: likerId,
@@ -716,6 +739,7 @@ async function handleExpiration(
   if (isSharedGrantedLikerPlus(user.likerPlus)) return;
   if (!user.likerPlus) return;
   if (isSandboxLockedOut(isSandbox, user.likerPlus)) return;
+  if (isForOtherSubscription(event, user.likerPlus)) return;
   const expiredAt = event.expiration_at_ms || Date.now();
   await revokeLikerPlus(likerId, user.likerPlus, {
     currentPeriodEnd: Math.min(user.likerPlus.currentPeriodEnd || expiredAt, expiredAt),
@@ -731,6 +755,7 @@ async function handleExpiration(
 }
 
 async function handleBillingIssue(
+  event: RevenueCatEvent,
   likerId: string,
   user: { likerPlus?: LikerPlusData },
   isSandbox: boolean,
@@ -739,6 +764,7 @@ async function handleBillingIssue(
   if (isSharedGrantedLikerPlus(user.likerPlus)) return;
   if (!user.likerPlus) return;
   if (isSandboxLockedOut(isSandbox, user.likerPlus)) return;
+  if (isForOtherSubscription(event, user.likerPlus)) return;
   if (user.likerPlus.subscriptionStatus === 'past_due') return;
   await userCollection.doc(likerId).update({
     likerPlus: {
@@ -749,9 +775,24 @@ async function handleBillingIssue(
   });
 }
 
-// When a subscription's app_user_id changes (e.g. anonymous → logged-in, or
-// account switch), RevenueCat sends a TRANSFER. Revoke from the source identities
-// and let the next grant/renewal event populate the destination.
+// Movable only if RevenueCat owns the record (Stripe-owned and shared-granted ones
+// follow their own lifecycles) and it still confers access — a lapsed record grants
+// the destination nothing. isSandboxLockedOut stops a sandbox event copying a live
+// production subscription onto a second account.
+function isTransferableLikerPlus(
+  likerPlus: LikerPlusData | undefined,
+  isSandbox: boolean,
+): boolean {
+  if (!likerPlus) return false;
+  if (isStripeOwnedLikerPlus(likerPlus)) return false;
+  if (isSharedGrantedLikerPlus(likerPlus)) return false;
+  if (isSandboxLockedOut(isSandbox, likerPlus)) return false;
+  return hasLivePlusAccess(likerPlus);
+}
+
+// A TRANSFER moves a subscription between app_user_ids. A pure account switch emits
+// TRANSFER and nothing else, and its payload carries no product/expiration data — so
+// the destination must be seeded from the source or holds no Plus until next RENEWAL.
 async function handleTransfer(
   event: RevenueCatEvent,
   req: Express.Request,
@@ -759,16 +800,54 @@ async function handleTransfer(
 ): Promise<void> {
   const fromIds = (event.transferred_from || []).filter((id) => id && !isAnonymousId(id));
   const toIds = (event.transferred_to || []).filter((id) => id && !isAnonymousId(id));
-  await Promise.all(fromIds.map(async (likerId) => {
-    const user = await getUserWithCivicLikerProperties(likerId);
-    await revokeIfRevenueCatOwned(likerId, user?.likerPlus, isSandbox);
-  }));
+
+  const sources = await Promise.all(fromIds.map(async (likerId) => ({
+    likerId,
+    likerPlus: (await getUserWithCivicLikerProperties(likerId))?.likerPlus,
+  })));
+  const source = sources.find((s) => isTransferableLikerPlus(s.likerPlus, isSandbox));
+  const carried = source?.likerPlus;
+
+  let carriedTo: string[] = [];
+  if (carried) {
+    const written = await Promise.all(toIds.map(async (likerId) => {
+      if (fromIds.includes(likerId)) return undefined;
+      const user = await getUserWithCivicLikerProperties(likerId);
+      // Never overwrite a destination that already has access: a TRANSFER is not
+      // proof of a new purchase, and clobbering would discard a Stripe-owned
+      // record's subscriptionId/customerId, which RevenueCat cannot restore.
+      if (!user || hasLivePlusAccess(user.likerPlus)) return undefined;
+      await userCollection.doc(likerId).update({
+        likerPlus: { ...carried, provider: 'revenuecat' },
+      });
+      return likerId;
+    }));
+    carriedTo = written.filter((likerId): likerId is string => !!likerId);
+  }
+
+  // Revoke the source only after the carry, so a failed destination write leaves
+  // the user with access on the old identity rather than none at all.
+  await Promise.all(sources.map(
+    ({ likerId, likerPlus }) => revokeIfRevenueCatOwned(likerId, likerPlus, isSandbox),
+  ));
+
+  // CRM sync trails the Firestore writes: it is best-effort, and RevenueCat retries
+  // this webhook on timeout, so it must not sit between the carry and the revoke.
+  if (carried && !isQuarantinedSandbox(isSandbox)) {
+    await Promise.all(carriedTo.map((likerId) => setIntercomPlusFlags(likerId, {
+      isTrial: carried.currentType === 'trial',
+      tier: carried.tier || 'plus',
+    })));
+  }
+
   try {
     publisher.publish(PUBSUB_TOPIC_MISC, req, {
       logType: 'PlusRevenueCatTransfer',
       eventId: event.id,
       transferredFrom: fromIds,
       transferredTo: toIds,
+      carriedFrom: source?.likerId,
+      carriedTo,
     });
   } catch (err) {
     // eslint-disable-next-line no-console
@@ -837,7 +916,7 @@ export async function processRevenueCatEvent(
   } else if (event.type === 'EXPIRATION') {
     await handleExpiration(event, likerId, user, isSandbox);
   } else if (event.type === 'BILLING_ISSUE') {
-    await handleBillingIssue(likerId, user, isSandbox);
+    await handleBillingIssue(event, likerId, user, isSandbox);
   } else if (event.type === 'CANCELLATION') {
     // Auto-renew turned off — the user keeps access until EXPIRATION. Nothing to
     // revoke; fall through to logging only.

--- a/test/api/plus.revenuecat.test.ts
+++ b/test/api/plus.revenuecat.test.ts
@@ -12,6 +12,21 @@ const EXPIRATION_AT_MS = 1778536000000;
 // A prior holder from an earlier billing period than the incoming grant, so the
 // grant's newest-wins dedupe revokes it (rather than yielding to a newer owner).
 const PRIOR_PERIOD_START_MS = PURCHASED_AT_MS - 30 * 24 * 60 * 60 * 1000;
+// EXPIRATION_AT_MS is in the past, so guards keyed on live access need their own end.
+const FUTURE_PERIOD_END_MS = Date.now() + 30 * 24 * 60 * 60 * 1000;
+
+// A live, RevenueCat-owned APP_STORE record — the shape the subscription-scoping
+// and transfer-carry guards operate on. Spread it so tests can't share a reference.
+const liveAppStorePlus = {
+  since: PURCHASED_AT_MS,
+  currentPeriodStart: PURCHASED_AT_MS,
+  currentPeriodEnd: FUTURE_PERIOD_END_MS,
+  currentType: 'paid',
+  subscriptionStatus: 'active',
+  provider: 'revenuecat',
+  store: 'APP_STORE',
+  originalTransactionId: 'txn_123',
+};
 
 function rcBody(event: Record<string, unknown>) {
   return { api_version: '1.0', event };
@@ -163,6 +178,45 @@ describe('Plus RevenueCat webhook', () => {
     expect(user?.likerPlus?.subscriptionId).toBe('sub_legacy');
   });
 
+  it('does not revoke a paid store subscription when an unrelated promotional entitlement expires', async () => {
+    // A promotional entitlement revoked from the RevenueCat dashboard emits
+    // CANCELLATION + EXPIRATION with store PROMOTIONAL and no original_transaction_id.
+    // It must not collapse the live APP_STORE record it shares `likerPlus` with.
+    await userCollection.doc('testing').update({ likerPlus: { ...liveAppStorePlus } });
+    const promoExpiry: Record<string, unknown> = {
+      ...baseEvent,
+      id: 'evt_promo_expire',
+      type: 'EXPIRATION',
+      store: 'PROMOTIONAL',
+      product_id: 'rc_promo_plus_daily',
+      expiration_at_ms: Date.now(),
+    };
+    delete promoExpiry.original_transaction_id;
+    const res = await post(promoExpiry, { Authorization: AUTH });
+    expect(res.status).toBe(200);
+    const user = await getUserWithCivicLikerProperties('testing');
+    expect(user?.likerPlus?.subscriptionStatus).toBe('active');
+    expect(user?.likerPlus?.currentPeriodEnd).toBe(FUTURE_PERIOD_END_MS);
+  });
+
+  it('does not revoke on EXPIRATION naming a different original_transaction_id', async () => {
+    await userCollection.doc('testing').update({ likerPlus: { ...liveAppStorePlus } });
+    const res = await post(
+      {
+        ...baseEvent,
+        id: 'evt_other_txn',
+        type: 'EXPIRATION',
+        original_transaction_id: 'txn_other',
+        expiration_at_ms: Date.now(),
+      },
+      { Authorization: AUTH },
+    );
+    expect(res.status).toBe(200);
+    const user = await getUserWithCivicLikerProperties('testing');
+    expect(user?.likerPlus?.subscriptionStatus).toBe('active');
+    expect(user?.likerPlus?.currentPeriodEnd).toBe(FUTURE_PERIOD_END_MS);
+  });
+
   it('sets past_due on BILLING_ISSUE', async () => {
     await post({ ...baseEvent, type: 'INITIAL_PURCHASE' }, { Authorization: AUTH });
     const res = await post(
@@ -172,6 +226,22 @@ describe('Plus RevenueCat webhook', () => {
     expect(res.status).toBe(200);
     const user = await getUserWithCivicLikerProperties('testing');
     expect(user?.likerPlus?.subscriptionStatus).toBe('past_due');
+  });
+
+  it('does not set past_due on BILLING_ISSUE for a different subscription', async () => {
+    await userCollection.doc('testing').update({ likerPlus: { ...liveAppStorePlus } });
+    const res = await post(
+      {
+        ...baseEvent,
+        id: 'evt_billing_other',
+        type: 'BILLING_ISSUE',
+        original_transaction_id: 'txn_other',
+      },
+      { Authorization: AUTH },
+    );
+    expect(res.status).toBe(200);
+    const user = await getUserWithCivicLikerProperties('testing');
+    expect(user?.likerPlus?.subscriptionStatus).toBe('active');
   });
 
   it('revokes a RevenueCat-owned record for transferred_from users on TRANSFER', async () => {
@@ -230,6 +300,106 @@ describe('Plus RevenueCat webhook', () => {
     const user = await getUserWithCivicLikerProperties('testing');
     expect(user?.likerPlus?.subscriptionStatus).toBe('active');
     expect(user?.likerPlus?.subscriptionId).toBe('sub_legacy');
+  });
+
+  it('carries a live subscription to transferred_to on TRANSFER', async () => {
+    // A pure account switch (log into a new account days after buying) emits only
+    // TRANSFER — no grant event follows — so the destination must be populated from
+    // the source record or it holds no Plus until the next RENEWAL.
+    await userCollection.doc('testing').update({
+      likerPlus: {
+        ...liveAppStorePlus, dailyValue: 0.43, dailyValueCurrency: 'USD', period: 'month',
+      },
+    });
+    await userCollection.doc('testuser').update({ likerPlus: null });
+    const res = await post(
+      {
+        id: 'evt_transfer_carry',
+        type: 'TRANSFER',
+        store: 'APP_STORE',
+        environment: 'SANDBOX',
+        transferred_from: ['$RCAnonymousID:abc', 'testing'],
+        transferred_to: ['testuser'],
+      },
+      { Authorization: AUTH },
+    );
+    expect(res.status).toBe(200);
+
+    const destination = await getUserWithCivicLikerProperties('testuser');
+    expect(destination?.likerPlus?.subscriptionStatus).toBe('active');
+    expect(destination?.likerPlus?.provider).toBe('revenuecat');
+    expect(destination?.likerPlus?.currentPeriodEnd).toBe(FUTURE_PERIOD_END_MS);
+    expect(destination?.likerPlus?.currentPeriodStart).toBe(PURCHASED_AT_MS);
+    expect(destination?.likerPlus?.since).toBe(PURCHASED_AT_MS);
+    expect(destination?.likerPlus?.originalTransactionId).toBe('txn_123');
+    expect(destination?.likerPlus?.store).toBe('APP_STORE');
+    expect(destination?.likerPlus?.period).toBe('month');
+    expect(destination?.likerPlus?.dailyValue).toBe(0.43);
+
+    // The source still loses access — the subscription moved, it wasn't copied.
+    const origin = await getUserWithCivicLikerProperties('testing');
+    expect(origin?.likerPlus?.subscriptionStatus).toBe('canceled');
+    expect((origin?.likerPlus?.currentPeriodEnd || 0)).toBeLessThanOrEqual(Date.now());
+  });
+
+  it('does not carry an already-expired source record on TRANSFER', async () => {
+    await userCollection.doc('testing').update({
+      likerPlus: {
+        since: PURCHASED_AT_MS,
+        currentPeriodStart: PURCHASED_AT_MS,
+        currentPeriodEnd: EXPIRATION_AT_MS, // in the past
+        currentType: 'paid',
+        subscriptionStatus: 'canceled',
+        provider: 'revenuecat',
+      },
+    });
+    await userCollection.doc('testuser').update({ likerPlus: null });
+    const res = await post(
+      {
+        id: 'evt_transfer_expired',
+        type: 'TRANSFER',
+        store: 'APP_STORE',
+        environment: 'SANDBOX',
+        transferred_from: ['testing'],
+        transferred_to: ['testuser'],
+      },
+      { Authorization: AUTH },
+    );
+    expect(res.status).toBe(200);
+    const destination = await getUserWithCivicLikerProperties('testuser');
+    expect(destination?.likerPlus).toBeFalsy();
+  });
+
+  it('does not overwrite a destination that already has live access on TRANSFER', async () => {
+    // Clobbering would discard the Stripe-owned record's subscriptionId/customerId,
+    // which RevenueCat cannot restore, and the user already has access either way.
+    await userCollection.doc('testing').update({ likerPlus: { ...liveAppStorePlus } });
+    await userCollection.doc('testuser').update({
+      likerPlus: {
+        since: PURCHASED_AT_MS,
+        currentPeriodStart: PURCHASED_AT_MS,
+        currentPeriodEnd: FUTURE_PERIOD_END_MS,
+        currentType: 'paid',
+        subscriptionStatus: 'active',
+        subscriptionId: 'sub_stripe',
+        customerId: 'cus_stripe',
+      },
+    });
+    const res = await post(
+      {
+        id: 'evt_transfer_occupied',
+        type: 'TRANSFER',
+        store: 'APP_STORE',
+        environment: 'SANDBOX',
+        transferred_from: ['testing'],
+        transferred_to: ['testuser'],
+      },
+      { Authorization: AUTH },
+    );
+    expect(res.status).toBe(200);
+    const destination = await getUserWithCivicLikerProperties('testuser');
+    expect(destination?.likerPlus?.subscriptionId).toBe('sub_stripe');
+    expect(destination?.likerPlus?.originalTransactionId).toBeFalsy();
   });
 
   it('revokes a prior Liker ID that holds Plus tied to the same original_transaction_id on grant', async () => {


### PR DESCRIPTION
Two defects surfaced by a user who lost Plus after switching accounts.

A promotional entitlement expiring revoked the paid App Store record it shares `likerPlus` with: terminal events were identity-scoped but never subscription-scoped. handleExpiration and handleBillingIssue now skip an event naming a different original_transaction_id or store.

TRANSFER only revoked the source, assuming a later grant would populate the destination. That holds for a purchase-time transfer, where INITIAL_PURCHASE follows, but not for a pure account switch, which emits TRANSFER alone and carries no product or expiration data — leaving the destination with no Plus until the next RENEWAL. The source record is now carried over before the source is revoked, so a failed write leaves access on the old identity rather than nowhere.