### PR TITLE
🐛 Detect the ebook content type from plaintext, not the gateway

### DIFF
--- a/src/util/api/arweave/contentType.ts
+++ b/src/util/api/arweave/contentType.ts
@@ -1,0 +1,44 @@
+import fileType from 'file-type';
+
+export const EPUB_CONTENT_TYPE = 'application/epub+zip';
+export const PDF_CONTENT_TYPE = 'application/pdf';
+
+// What an unidentified object is stored as. Legacy ingests recorded this for
+// every protected upload — the Arweave gateway describes the AES-GCM blob, not
+// the ebook inside it — so it doubles as the marker the one-off relabel script
+// selects on (likecoin-misc-services backfillProtectedContentType.js).
+export const PLACEHOLDER_CONTENT_TYPE = 'application/octet-stream';
+
+export const EBOOK_CONTENT_TYPES = [EPUB_CONTENT_TYPE, PDF_CONTENT_TYPE] as const;
+
+export type EbookContentType = typeof EBOOK_CONTENT_TYPES[number];
+
+// file-type's own minimumBytes is 4100, but PDF needs 5 and EPUB 58: the OCF
+// media type sits at offset 38. Revisit this if EBOOK_CONTENT_TYPES ever grows
+// a format whose signature lands later, or detection will silently under-read.
+export const CONTENT_SNIFF_LENGTH = 128;
+
+function isEbookContentType(mime?: string): mime is EbookContentType {
+  return !!mime && (EBOOK_CONTENT_TYPES as readonly string[]).includes(mime);
+}
+
+/**
+ * Identify an ebook from its leading bytes. The protected tier only ever holds
+ * the two types the upload schema accepts, so anything else returns undefined
+ * for the caller to fall back on rather than being guessed at.
+ */
+export function detectEbookContentType(head: Buffer): EbookContentType | undefined {
+  const window = head.subarray(0, CONTENT_SNIFF_LENGTH);
+  const mime = fileType(window)?.mime;
+  if (isEbookContentType(mime)) return mime;
+  // OCF requires the first zip entry to be an uncompressed `mimetype` file whose
+  // data is the media type, and file-type only matches it at exactly offset 38.
+  // An EPUB that pads its local header with an extra field is malformed but still
+  // readable, and reports as a plain zip — recognise it rather than lose it.
+  if (mime === 'application/zip' && window.includes(EPUB_CONTENT_TYPE)) {
+    return EPUB_CONTENT_TYPE;
+  }
+  return undefined;
+}
+
+export default detectEbookContentType;

--- a/src/util/api/arweave/ingest.ts
+++ b/src/util/api/arweave/ingest.ts
@@ -12,6 +12,11 @@ import {
 import type { ContentTier } from '../../gcloudStorage';
 import { ValidationError } from '../../ValidationError';
 import { ARWEAVE_MAX_SIZE_V2 } from './index';
+import {
+  CONTENT_SNIFF_LENGTH,
+  PLACEHOLDER_CONTENT_TYPE,
+  detectEbookContentType,
+} from './contentType';
 import { markArweaveTxIngested } from './tx';
 
 const AES_GCM_IV_LENGTH = 12;
@@ -92,6 +97,30 @@ export function createHashTransform(hash: crypto.Hash): Transform {
       callback(null, chunk);
     },
   });
+}
+
+/**
+ * Copy the leading bytes as they stream past, leaving them untouched. Unlike
+ * createHashTransform there is no caller-owned accumulator to read back from —
+ * Buffer has no equivalent of crypto.Hash — so the buffer stays in the closure
+ * behind a getter. Read it only once the pipeline has resolved.
+ */
+export function createHeadCaptureTransform(length: number): {
+  transform: Transform;
+  getHead: () => Buffer;
+} {
+  let head = Buffer.alloc(0);
+  const transform = new Transform({
+    transform(chunk, _encoding, callback) {
+      if (head.length < length) {
+        // Bound the concat rather than slicing after it, so a large chunk never
+        // leaves the whole allocation pinned behind a view.
+        head = Buffer.concat([head, chunk], Math.min(length, head.length + chunk.length));
+      }
+      callback(null, chunk);
+    },
+  });
+  return { transform, getHead: () => head };
 }
 
 // txHash doubles as the object name; callers only ever mint an on-chain hash,
@@ -294,18 +323,29 @@ export async function ingestProtectedContent(txHash: string, {
   const decrypt = createGcmDecryptTransform(key);
   const hash = crypto.createHash('sha256');
   const stagingFile = getStagedFile(txHash, 'protected');
-  const { stream, contentType: fetchedContentType } = await fetchStreamWithFallback(
+  const { stream } = await fetchStreamWithFallback(
     ARWEAVE_GATEWAYS.map((gateway) => `${gateway}${arweaveId}`),
     { timeout: DOWNLOAD_TIMEOUT_MS, maxContentLength },
   );
-  const contentType = fetchedContentType || 'application/octet-stream';
+  const headCapture = createHeadCaptureTransform(CONTENT_SNIFF_LENGTH);
   try {
     await pipeline(
       stream,
       decrypt,
       createHashTransform(hash),
-      stagingFile.createWriteStream({ resumable: false, metadata: { contentType } }),
+      headCapture.transform,
+      // No content type yet — the gateway only describes the ciphertext, and the
+      // plaintext's own bytes have not arrived. Staging is deleted below and only
+      // ever read by the promote copy, which sets the real type on the destination.
+      stagingFile.createWriteStream({ resumable: false }),
     );
+    // Sniff the plaintext rather than trusting the gateway, which served the
+    // AES-GCM blob and can only describe that. Deliberately no fallback to the
+    // fetched header: an uploader-set DataItem tag would be an unverified guess,
+    // and storing a non-placeholder type would hide the doc from the relabel
+    // script, which selects on the placeholder.
+    const contentType = detectEbookContentType(headCapture.getHead())
+      || PLACEHOLDER_CONTENT_TYPE;
     const computedSHA256 = hash.digest('hex');
     if (fileSHA256 && fileSHA256.toLowerCase() !== computedSHA256) {
       throw new Error('PLAINTEXT_HASH_MISMATCH');

--- a/src/util/api/arweave/schemas.ts
+++ b/src/util/api/arweave/schemas.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { CONTENT_TIERS } from '../../gcloudStorage';
+import { EBOOK_CONTENT_TYPES } from './contentType';
 
 const Sha256HexSchema = z.string().regex(/^[0-9a-f]{64}$/i);
 
@@ -29,7 +30,6 @@ export const ArweaveTxHashParamsSchema = z.object({
   txHash: z.string().min(1),
 });
 
-const EBOOK_CONTENT_TYPES = ['application/epub+zip', 'application/pdf'] as const;
 // Cover types the open tier accepts. `image/svg+xml` is deliberately absent: SVG
 // can carry script, and these objects are served under the content type they were
 // stored with. Mirrors OPEN_IMAGE_FILE_TYPES in publish-3ook-com.

--- a/test/stub/epub.ts
+++ b/test/stub/epub.ts
@@ -1,0 +1,22 @@
+// Zip local file header for the uncompressed `mimetype` entry OCF requires
+// first, so the media type lands at offset 38 exactly as in a real EPUB.
+// `extraFieldLength` pushes it past that, which is malformed but does occur.
+export function epubHeader({ extraFieldLength = 0 } = {}): Buffer {
+  const header = Buffer.alloc(30);
+  header.writeUInt32LE(0x04034b50, 0); // local file header signature
+  header.writeUInt16LE(20, 4); // version needed
+  header.writeUInt16LE(0, 8); // method: stored
+  header.writeUInt32LE(20, 18); // compressed size
+  header.writeUInt32LE(20, 22); // uncompressed size
+  header.writeUInt16LE(8, 26); // file name length: 'mimetype'
+  header.writeUInt16LE(extraFieldLength, 28);
+  return Buffer.concat([
+    header,
+    Buffer.from('mimetype'),
+    Buffer.alloc(extraFieldLength),
+    Buffer.from('application/epub+zip'),
+    Buffer.from('...rest of the archive...'),
+  ]);
+}
+
+export default epubHeader;

--- a/test/util/arweave-content-type.test.ts
+++ b/test/util/arweave-content-type.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+
+import { epubHeader } from '../stub/epub';
+import {
+  EPUB_CONTENT_TYPE,
+  PDF_CONTENT_TYPE,
+  detectEbookContentType,
+} from '../../src/util/api/arweave/contentType';
+
+describe('detectEbookContentType', () => {
+  it('identifies an EPUB from its OCF mimetype entry', () => {
+    expect(detectEbookContentType(epubHeader())).toBe(EPUB_CONTENT_TYPE);
+  });
+
+  // file-type only matches the media type at exactly offset 38 and calls this a
+  // plain zip; the fallback is what keeps a malformed EPUB from being lost.
+  it('tolerates an extra field between the name and the media type', () => {
+    expect(detectEbookContentType(epubHeader({ extraFieldLength: 12 }))).toBe(EPUB_CONTENT_TYPE);
+  });
+
+  it('identifies a PDF from its magic bytes', () => {
+    expect(detectEbookContentType(Buffer.from('%PDF-1.7\n%...'))).toBe(PDF_CONTENT_TYPE);
+  });
+
+  it('does not claim a plain zip is an EPUB', () => {
+    const zip = Buffer.concat([
+      Buffer.from([0x50, 0x4b, 0x03, 0x04]),
+      Buffer.alloc(120),
+    ]);
+    expect(detectEbookContentType(zip)).toBeUndefined();
+  });
+
+  it('returns undefined for unknown bytes, rather than guessing', () => {
+    expect(detectEbookContentType(Buffer.from('not an ebook at all'))).toBeUndefined();
+    expect(detectEbookContentType(Buffer.alloc(0))).toBeUndefined();
+  });
+
+  // The media type sits at offset 38, so a marker past the window must not match
+  // on the zip magic alone — otherwise a longer sniff would change the answer.
+  it('ignores an EPUB marker beyond the sniff window', () => {
+    const far = Buffer.concat([
+      Buffer.from([0x50, 0x4b, 0x03, 0x04]),
+      Buffer.alloc(200),
+      Buffer.from(EPUB_CONTENT_TYPE),
+    ]);
+    expect(detectEbookContentType(far)).toBeUndefined();
+  });
+});

--- a/test/util/arweave-ingest-storage.test.ts
+++ b/test/util/arweave-ingest-storage.test.ts
@@ -4,6 +4,8 @@ import {
 import { webcrypto, createHash } from 'crypto';
 import { Readable, PassThrough } from 'stream';
 
+import { epubHeader } from '../stub/epub';
+
 const calls: string[] = [];
 const objects = new Map<string, Buffer>();
 const copyOptions = new Map<string, unknown>();
@@ -58,10 +60,10 @@ const { ingestProtectedContent } = await import('../../src/util/api/arweave/inge
 
 const PLAINTEXT = Buffer.from(Array.from({ length: 50000 }, (_, i) => i % 256));
 
-async function encrypted() {
+async function encrypted(plaintext: Buffer = PLAINTEXT) {
   const cryptoKey = await webcrypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt']);
   const iv = webcrypto.getRandomValues(new Uint8Array(12));
-  const enc = await webcrypto.subtle.encrypt({ name: 'AES-GCM', iv }, cryptoKey, PLAINTEXT);
+  const enc = await webcrypto.subtle.encrypt({ name: 'AES-GCM', iv }, cryptoKey, plaintext);
   const raw = await webcrypto.subtle.exportKey('raw', cryptoKey);
   return {
     keyBase64: Buffer.from(raw).toString('base64'),
@@ -76,6 +78,9 @@ describe('ingestProtectedContent (staging → verify → promote)', () => {
     copyOptions.clear();
   });
 
+  // Bytes that are neither EPUB nor PDF keep the placeholder even though the
+  // gateway named a type: an unverified header must not put the doc beyond the
+  // reach of the backfill sweep, which selects on the placeholder.
   it('stages, verifies, promotes, and cleans up', async () => {
     const { keyBase64, combined } = await encrypted();
     const sha = createHash('sha256').update(PLAINTEXT).digest('hex');
@@ -92,15 +97,35 @@ describe('ingestProtectedContent (staging → verify → promote)', () => {
     expect(calls).toEqual([
       'write:staging/txhash1',
       'copy:staging/txhash1->txhash1',
-      `mark:${JSON.stringify({ contentBucketPath: 'txhash1', contentType: 'application/pdf' })}`,
+      `mark:${JSON.stringify({ contentBucketPath: 'txhash1', contentType: 'application/octet-stream' })}`,
       'delete:staging/txhash1',
     ]);
     expect((objects.get('txhash1') as Buffer).equals(PLAINTEXT)).toBe(true);
     // copy() nests custom metadata differently from createWriteStream() — pin it.
     expect(copyOptions.get('txhash1')).toEqual({
-      contentType: 'application/pdf',
+      contentType: 'application/octet-stream',
       metadata: { arweaveId: 'ar1', ipfsHash: 'ipfs1', fileSHA256: sha },
     });
+  });
+
+  // The gateway serves the AES-GCM blob, so it can only ever say octet-stream —
+  // the real type has to come from the decrypted bytes.
+  it('labels the promoted object from the plaintext, not the gateway header', async () => {
+    const epub = Buffer.concat([epubHeader(), Buffer.alloc(4096)]);
+    const { keyBase64, combined } = await encrypted(epub);
+    axiosGet.mockResolvedValue({
+      data: Readable.from([combined], { objectMode: false }),
+      headers: { 'content-type': 'application/octet-stream' },
+    });
+
+    await ingestProtectedContent('txhash4', { arweaveId: 'ar1', key: keyBase64 });
+
+    expect(copyOptions.get('txhash4')).toMatchObject({ contentType: 'application/epub+zip' });
+    expect(calls).toContain(`mark:${JSON.stringify({
+      contentBucketPath: 'txhash4',
+      contentType: 'application/epub+zip',
+      fileSHA256: createHash('sha256').update(epub).digest('hex'),
+    })}`);
   });
 
   it('leaves nothing at the canonical path when the hash anchor mismatches', async () => {


### PR DESCRIPTION
Legacy protected ingest took the content type from the Arweave gateway's response header, but that describes the AES-GCM ciphertext, so every ingested book was stored and recorded as application/octet-stream and browsers downloaded ebooks instead of opening them.

Sniff the decrypted bytes as they stream into GCS instead, reusing the file-type dependency already in the tree. A head-capture transform sits alongside the existing hash transform in the same pipeline, so nothing is re-read and the staging write is unaffected. Detection covers both types the protected tier accepts, so PDFs are not mislabelled as EPUB.

There is deliberately no fallback to the fetched header. An uploader-set DataItem tag would be an unverified guess, and storing a non-placeholder type would hide the doc from the relabel script, which selects on the placeholder — turning a wrong label into a permanent one.

Books already ingested keep the placeholder and are repaired out of band by backfillProtectedContentType.js in likecoin-misc-services. That script ranged-reads each object's first bytes, detects the type from the same two signatures, and rewrites the object metadata before the doc: the doc's placeholder is what selects it, so clearing that first would leave a failed object with nothing left to find it by.
