### PR TITLE
✨ Review settled Plus periods via dry run and CSV export

### DIFF
--- a/src/routes/plus/index.ts
+++ b/src/routes/plus/index.ts
@@ -22,6 +22,7 @@ import {
   PlusReadingUsageResponseSchema,
   PlusSelfAffiliateResponseSchema,
   PlusSettleBodySchema,
+  PlusSettleQuerySchema,
   PlusSettleResponseSchema,
   PlusSweepBodySchema,
   PlusSweepResponseSchema,
@@ -32,7 +33,7 @@ import type { PlusSelfAffiliateEntry } from '../../util/api/plus/schemas';
 import { plusReadingServiceAuth } from '../../middleware/plus-reading-service-auth';
 import { plusSettleAdminAuth } from '../../middleware/plus-settle-admin-auth';
 import { getUsageDayId, recordPlusReadingUsage } from '../../util/api/plus/revenueShare';
-import { settlePlusReadingPeriod, sweepPlusReadingPendingPayouts } from '../../util/api/plus/settleJob';
+import { formatPlusSettleCSV, settlePlusReadingPeriod, sweepPlusReadingPendingPayouts } from '../../util/api/plus/settleJob';
 import { getBookUserInfo, getBookUserInfoFromWallet, getBookUserInfoFromLikerId } from '../../util/api/likernft/book/user';
 import type { NFTBookUserData } from '../../types/book';
 import { getStripeClient } from '../../util/stripe';
@@ -121,12 +122,26 @@ router.post('/reading/usage', plusReadingServiceAuth, validateBody(PlusReadingUs
 
 // Admin/cron: settle the Plus reading revenue share for a `YYYY-MM` (month) or `YYYY-MM-DD`
 // (day) period — accrue the pool, freeze usage, price each book, and pay payees via Stripe
-// Connect. `dryRun` returns the full allocation without writing or transferring (run it first
-// to eyeball the split, or to preview an in-progress day).
-router.post('/admin/reading/settle', plusSettleAdminAuth, validateBody(PlusSettleBodySchema), async (req, res, next) => {
+// Connect. `dryRun` returns the full allocation without writing or transferring — run it
+// first to eyeball the split, to preview an in-progress day, or to re-review a settled
+// period. `?format=csv` returns the per-(book, payee) rows as a downloadable file.
+router.post('/admin/reading/settle', plusSettleAdminAuth, validateQuery(PlusSettleQuerySchema), validateBody(PlusSettleBodySchema), async (req, res, next) => {
   try {
-    const { periodId, dryRun = false, mode } = req.body;
-    const result = await settlePlusReadingPeriod({ periodId, dryRun, mode });
+    const {
+      periodId, dryRun = false, mode, includePayouts: wantPayouts,
+    } = req.body;
+    const isCSV = req.query.format === 'csv';
+    // The CSV is payout-grain, so it needs the rows regardless of what the body asked for.
+    const includePayouts = isCSV || !!wantPayouts;
+    const result = await settlePlusReadingPeriod({
+      periodId, dryRun, mode, includePayouts,
+    });
+    if (isCSV) {
+      // Sets both the csv content type and an RFC 6266-escaped filename.
+      res.attachment(`plus-settle-${periodId}${dryRun ? '-dryrun' : ''}.csv`);
+      res.send(formatPlusSettleCSV(result));
+      return;
+    }
     sendValidatedJSON(res, PlusSettleResponseSchema, { success: true, ...result });
   } catch (err) {
     next(err);

--- a/src/util/api/likernft/book/metaCatalog.ts
+++ b/src/util/api/likernft/book/metaCatalog.ts
@@ -1,6 +1,6 @@
 import { listCatalogVariants } from './catalogSource';
 import type { CatalogVariant } from './catalogSource';
-import { buildCatalogCSV } from './catalogCSV';
+import { buildCSV } from '../../../csv';
 // Category mirrors `product:category` in liker-land-v3's use-structured-data.ts.
 const META_CATALOG_GOOGLE_PRODUCT_CATEGORY = 'Media > Books > E-Books';
 // `fb_product_category` uses Meta's own product taxonomy (distinct from Google's
@@ -86,5 +86,5 @@ export async function getMetaProductCatalogItems(): Promise<MetaCatalogItem[]> {
 }
 
 export function formatMetaProductCatalogCSV(items: MetaCatalogItem[]): string {
-  return buildCatalogCSV(META_CATALOG_CSV_COLUMNS, items);
+  return buildCSV(META_CATALOG_CSV_COLUMNS, items);
 }

--- a/src/util/api/likernft/book/openaiCatalog.ts
+++ b/src/util/api/likernft/book/openaiCatalog.ts
@@ -9,7 +9,7 @@ import {
   normalizeISBNToGTIN,
 } from './catalogSource';
 import type { CatalogVariant } from './catalogSource';
-import { buildCatalogCSV } from './catalogCSV';
+import { buildCSV } from '../../../csv';
 import type { NFTBookListingInfo, NFTBookPrice } from '../../../../types/book';
 
 // Search-only feed shaped for OpenAI's commerce *API* product schema
@@ -256,5 +256,5 @@ export async function getOpenAIFeedItems(): Promise<OpenAIFeedItem[]> {
 }
 
 export function formatOpenAIFeedCSV(items: OpenAIFeedItem[]): string {
-  return buildCatalogCSV(OPENAI_FEED_CSV_COLUMNS, items);
+  return buildCSV(OPENAI_FEED_CSV_COLUMNS, items);
 }

--- a/src/util/api/likernft/book/stripeCatalog.ts
+++ b/src/util/api/likernft/book/stripeCatalog.ts
@@ -1,6 +1,6 @@
 import { listCatalogVariants } from './catalogSource';
 import type { CatalogVariant } from './catalogSource';
-import { buildCatalogCSV } from './catalogCSV';
+import { buildCSV } from '../../../csv';
 
 // Stripe Agentic Commerce product feed
 // (https://docs.stripe.com/agentic-commerce/product-feed): a flat CSV in the
@@ -89,5 +89,5 @@ export async function getStripeFeedItems(): Promise<StripeFeedItem[]> {
 }
 
 export function formatStripeFeedCSV(items: StripeFeedItem[]): string {
-  return buildCatalogCSV(STRIPE_FEED_CSV_COLUMNS, items);
+  return buildCSV(STRIPE_FEED_CSV_COLUMNS, items);
 }

--- a/src/util/api/plus/schemas.ts
+++ b/src/util/api/plus/schemas.ts
@@ -7,7 +7,11 @@ import {
   StripeCheckoutResponseSchema,
   TrackingFieldsSchema,
 } from '../likernft/book/schemas';
-import { PLUS_READING_ALLOCATION_MODES } from './settle';
+import {
+  PLUS_READING_ALLOCATION_MODES,
+  PLUS_SETTLE_BOOK_SKIP_REASONS,
+  PLUS_SETTLE_PAYOUT_OUTCOMES,
+} from './settle';
 
 const TrialPeriodDaysSchema = z.union([
   z.literal(0),
@@ -327,7 +331,17 @@ export const PlusSettleBodySchema = z.object({
   periodId: PeriodIdSchema,
   dryRun: z.boolean().optional(),
   mode: z.enum(PLUS_READING_ALLOCATION_MODES).optional(),
+  // Adds the per-(book, wallet) `payouts` rows. Off by default so the cron's response stays
+  // small; forced on when `?format=csv`, whose rows are that grain.
+  includePayouts: z.boolean().optional(),
 });
+
+// `csv` returns the payout rows as a downloadable file, `json` (the default) the full result.
+// Enumerated rather than a free string so a typo 400s instead of silently yielding JSON.
+// `.passthrough()` because validate.ts reassigns req.query wholesale.
+export const PlusSettleQuerySchema = z.object({
+  format: z.enum(['json', 'csv']).optional(),
+}).passthrough();
 
 export const PlusSettleResponseSchema = z.object({
   success: z.literal(true),
@@ -349,8 +363,12 @@ export const PlusSettleResponseSchema = z.object({
   readerCount: z.number(),
   paidCount: z.number(),
   pendingCount: z.number(),
+  // Splits an earlier run already paid — counted at their ledger amounts, not this run's
+  // recomputed ones. A dry-run re-run of a completed period reports its payout here.
+  settledCount: z.number(),
   paidCents: z.number(),
   pendingCents: z.number(),
+  settledCents: z.number(),
   books: z.array(z.object({
     classId: z.string(),
     amountCents: z.number(),
@@ -359,7 +377,30 @@ export const PlusSettleResponseSchema = z.object({
     // Per-book unique readers; a reader of N books counts in each, so these can sum
     // past the top-level readerCount.
     readerCount: z.number(),
+    // Where this book's amount landed, rolled up from its payouts.
+    payeeCount: z.number(),
+    paidCents: z.number(),
+    pendingCents: z.number(),
+    settledCents: z.number(),
+    // Present when the book produced no payout at all, so unallocated money stays visible.
+    skipReason: z.enum(PLUS_SETTLE_BOOK_SKIP_REASONS).optional(),
   })),
+  // Per-(book, wallet) rows; only when `includePayouts` (or `?format=csv`) was requested.
+  payouts: z.array(z.object({
+    classId: z.string(),
+    wallet: z.string(),
+    // What this run computed. Diverges from `ledgerAmountCents` when the allocation
+    // config changed after the period was settled.
+    amountCents: z.number(),
+    outcome: z.enum(PLUS_SETTLE_PAYOUT_OUTCOMES),
+    readingTimeMs: z.number(),
+    ttsTimeMs: z.number(),
+    // The payout record as it stood before this run, absent if there was none.
+    ledgerStatus: z.string().optional(),
+    ledgerAmountCents: z.number().optional(),
+    transferId: z.string().optional(),
+    updatedAt: z.number().optional(),
+  })).optional(),
 });
 
 // Admin Plus reading pending-payout sweep (POST /plus/admin/reading/sweep).

--- a/src/util/api/plus/settle.ts
+++ b/src/util/api/plus/settle.ts
@@ -16,6 +16,17 @@ import { ONE_MINUTE_IN_MS } from '../../../constant';
 export const PLUS_READING_ALLOCATION_MODES = ['static', 'blended', 'split', 'weighted'] as const;
 export type PlusReadingAllocationMode = typeof PLUS_READING_ALLOCATION_MODES[number];
 
+// How one (book, wallet) split resolved in a settle run. `settled` means an earlier run
+// already paid it. Single-sourced here so the settle job's union and the response schema
+// can't drift apart.
+export const PLUS_SETTLE_PAYOUT_OUTCOMES = ['paid', 'pending', 'settled'] as const;
+export type PlusSettlePayoutOutcome = typeof PLUS_SETTLE_PAYOUT_OUTCOMES[number];
+
+// Why a book with usage produced no payout: its allocation floored to 0 cents, it has no
+// resolvable payee, or its connectedWallets carry no positive weight.
+export const PLUS_SETTLE_BOOK_SKIP_REASONS = ['belowCent', 'noPayee', 'noPositiveWeight'] as const;
+export type PlusSettleBookSkipReason = typeof PLUS_SETTLE_BOOK_SKIP_REASONS[number];
+
 // Default static per-minute rate (USD). Live-tunable via the config doc's
 // `readRatePerMinUSD` / `ttsRatePerMinUSD`, like the rev-share rate.
 export const DEFAULT_STATIC_RATE_PER_MIN_USD = 0.01;

--- a/src/util/api/plus/settleJob.ts
+++ b/src/util/api/plus/settleJob.ts
@@ -6,6 +6,7 @@ import {
 import { getStripeClient } from '../../stripe';
 import { getBookUserInfo } from '../likernft/book/user';
 import { ValidationError } from '../../ValidationError';
+import { buildCSV } from '../../csv';
 import {
   accruePoolUSD, getPeriodBoundsMs, PLUS_READING_REVSHARE_CONFIG_DOC_ID,
 } from './revenueShare';
@@ -16,7 +17,12 @@ import {
   configNumber,
   splitAmountToWallets,
 } from './settle';
-import type { PlusReadingAllocationConfig, PlusReadingAllocationMode } from './settle';
+import type {
+  PlusReadingAllocationConfig,
+  PlusReadingAllocationMode,
+  PlusSettleBookSkipReason,
+  PlusSettlePayoutOutcome,
+} from './settle';
 import type { PlusReadingAccrualData } from '../../../types/user';
 import type { NFTBookListingInfo } from '../../../types/book';
 
@@ -39,7 +45,25 @@ interface WalletPayout {
   walletCents: number;
 }
 
-type PayoutOutcome = 'paid' | 'pending' | 'skipped';
+// The payout record on file: what an earlier run left, or what this run just wrote (a dry
+// run writes nothing, so it always reports the earlier one). Carried out of the payout so
+// the caller can report ledger truth — what really transferred — alongside this run's
+// recomputed amount, which diverges once the allocation config changes.
+interface PayoutLedger {
+  status: string;
+  amountCents: number;
+  transferId?: string;
+  updatedAt?: number;
+}
+
+interface PayoutResult {
+  outcome: PlusSettlePayoutOutcome;
+  ledger?: PayoutLedger;
+}
+
+// `extends` rather than an intersection: an intersection would silently merge a future
+// same-named field on WalletPayout, where this errors on the collision.
+interface SettledWalletPayout extends WalletPayout, PayoutResult {}
 
 /**
  * Maps `items` in bounded-concurrency chunks, preserving input order — the settle's
@@ -72,23 +96,20 @@ function getCachedBookUserInfo(wallet: string, cache: WalletUserInfoCache) {
 }
 
 /**
- * Pays one payee its share of a book for the period, returning how it resolved.
- * - dryRun: reports already-paid as skipped, else classifies by Connect-readiness, without
+ * Pays one payee its share of a book for the period, returning how it resolved plus the
+ * pre-existing payout record, if any.
+ * - dryRun: reports already-paid as `settled`, else classifies by Connect-readiness, without
  *   writing or transferring.
- * - already-paid (same period+book): skipped (idempotent re-run).
+ * - already-paid (same period+book): `settled` (idempotent re-run).
  * - not Connect-ready or transfer failed: carried forward as `pending` for a later run.
  * - otherwise: a Stripe Connect transfer (idempotency-keyed) + a `paid` payout record.
  */
 async function settleWalletPayout({
   periodId, book, wallet, walletCents, dryRun, userInfoCache,
-}: {
-  periodId: string;
-  book: BookUsage;
-  wallet: string;
-  walletCents: number;
+}: WalletPayout & {
   dryRun: boolean;
   userInfoCache: WalletUserInfoCache;
-}): Promise<PayoutOutcome> {
+}): Promise<PayoutResult> {
   const payoutDocRef = likeNFTBookUserCollection
     .doc(wallet)
     .collection('plusReadingPayouts')
@@ -99,12 +120,19 @@ async function settleWalletPayout({
   // Checked before the user-info read and the dryRun return so a preview, and a re-run over
   // an already-paid split, both short-circuit without the extra Firestore read.
   const existing = await payoutDocRef.get();
-  if (existing.exists && existing.data()?.status === 'paid') return 'skipped';
+  const existingData = existing.data();
+  const ledger: PayoutLedger | undefined = existingData ? {
+    status: String(existingData.status || ''),
+    amountCents: Number(existingData.amountCents) || 0,
+    transferId: existingData.transferId ? String(existingData.transferId) : undefined,
+    updatedAt: existingData.updatedAt?.toMillis?.(),
+  } : undefined;
+  if (ledger?.status === 'paid') return { outcome: 'settled', ledger };
 
   const userInfo = await getCachedBookUserInfo(wallet, userInfoCache);
   const isReady = !!userInfo?.isStripeConnectReady && !!userInfo.stripeConnectAccountId;
 
-  if (dryRun) return isReady ? 'paid' : 'pending';
+  if (dryRun) return { outcome: isReady ? 'paid' : 'pending', ledger };
 
   const baseRecord = {
     periodId,
@@ -120,7 +148,7 @@ async function settleWalletPayout({
   if (!userInfo?.isStripeConnectReady || !userInfo.stripeConnectAccountId) {
     // Carry forward: hold until the payee finishes Stripe Connect onboarding.
     await payoutDocRef.set({ ...baseRecord, status: 'pending' }, { merge: true });
-    return 'pending';
+    return { outcome: 'pending', ledger: { status: 'pending', amountCents: walletCents } };
   }
   const { stripeConnectAccountId } = userInfo;
 
@@ -148,7 +176,7 @@ async function settleWalletPayout({
 
   if (!transfer) {
     await payoutDocRef.set({ ...baseRecord, status: 'pending' }, { merge: true });
-    return 'pending';
+    return { outcome: 'pending', ledger: { status: 'pending', amountCents: walletCents } };
   }
   await payoutDocRef.set({
     ...baseRecord,
@@ -156,7 +184,11 @@ async function settleWalletPayout({
     transferId: transfer.id,
     stripeConnectAccountId,
   }, { merge: true });
-  return 'paid';
+  // Report the record just written, so a live run's export carries the transfer it made.
+  return {
+    outcome: 'paid',
+    ledger: { status: 'paid', amountCents: walletCents, transferId: transfer.id },
+  };
 }
 
 /**
@@ -173,21 +205,21 @@ async function getBookDataByClassId(
 }
 
 /**
- * Settles each payout, returning the outcomes in `payouts` order. Fail-fast: a Firestore
- * error aborts the run, leaving the period uncompleted so a re-run resumes it (already-paid
- * splits short-circuit, and the Stripe idempotency key covers a transfer whose write was
- * lost). The user-info cache lives for one run, so a payee's Connect status is read fresh
- * each time.
+ * Settles each payout, returning each one merged with how it resolved, so callers read the
+ * amount and the outcome off one row. Fail-fast: a
+ * Firestore error aborts the run, leaving the period uncompleted so a re-run resumes it
+ * (already-paid splits short-circuit, and the Stripe idempotency key covers a transfer whose
+ * write was lost). The user-info cache lives for one run, so a payee's Connect status is read
+ * fresh each time.
  */
 function settleWalletPayouts(
   payouts: WalletPayout[],
   { dryRun }: { dryRun: boolean },
-): Promise<PayoutOutcome[]> {
+): Promise<SettledWalletPayout[]> {
   const userInfoCache: WalletUserInfoCache = new Map();
-  return mapInChunks(payouts, ({
-    periodId, book, wallet, walletCents,
-  }) => settleWalletPayout({
-    periodId, book, wallet, walletCents, dryRun, userInfoCache,
+  return mapInChunks(payouts, async (payout) => ({
+    ...payout,
+    ...await settleWalletPayout({ ...payout, dryRun, userInfoCache }),
   }));
 }
 
@@ -196,7 +228,9 @@ function settleWalletPayouts(
  * or a single day (`YYYY-MM-DD`): accrues the funding pool, freezes the usage snapshot,
  * prices each book, and pays its payees via Stripe Connect (carrying forward anyone not yet
  * Connect-ready). `dryRun` computes and returns the full allocation without writing or
- * transferring. Idempotent and non-overlapping: a completed or overlapping period is refused,
+ * transferring, so re-running it over a completed period doubles as a review of what that
+ * period paid. `includePayouts` adds the per-(book, wallet) rows; off by default so the
+ * cron's response stays small. Idempotent: a completed or overlapping period is refused,
  * a window whose last day hasn't elapsed is refused, and per-payout records guard against
  * double payment on re-run.
  */
@@ -204,10 +238,12 @@ export async function settlePlusReadingPeriod({
   periodId,
   dryRun,
   mode,
+  includePayouts = false,
 }: {
   periodId: string;
   dryRun: boolean;
   mode?: PlusReadingAllocationMode;
+  includePayouts?: boolean;
 }) {
   const configDocRef = configCollection.doc(PLUS_READING_REVSHARE_CONFIG_DOC_ID);
   const periodsCol = configDocRef.collection('periods');
@@ -344,17 +380,29 @@ export async function settlePlusReadingPeriod({
   const payableBooks = books.filter((b) => b.amountCents > 0);
   const bookDataByClassId = await getBookDataByClassId(payableBooks.map((b) => b.classId));
 
+  // Reported per book so unallocated money stays reviewable in the response, not just in
+  // the warnings below.
+  const skipReasonByClass = new Map<string, PlusSettleBookSkipReason>();
+  books.forEach((b) => {
+    if (b.amountCents <= 0) skipReasonByClass.set(b.classId, 'belowCent');
+  });
+
   // Resolved in book order, so the skip warnings below stay deterministic even though the
   // transfers themselves run concurrently.
   const payouts: WalletPayout[] = [];
   for (const book of payableBooks) {
     const bookData = bookDataByClassId.get(book.classId);
-    if (!bookData) continue; // usage with no book doc — skip
+    if (!bookData) {
+      // usage with no book doc — no payee to resolve
+      skipReasonByClass.set(book.classId, 'noPayee');
+      continue;
+    }
     const hasConnected = bookData.connectedWallets
       && Object.keys(bookData.connectedWallets).length > 0;
     if (!hasConnected && !bookData.ownerWallet) {
       // No resolvable payee — skip rather than synthesize a `{ '': 1 }` split that would
       // write to an empty doc id. The amount stays unallocated (surfaced in the log).
+      skipReasonByClass.set(book.classId, 'noPayee');
       // eslint-disable-next-line no-console
       console.warn(`Plus settle ${periodId}: ${book.classId} has usage but no payee; skipping`);
       continue;
@@ -367,6 +415,7 @@ export async function settlePlusReadingPeriod({
     if (splits.length === 0) {
       // connectedWallets present but no positive weight — surface rather than silently
       // drop it. The amount (guaranteed > 0 above) stays unallocated, like the no-payee case.
+      skipReasonByClass.set(book.classId, 'noPositiveWeight');
       // eslint-disable-next-line no-console
       console.warn(`Plus settle ${periodId}: ${book.classId} has connectedWallets but no positive weight; skipping`);
       continue;
@@ -378,21 +427,42 @@ export async function settlePlusReadingPeriod({
     }
   }
 
-  const outcomes = await settleWalletPayouts(payouts, { dryRun });
+  const results = await settleWalletPayouts(payouts, { dryRun });
 
   let paidCount = 0;
   let pendingCount = 0;
+  let settledCount = 0;
   let paidCents = 0;
   let pendingCents = 0;
-  outcomes.forEach((outcome, index) => {
-    const { walletCents } = payouts[index];
+  let settledCents = 0;
+  // Per-book rollup of the same outcomes, so `books` shows where each book's money landed.
+  const rollupByClass = new Map<string, {
+    payeeCount: number; paidCents: number; pendingCents: number; settledCents: number;
+  }>();
+  results.forEach(({
+    outcome, ledger, book, walletCents,
+  }) => {
+    const roll = rollupByClass.get(book.classId)
+      || {
+        payeeCount: 0, paidCents: 0, pendingCents: 0, settledCents: 0,
+      };
+    roll.payeeCount += 1;
     if (outcome === 'paid') {
       paidCount += 1;
       paidCents += walletCents;
+      roll.paidCents += walletCents;
     } else if (outcome === 'pending') {
       pendingCount += 1;
       pendingCents += walletCents;
+      roll.pendingCents += walletCents;
+    } else {
+      // The ledger amount, not this run's `walletCents` — see PayoutLedger.
+      const ledgerCents = ledger?.amountCents || 0;
+      settledCount += 1;
+      settledCents += ledgerCents;
+      roll.settledCents += ledgerCents;
     }
+    rollupByClass.set(book.classId, roll);
   });
 
   // What we actually pay out this period (pre cent-rounding), and how it compares to
@@ -419,9 +489,39 @@ export async function settlePlusReadingPeriod({
     readerCount: allReaders.size,
     paidCount,
     pendingCount,
+    settledCount,
     paidCents,
     pendingCents,
+    settledCents,
   };
+
+  const bookRows = books.map((book) => {
+    const roll = rollupByClass.get(book.classId);
+    return {
+      ...book,
+      payeeCount: roll?.payeeCount || 0,
+      paidCents: roll?.paidCents || 0,
+      pendingCents: roll?.pendingCents || 0,
+      settledCents: roll?.settledCents || 0,
+      skipReason: skipReasonByClass.get(book.classId),
+    };
+  });
+
+  // Per-(book, wallet) grain — the money grain, and what the CSV export rows come from.
+  const payoutRows = includePayouts ? results.map(({
+    book, wallet, walletCents, outcome, ledger,
+  }) => ({
+    classId: book.classId,
+    wallet,
+    amountCents: walletCents,
+    outcome,
+    readingTimeMs: book.readingTimeMs,
+    ttsTimeMs: book.ttsTimeMs,
+    ledgerStatus: ledger?.status,
+    ledgerAmountCents: ledger?.amountCents,
+    transferId: ledger?.transferId,
+    updatedAt: ledger?.updatedAt,
+  })) : undefined;
 
   if (!dryRun) {
     await periodDocRef.set({
@@ -433,7 +533,80 @@ export async function settlePlusReadingPeriod({
     }, { merge: true });
   }
 
-  return { dryRun, ...summary, books };
+  return {
+    dryRun, ...summary, books: bookRows, ...(payoutRows ? { payouts: payoutRows } : {}),
+  };
+}
+
+// Payout grain (one row per book × payee), with the book's columns denormalized onto each
+// row so the file needs no join. A book that produced no payout still gets a row, carrying
+// its `skipReason` and an empty wallet, so unallocated money can't vanish from the export.
+const PLUS_SETTLE_CSV_COLUMNS = [
+  'periodId',
+  'classId',
+  'wallet',
+  'amountCents',
+  'outcome',
+  'ledgerStatus',
+  'ledgerAmountCents',
+  'transferId',
+  'readingTimeMs',
+  'ttsTimeMs',
+  'bookAmountCents',
+  'bookReaderCount',
+  'skipReason',
+] as const;
+
+// Absent columns render empty, so a row only carries the cells it actually has.
+type PlusSettleCSVRow = Partial<Record<typeof PLUS_SETTLE_CSV_COLUMNS[number], string>>;
+
+const csvNum = (value: number | undefined) => (value === undefined ? undefined : String(value));
+
+type PlusSettleResult = Awaited<ReturnType<typeof settlePlusReadingPeriod>>;
+
+/**
+ * Serializes a settle result as CSV for offline review. Amounts stay in cents — integers
+ * survive a spreadsheet round-trip where fractional dollars wouldn't. `amountCents` is what
+ * this run computed and `ledgerAmountCents` what was actually paid, so a re-run over a
+ * settled period shows config drift as a column diff. Pass a result produced with
+ * `includePayouts`, or every book comes out as a payee-less row.
+ */
+export function formatPlusSettleCSV(result: PlusSettleResult): string {
+  const { periodId } = result;
+  const payoutsByClass = new Map<string, NonNullable<typeof result.payouts>>();
+  (result.payouts || []).forEach((payout) => {
+    const list = payoutsByClass.get(payout.classId) || [];
+    list.push(payout);
+    payoutsByClass.set(payout.classId, list);
+  });
+
+  // Book order, payees grouped under their book — the same order the settle resolved them in.
+  const rows: PlusSettleCSVRow[] = [];
+  result.books.forEach((book) => {
+    const bookColumns = {
+      periodId,
+      classId: book.classId,
+      bookAmountCents: csvNum(book.amountCents),
+      bookReaderCount: csvNum(book.readerCount),
+    };
+    const payouts = payoutsByClass.get(book.classId) || [];
+    payouts.forEach((payout) => rows.push({
+      ...bookColumns,
+      wallet: payout.wallet,
+      amountCents: csvNum(payout.amountCents),
+      outcome: payout.outcome,
+      ledgerStatus: payout.ledgerStatus,
+      ledgerAmountCents: csvNum(payout.ledgerAmountCents),
+      transferId: payout.transferId,
+      readingTimeMs: csvNum(payout.readingTimeMs),
+      ttsTimeMs: csvNum(payout.ttsTimeMs),
+    }));
+    if (!payouts.length) {
+      rows.push({ ...bookColumns, skipReason: book.skipReason });
+    }
+  });
+
+  return buildCSV([...PLUS_SETTLE_CSV_COLUMNS], rows);
 }
 
 /**
@@ -467,15 +640,15 @@ export async function sweepPlusReadingPendingPayouts({ dryRun }: { dryRun: boole
     }))
     .filter((p) => p.walletCents > 0);
 
-  const outcomes = await settleWalletPayouts(payouts, { dryRun });
+  const results = await settleWalletPayouts(payouts, { dryRun });
 
   let paidCount = 0;
   let stillPendingCount = 0;
   let paidCents = 0;
-  outcomes.forEach((outcome, index) => {
+  results.forEach(({ outcome, walletCents }) => {
     if (outcome === 'paid') {
       paidCount += 1;
-      paidCents += payouts[index].walletCents;
+      paidCents += walletCents;
     } else if (outcome === 'pending') {
       stillPendingCount += 1;
     }

--- a/src/util/csv.ts
+++ b/src/util/csv.ts
@@ -1,5 +1,6 @@
-// Shared CSV serialization for product-catalog feeds (Meta, OpenAI file-upload).
-// Centralizes the security-sensitive escaping so it can't drift between feeds.
+// Shared CSV serialization for product-catalog feeds (Meta, OpenAI file-upload)
+// and admin exports. Centralizes the security-sensitive escaping so it can't
+// drift between callers.
 
 // Defang spreadsheet formula injection (CWE-1236): publisher-supplied fields
 // (title/description/brand) could start with a formula trigger. The platform
@@ -19,7 +20,7 @@ export function escapeCSVField(value: string | undefined): string {
 
 // Emit a header row in column order followed by one row per item. Items are
 // expected to hold string (or undefined) values; absent columns render empty.
-export function buildCatalogCSV<T>(columns: Array<keyof T>, items: T[]): string {
+export function buildCSV<T>(columns: Array<keyof T>, items: T[]): string {
   const header = columns.join(',');
   const rows = items.map((item) => columns
     .map((col) => escapeCSVField(item[col] as unknown as string | undefined))

--- a/test/api/plus-settle.test.ts
+++ b/test/api/plus-settle.test.ts
@@ -203,6 +203,120 @@ describe('POST /plus/admin/reading/settle — settle guards', () => {
   });
 });
 
+describe('POST /plus/admin/reading/settle — settled review & CSV', () => {
+  const CLASS_ID = mockEVMAddress(0x77);
+  const OWNER = mockEVMAddress(0x78);
+  const PERIOD = '2026-04';
+
+  // An earlier settle paid 55c; today's static config recomputes 60c for the same usage.
+  // The two must stay distinguishable so a re-run surfaces config drift instead of hiding it.
+  async function seedSettledBook() {
+    await seedUsage(CLASS_ID, '2026-04-05', Date.UTC(2026, 3, 5), min(60), OWNER);
+    // The stub only materializes a subcollection under an existing parent doc.
+    await likeNFTBookUserCollection.doc(OWNER).set({} as any, { merge: true });
+    await likeNFTBookUserCollection.doc(OWNER)
+      .collection('plusReadingPayouts').doc(`${PERIOD}_${CLASS_ID}`)
+      .set({
+        periodId: PERIOD,
+        classId: CLASS_ID,
+        wallet: OWNER,
+        amountCents: 55,
+        status: 'paid',
+        transferId: 'tr_test',
+      } as any);
+  }
+
+  it('reports an already-paid split as settled at its ledger amount', async () => {
+    await seedSettledBook();
+
+    const res = await post({
+      periodId: PERIOD, dryRun: true, mode: 'static', includePayouts: true,
+    }, AUTH_HEADER);
+    expect(res.status).toBe(200);
+    expect(res.data).toMatchObject({
+      settledCount: 1, settledCents: 55, paidCount: 0, pendingCount: 0, paidCents: 0,
+    });
+    expect(res.data.books[0]).toMatchObject({
+      classId: CLASS_ID, amountCents: 60, settledCents: 55, paidCents: 0, payeeCount: 1,
+    });
+    expect(res.data.payouts).toMatchObject([{
+      classId: CLASS_ID,
+      wallet: OWNER,
+      amountCents: 60,
+      outcome: 'settled',
+      ledgerStatus: 'paid',
+      ledgerAmountCents: 55,
+      transferId: 'tr_test',
+    }]);
+  });
+
+  it('omits the payout rows unless asked', async () => {
+    await seedSettledBook();
+
+    const res = await post({ periodId: PERIOD, dryRun: true, mode: 'static' }, AUTH_HEADER);
+    expect(res.status).toBe(200);
+    expect(res.data.payouts).toBeUndefined();
+    expect(res.data.settledCount).toBe(1);
+  });
+
+  it('reports why a book with usage produced no payout', async () => {
+    // Book doc with neither connectedWallets nor ownerWallet — no payee to resolve.
+    await likeNFTBookCollection.doc(CLASS_ID).set({ classId: CLASS_ID } as any);
+    await likeNFTBookCollection.doc(CLASS_ID).collection('plusUsage').doc('2026-04-05')
+      .set({ readingTimeMs: min(60), ttsTimeMs: 0, dayMs: Date.UTC(2026, 3, 5) } as any);
+    // Half a minute allocates to 0.5c, which floors to nothing.
+    const dustClassId = mockEVMAddress(0x79);
+    await seedUsage(dustClassId, '2026-04-06', Date.UTC(2026, 3, 6), 30 * 1000, OWNER);
+
+    const res = await post({ periodId: PERIOD, dryRun: true, mode: 'static' }, AUTH_HEADER);
+    expect(res.status).toBe(200);
+    const byClass = Object.fromEntries(res.data.books.map((b) => [b.classId, b]));
+    expect(byClass[CLASS_ID]).toMatchObject({ amountCents: 60, skipReason: 'noPayee' });
+    expect(byClass[dustClassId]).toMatchObject({ amountCents: 0, skipReason: 'belowCent' });
+  });
+
+  it('rejects an unrecognized format', async () => {
+    const res = await postTo(`${PATH}?format=xlsx`)(
+      { periodId: PERIOD, dryRun: true },
+      AUTH_HEADER,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('exports the payout rows as CSV, including books that paid nobody', async () => {
+    await seedSettledBook();
+    // A book with usage but no resolvable payee still has to reach the export.
+    const orphanClassId = mockEVMAddress(0x7a);
+    await likeNFTBookCollection.doc(orphanClassId).set({ classId: orphanClassId } as any);
+    await likeNFTBookCollection.doc(orphanClassId).collection('plusUsage').doc('2026-04-07')
+      .set({ readingTimeMs: min(30), ttsTimeMs: 0, dayMs: Date.UTC(2026, 3, 7) } as any);
+
+    const res = await postTo(`${PATH}?format=csv`)(
+      { periodId: PERIOD, dryRun: true, mode: 'static' },
+      AUTH_HEADER,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('text/csv; charset=utf-8');
+    expect(res.headers['content-disposition']).toBe(
+      `attachment; filename="plus-settle-${PERIOD}-dryrun.csv"`,
+    );
+
+    const [header, ...rows] = res.data.trim().split('\n');
+    expect(header).toBe([
+      'periodId', 'classId', 'wallet', 'amountCents', 'outcome', 'ledgerStatus',
+      'ledgerAmountCents', 'transferId', 'readingTimeMs', 'ttsTimeMs',
+      'bookAmountCents', 'bookReaderCount', 'skipReason',
+    ].join(','));
+    expect(rows).toContain(
+      `${PERIOD},${CLASS_ID},${OWNER},60,settled,paid,55,tr_test,${min(60)},0,60,0,`,
+    );
+    // Payee-less book: no wallet/outcome/ledger columns, but its amount and reason survive.
+    expect(rows).toContain([
+      PERIOD, orphanClassId, '', '', '', '', '', '', '', '', 30, 0, 'noPayee',
+    ].join(','));
+  });
+});
+
 describe('POST /plus/admin/reading/sweep', () => {
   it('rejects requests without the admin token', async () => {
     const res = await postSweep({ dryRun: true });


### PR DESCRIPTION
A dry run over a completed period reported zeros: already-paid splits collapsed to `skipped` and were dropped from the counters. They now come back as `settled` at their ledger amounts, so re-running a dry run doubles as a review of what the period actually paid — and the ledger amount sitting next to this run's recomputed one surfaces config drift.

Books gained per-outcome rollups and a `skipReason`, so usage that produced no payout stays visible in the response instead of only reaching the logs, and reaches the export as a payee-less row.

`?format=csv` returns the per-(book, payee) rows as a download, behind the same admin token. Each row carries the payout's transfer id, whether an earlier run made it or this one did. `buildCatalogCSV` moved to `src/util/csv.ts` as `buildCSV`, since it is no longer catalog-specific.