### PR TITLE
[TAS-6291] 🔥 Drop the legacy client-signed arweave upload endpoints

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -64,8 +64,11 @@ config.ARWEAVE_EVM_TARGET_ADDRESS = '';
 config.IPFS_ENDPOINT = 'https://ipfs.infura.io:5001/api/v0';
 config.REPLICA_IPFS_ENDPOINTS = [];
 config.ARWEAVE_LINK_INTERNAL_TOKEN = '';
-config.ARWEAVE_SPONSORED_DAILY_UPLOAD_LIMIT = 10;
-config.ARWEAVE_SPONSORED_DAILY_BYTES_LIMIT = 100 * 1024 * 1024; // 100MB
+// Staging costs the caller nothing up front, so this quota is the only bound on
+// GCS staging (both tiers) and on sponsored open-tier Arweave spend. The two
+// limits are coupled: they cross over at a 10MB average file, so tune them together.
+config.ARWEAVE_SPONSORED_DAILY_UPLOAD_LIMIT = 20;
+config.ARWEAVE_SPONSORED_DAILY_BYTES_LIMIT = 200 * 1024 * 1024; // 200MB
 // Cloud KMS cryptoKey resource name used to wrap content keys at rest in
 // Firestore. Empty = passthrough (dev/test store plaintext); prod sets this.
 config.ARWEAVE_KEY_KMS_NAME = process.env.ARWEAVE_KEY_KMS_NAME || '';

--- a/src/routes/arweave/index.ts
+++ b/src/routes/arweave/index.ts
@@ -2,9 +2,7 @@ import { Router } from 'express';
 import uuidv4 from 'uuid/v4';
 import {
   ARWEAVE_MAX_SIZE_V2,
-  checkArweaveTxV2,
   estimateUploadToArweaveV2,
-  pushArweaveSingleFileToIPFS,
 } from '../../util/api/arweave';
 import publisher from '../../util/gcloudPub';
 import { API_HOSTNAME, ARWEAVE_GATEWAY, PUBSUB_TOPIC_MISC } from '../../constant';
@@ -12,31 +10,26 @@ import {
   ARWEAVE_EVM_TARGET_ADDRESS,
   ARWEAVE_LINK_INTERNAL_TOKEN,
 } from '../../../config/config';
-import { getPublicKey, signData as signArweaveData } from '../../util/arweave/signer';
 import {
-  createNewArweaveTx,
   createNewGcsUploadTx,
   getArweaveTxInfo,
   getOwnedPendingGcsTx,
   isArweaveTxOwner,
   markGcsTxCompleted,
-  updateArweaveTxStatus,
   rotateArweaveTxAccessToken,
   resolveArweaveTxKey,
   isArweaveTxEncrypted,
 } from '../../util/api/arweave/tx';
 import { getRemainingQuota, withReservedQuota } from '../../util/api/arweave/quota';
-import { reconcilePendingIrysFunding, fundUploadIfNeeded } from '../../util/api/arweave/funding';
+import { reconcilePendingIrysFunding } from '../../util/api/arweave/funding';
 import {
   deleteStagedObject,
   getStagedUploadSignedUrl,
-  ingestProtectedContent,
   promoteStagedObject,
   verifyStagedObject,
 } from '../../util/api/arweave/ingest';
 import { uploadStagedObjectToArweave } from '../../util/api/arweave/openUpload';
 import { getTierContentUri, isEbookTierBucketEnabled } from '../../util/gcloudStorage';
-import { isAlreadyExistsError } from '../../util/misc';
 import {
   ArweaveEstimateBodySchema,
   ArweaveEstimateResponseSchema,
@@ -45,12 +38,7 @@ import {
   ArweaveGcsFinalizeResponseSchema,
   ArweaveGcsUploadInitBodySchema,
   ArweaveGcsUploadInitResponseSchema,
-  ArweaveRegisterBodySchema,
-  ArweaveRegisterResponseSchema,
-  ArweaveSignPaymentBodySchema,
-  ArweaveSignPaymentResponseSchema,
   ArweaveTxHashParamsSchema,
-  ArweavePublicKeyResponseSchema,
   ArweaveLinkResponseSchema,
   ArweaveAccessTokenResponseSchema,
   ArweaveFundingReconcileBodySchema,
@@ -67,18 +55,6 @@ const router = Router();
 function getArweaveLinkV2Url(txHash: string): string {
   return `https://${API_HOSTNAME}/arweave/v2/link/${txHash}`;
 }
-
-router.get(
-  '/v2/public_key',
-  async (req, res, next) => {
-    try {
-      const publicKey = await getPublicKey();
-      sendValidatedJSON(res, ArweavePublicKeyResponseSchema, { publicKey: publicKey.toString('base64') });
-    } catch (error) {
-      next(error);
-    }
-  },
-);
 
 router.post(
   '/v2/estimate',
@@ -120,181 +96,6 @@ router.post(
         }
       }
       sendValidatedJSON(res, ArweaveEstimateResponseSchema, result);
-    } catch (error) {
-      next(error);
-    }
-  },
-);
-
-router.post(
-  '/v2/sign_payment_data',
-  jwtOptionalAuth('write:iscn'),
-  validateBody(ArweaveSignPaymentBodySchema),
-  async (req, res, next) => {
-    try {
-      const {
-        fileSize, ipfsHash, txHash, signatureData, txToken = 'BASEETH',
-      } = req.body;
-
-      const isSponsored = txToken === 'SPONSORED';
-      if (isSponsored && !req.user?.wallet) {
-        throw new ValidationError('MISSING_USER', 401);
-      }
-      if (!isSponsored && !txHash) {
-        throw new Error('MISSING_TX_HASH');
-      }
-
-      const estimate = await estimateUploadToArweaveV2(
-        fileSize,
-        ipfsHash,
-        { margin: 0, checkDuplicate: false },
-      );
-      const {
-        ETH,
-        arweaveId,
-        isExists,
-      } = estimate;
-
-      let token: string;
-      let uploadId: string;
-
-      if (isSponsored) {
-        const { wallet } = req.user!;
-        uploadId = `sponsored-${uuidv4()}`;
-        token = await withReservedQuota(wallet, fileSize, ETH, async () => {
-          const newToken = await createNewArweaveTx(uploadId, {
-            ipfsHash,
-            fileSize,
-            ownerWallet: wallet,
-            isSponsored: true,
-            sponsoredETH: ETH,
-          });
-          // Sponsored uploads carry no payment to pass through; the standing Irys
-          // balance buffer covers them.
-          return newToken;
-        });
-      } else {
-        uploadId = txHash;
-        const { paidETH } = await checkArweaveTxV2({
-          fileSize, ipfsHash, txHash, ETH, txToken,
-        });
-        try {
-          token = await createNewArweaveTx(txHash, {
-            ipfsHash,
-            fileSize,
-            ownerWallet: req.user?.wallet || '',
-          });
-        } catch (error) {
-          if (isAlreadyExistsError(error)) {
-            // eslint-disable-next-line no-console
-            console.warn(error);
-            res.status(429).send('TX_HASH_ALREADY_USED');
-            return;
-          }
-          throw error;
-        }
-        fundUploadIfNeeded(uploadId, paidETH);
-      }
-
-      // TODO: verify signatureData match filesize if possible
-      const signature = await signArweaveData(Buffer.from(signatureData, 'base64'));
-      const signatureHex = signature && signature.toString('base64');
-
-      sendValidatedJSON(res, ArweaveSignPaymentResponseSchema, {
-        token,
-        id: uploadId,
-        arweaveId,
-        isExists,
-        signature: signatureHex,
-      });
-      publisher.publish(PUBSUB_TOPIC_MISC, req, {
-        logType: isSponsored ? 'arweaveSponsoredSigningV2' : 'arweaveSigningV2',
-        ipfsHash,
-        arweaveId,
-        ETH,
-        txHash: uploadId,
-        ...(isSponsored ? { wallet: req.user!.wallet } : {}),
-      });
-    } catch (error) {
-      next(error);
-    }
-  },
-);
-
-router.post(
-  '/v2/register',
-  jwtOptionalAuth('write:iscn'),
-  validateBody(ArweaveRegisterBodySchema),
-  async (req, res, next) => {
-    try {
-      const {
-        txHash, arweaveId, token, key, isRequireAuth = true, fileSHA256,
-      } = req.body;
-      if (isRequireAuth && !req.user?.wallet) throw new ValidationError('MISSING_USER', 401);
-      const tx = await getArweaveTxInfo(txHash);
-      if (!tx) throw new ValidationError('TX_NOT_FOUND', 404);
-      const { ownerWallet, authToken } = tx;
-      const userWallet = req.user?.wallet || '';
-      // Token match first: it needs no Firestore read, unlike the owner lookup.
-      const isAuthed = !!(authToken && authToken === token)
-        || (await isArweaveTxOwner(userWallet, ownerWallet));
-      if (!isAuthed) throw new ValidationError('INVALID_TOKEN', 403);
-      if (tx.status !== 'pending') throw new ValidationError('TX_ALREADY_REGISTERED', 409);
-      const accessToken = await updateArweaveTxStatus(txHash, {
-        arweaveId,
-        ownerWallet: req.user?.wallet || '',
-        key,
-        isRequireAuth,
-        fileSHA256,
-      });
-      sendValidatedJSON(res, ArweaveRegisterResponseSchema, {
-        link: getArweaveLinkV2Url(txHash),
-        token,
-        accessToken,
-        isRequireAuth,
-      });
-      const {
-        ipfsHash, fileSize,
-      } = tx;
-      publisher.publish(PUBSUB_TOPIC_MISC, req, {
-        logType: 'arweaveIdRegisterStartV2',
-        ipfsHash,
-        arweaveId,
-        txHash,
-      });
-      await pushArweaveSingleFileToIPFS({ arweaveId, ipfsHash, fileSize });
-      publisher.publish(PUBSUB_TOPIC_MISC, req, {
-        logType: 'arweaveIdRegisterCompleteV2',
-        ipfsHash,
-        arweaveId,
-        txHash,
-      });
-      // Dual-store protected uploads into the private CMEK bucket (Phase 3).
-      // Best-effort: a failure here leaves Arweave as the only copy, which is
-      // today's status quo; Phase 4's re-ingest sweep catches stragglers.
-      if (key) {
-        try {
-          const ingested = await ingestProtectedContent(txHash, {
-            arweaveId, key, ipfsHash, fileSize, fileSHA256,
-          });
-          if (ingested) {
-            publisher.publish(PUBSUB_TOPIC_MISC, req, {
-              logType: 'arweaveProtectedIngestCompleteV2',
-              arweaveId,
-              txHash,
-              contentBucketPath: ingested.contentBucketPath,
-              fileSHA256: ingested.fileSHA256,
-            });
-          }
-        } catch (error) {
-          publisher.publish(PUBSUB_TOPIC_MISC, req, {
-            logType: 'arweaveProtectedIngestErrorV2',
-            arweaveId,
-            txHash,
-            error: (error as Error).message,
-          });
-        }
-      }
     } catch (error) {
       next(error);
     }

--- a/src/util/api/arweave/ingest.ts
+++ b/src/util/api/arweave/ingest.ts
@@ -302,6 +302,10 @@ export async function deleteStagedObject(
  * storing plaintext-at-rest under a key-free path. No-op when the bucket is
  * unconfigured. Gateway fallback only covers opening the stream; once bytes are
  * flowing into GCS a mid-stream failure aborts rather than restarting.
+ *
+ * No live route calls this: new protected uploads stage straight into the bucket
+ * via /v2/gcs/finalize. It stays for the Phase 4 sweep, which pulls legacy books
+ * through this same decrypt path before their encryptedKey is destroyed.
  */
 export async function ingestProtectedContent(txHash: string, {
   arweaveId,
@@ -360,7 +364,7 @@ export async function ingestProtectedContent(txHash: string, {
       contentBucketPath,
       contentType,
       // Only backfill the doc hash when the client supplied none; a client
-      // anchor was already stored at register and verified above.
+      // anchor was already stored with the legacy doc and verified above.
       ...(fileSHA256 ? {} : { fileSHA256: computedSHA256 }),
     });
     return { contentBucketPath, fileSHA256: computedSHA256 };

--- a/src/util/api/arweave/schemas.ts
+++ b/src/util/api/arweave/schemas.ts
@@ -9,23 +9,6 @@ export const ArweaveEstimateBodySchema = z.object({
   ipfsHash: z.string().optional(),
 });
 
-export const ArweaveSignPaymentBodySchema = z.object({
-  fileSize: z.coerce.number().int().positive(),
-  ipfsHash: z.string().min(1),
-  txHash: z.string().optional(),
-  signatureData: z.string().min(1),
-  txToken: z.enum(['BASEETH', 'SPONSORED']).optional(),
-});
-
-export const ArweaveRegisterBodySchema = z.object({
-  txHash: z.string().min(1),
-  arweaveId: z.string().min(1),
-  token: z.string().optional(),
-  key: z.string().optional(),
-  isRequireAuth: z.boolean().optional(),
-  fileSHA256: Sha256HexSchema.optional(),
-});
-
 export const ArweaveTxHashParamsSchema = z.object({
   txHash: z.string().min(1),
 });
@@ -60,9 +43,9 @@ export const ArweaveGcsUploadInitBodySchema = z.object({
   }
 });
 
-// Server-side Arweave upload of an already-staged open-tier object. Payment
-// mirrors /v2/sign_payment_data: a Base ETH tx the caller already broadcast, or
-// SPONSORED against the daily quota.
+// Server-side Arweave upload of an already-staged open-tier object. Payment is
+// either a Base ETH tx the caller already broadcast, or SPONSORED against the
+// daily quota.
 export const ArweaveGcsArweaveBodySchema = z.object({
   ipfsHash: z.string().min(1),
   paymentTxHash: z.string().optional(),
@@ -93,25 +76,6 @@ export const ArweaveEstimateResponseSchema = z.object({
   remainingBytes: z.number().int().min(0).optional(),
   remainingUploads: z.number().int().min(0).optional(),
   isUnlimited: z.boolean().optional(),
-});
-
-export const ArweaveSignPaymentResponseSchema = z.object({
-  token: z.string(),
-  id: z.string(),
-  arweaveId: z.string().optional(),
-  isExists: z.boolean().optional(),
-  signature: z.string().optional(),
-});
-
-export const ArweaveRegisterResponseSchema = z.object({
-  link: z.string().url(),
-  token: z.string().optional(),
-  accessToken: z.string(),
-  isRequireAuth: z.boolean(),
-});
-
-export const ArweavePublicKeyResponseSchema = z.object({
-  publicKey: z.string(),
 });
 
 export const ArweaveLinkResponseSchema = z.object({

--- a/src/util/api/arweave/tx.ts
+++ b/src/util/api/arweave/tx.ts
@@ -1,39 +1,11 @@
 import uuidv4 from 'uuid/v4';
 import { FieldValue, iscnArweaveTxCollection } from '../../firebase';
-import { wrapKey, unwrapKey, isKMSEnabled } from '../../kms';
+import { unwrapKey, isKMSEnabled } from '../../kms';
 import { getUserWalletsByWallet } from '../users/getPublicInfo';
 import { ValidationError } from '../../ValidationError';
 import { isAlreadyExistsError } from '../../misc';
 import type { ArweaveTxData } from '../../../types/transaction';
 import type { ContentTier } from '../../gcloudStorage';
-
-export async function createNewArweaveTx(docId: string, {
-  ipfsHash,
-  fileSize,
-  ownerWallet,
-  isSponsored,
-  sponsoredETH,
-}: {
-  ipfsHash: string;
-  fileSize: number;
-  ownerWallet: string;
-  isSponsored?: boolean;
-  sponsoredETH?: string;
-}): Promise<string> {
-  const token = uuidv4();
-  const data: ArweaveTxData = {
-    token,
-    ipfsHash,
-    fileSize,
-    ownerWallet,
-    status: 'pending',
-    timestamp: FieldValue.serverTimestamp(),
-    lastUpdateTimestamp: FieldValue.serverTimestamp(),
-    ...(isSponsored ? { isSponsored: true, sponsoredETH } : {}),
-  };
-  await iscnArweaveTxCollection.doc(docId).create(data);
-  return token;
-}
 
 // GCS-direct upload doc (ADR 0001 Phase 3): no content key ever exists, and no
 // legacy `token` — the flow is JWT-owner-gated end to end. fileSHA256 is the
@@ -71,9 +43,8 @@ export async function createNewGcsUploadTx(docId: string, {
 }
 
 // Complete a GCS-direct upload: the ingest markers plus the lifecycle fields
-// legacy docs get from updateArweaveTxStatus() at register (status,
-// isRequireAuth, accessToken) — this flow never calls register, and without
-// isRequireAuth the link endpoint would serve the doc unauthenticated.
+// (status, isRequireAuth, accessToken) — without isRequireAuth the link
+// endpoint would serve the doc unauthenticated.
 // Open records pass isRequireAuth: false — their bytes are public on Arweave
 // anyway, so gating the mirror would leave the fallback more available than it.
 export async function markGcsTxCompleted(txHash: string, {
@@ -102,12 +73,10 @@ export async function getArweaveTxInfo(txHash: string): Promise<ArweaveTxData | 
 
 // Consume a Base payment exactly once.
 //
-// The legacy flow gets this for free: it keys the upload doc on the *payment*
-// hash, so a replay hits ALREADY_EXISTS. GCS-direct docs are keyed on gcs-<uuid>
-// instead, and checkArweaveTxV2 is pure read-only verification that happily
-// passes the same hash twice — so without this a caller could stage a file N
-// times and settle all N against one payment. Claiming it in the same collection
-// also stops a payment being spent once here and once via /v2/register.
+// GCS-direct docs are keyed on gcs-<uuid>, so the doc id carries no uniqueness
+// against the payment, and checkArweaveTxV2 is pure read-only verification that
+// happily passes the same hash twice — without this claim a caller could stage a
+// file N times and settle all N against one payment.
 export async function claimArweaveTxPayment(paymentTxHash: string, {
   uploadId,
   ownerWallet,
@@ -173,42 +142,6 @@ export async function getOwnedPendingGcsTx(
   if (!(await isArweaveTxOwner(reqUserWallet, tx.ownerWallet))) throw new ValidationError('NOT_OWNER', 403);
   if (tx.status !== 'pending') throw new ValidationError('TX_ALREADY_REGISTERED', 409);
   return tx;
-}
-
-export async function updateArweaveTxStatus(txHash: string, {
-  arweaveId,
-  ownerWallet,
-  key = '',
-  isRequireAuth = false,
-  fileSHA256 = '',
-}: {
-  arweaveId: string;
-  ownerWallet: string;
-  key?: string;
-  isRequireAuth?: boolean;
-  fileSHA256?: string;
-}): Promise<string> {
-  const accessToken = uuidv4();
-  // Under KMS store wrapped ciphertext in `encryptedKey` (AAD = txHash); in
-  // passthrough store plaintext in legacy `key` so enabling KMS later never
-  // decrypts non-ciphertext. Delete the opposite field to leave no plaintext.
-  let keyFields = {};
-  if (key) {
-    keyFields = isKMSEnabled()
-      ? { encryptedKey: await wrapKey(key, txHash), key: FieldValue.delete() }
-      : { key, encryptedKey: FieldValue.delete() };
-  }
-  await iscnArweaveTxCollection.doc(txHash).update({
-    status: 'complete',
-    arweaveId,
-    isRequireAuth,
-    ownerWallet,
-    ...keyFields,
-    ...(fileSHA256 ? { fileSHA256: fileSHA256.toLowerCase() } : {}),
-    accessToken,
-    lastUpdateTimestamp: FieldValue.serverTimestamp(),
-  });
-  return accessToken;
 }
 
 // Record a protected-content ingest: the plaintext's path in the private

--- a/src/util/arweave/signer.ts
+++ b/src/util/arweave/signer.ts
@@ -66,14 +66,6 @@ export async function getSigner(): Promise<TypedEthereumSigner> {
   return signer;
 }
 
-export async function getPublicKey() {
-  return (await getSigner()).publicKey;
-}
-
-export async function signData(signatureData) {
-  return Buffer.from(await (await getSigner()).sign(signatureData));
-}
-
 // Resolve the base-eth deposit address, verifying against /info when reachable so a
 // node key rotation can't silently misroute funds. Falls back to the expected
 // address (config pin or network default) if /info is unavailable.

--- a/test/util/arweave-open-tier.test.ts
+++ b/test/util/arweave-open-tier.test.ts
@@ -48,8 +48,8 @@ describe('getDeterministicAnchor', () => {
   });
 });
 
-// The open flow keys its upload doc on gcs-<uuid>, not on the payment hash, so it
-// loses the doc-id uniqueness that gives /v2/register replay protection for free.
+// The open flow keys its upload doc on gcs-<uuid>, not on the payment hash, so the
+// doc id carries no uniqueness against the payment.
 // checkArweaveTxV2 is pure read-only verification and passes the same hash twice,
 // so the claim below is the only thing stopping N staged uploads settling against
 // one payment.


### PR DESCRIPTION
publish-3ook-com now stages every file through GCS, so nothing asks the API to sign an ANS-104 item for the browser any more. /v2/public_key, /v2/sign_payment_data and /v2/register lose their last caller, along with the five schemas only they used.

That also strands createNewArweaveTx, updateArweaveTxStatus, getPublicKey and signData, so they go too. ingestProtectedContent stays despite having no route left: Phase 4 re-ingests legacy books through that same decrypt path. Comments naming a deleted route are reworded rather than dropped — the invariants they explain still hold.

With the client no longer paying on-chain, every publish it sends is now sponsored, so covers and DRM ebooks spend quota slots they never used to. Raise the daily ceiling to 20 uploads / 200MB to fit a normal book.