### PR TITLE
💄 Show the book title in Plus reading transfers, not the classId

### DIFF
--- a/src/util/api/plus/settleJob.ts
+++ b/src/util/api/plus/settleJob.ts
@@ -113,7 +113,10 @@ function getCachedBookName(classId: string, cache: BookNameCache) {
   const cached = cache.get(classId);
   if (cached) return cached;
   const pending = likeNFTBookCollection.doc(classId).get()
-    .then((snap) => (snap.data() as NFTBookListingInfo | undefined)?.name);
+    .then((snap) => (snap.data() as NFTBookListingInfo | undefined)?.name)
+    // The title is only a transfer label and falls back to the classId, so a failed read
+    // must not abort the payout — nor stay cached as a rejection for the book's other payees.
+    .catch(() => undefined);
   cache.set(classId, pending);
   return pending;
 }

--- a/src/util/api/plus/settleJob.ts
+++ b/src/util/api/plus/settleJob.ts
@@ -28,6 +28,9 @@ import type { NFTBookListingInfo } from '../../../types/book';
 
 const DEFAULT_REVSHARE_RATE = 0.3;
 
+// Margin under Stripe's description cap, so a long title can't fail the transfer.
+const MAX_DESCRIPTION_TITLE_LENGTH = 200;
+
 // Kept modest so a large period doesn't burst past Stripe's rate limit and leave
 // transfers spuriously carried forward as `pending`.
 const SETTLE_CONCURRENCY = 20;
@@ -41,6 +44,9 @@ interface BookUsage {
 interface WalletPayout {
   periodId: string;
   book: BookUsage;
+  // Title for the transfer description, when the caller already holds the book doc.
+  // Left unset (the sweep) it is read lazily — see getCachedBookName.
+  bookName?: string;
   wallet: string;
   walletCents: number;
 }
@@ -96,6 +102,23 @@ function getCachedBookUserInfo(wallet: string, cache: WalletUserInfoCache) {
 }
 
 /**
+ * Per-run cache of book titles, keyed by classId. Only the transfer description needs the
+ * title, so it's read at the last moment — a payout that short-circuits (already paid, dry
+ * run, payee not Connect-ready) never reads the book doc. Caches the in-flight promise, so
+ * a book split across several payees reads once.
+ */
+type BookNameCache = Map<string, Promise<string | undefined>>;
+
+function getCachedBookName(classId: string, cache: BookNameCache) {
+  const cached = cache.get(classId);
+  if (cached) return cached;
+  const pending = likeNFTBookCollection.doc(classId).get()
+    .then((snap) => (snap.data() as NFTBookListingInfo | undefined)?.name);
+  cache.set(classId, pending);
+  return pending;
+}
+
+/**
  * Pays one payee its share of a book for the period, returning how it resolved plus the
  * pre-existing payout record, if any.
  * - dryRun: reports already-paid as `settled`, else classifies by Connect-readiness, without
@@ -105,10 +128,11 @@ function getCachedBookUserInfo(wallet: string, cache: WalletUserInfoCache) {
  * - otherwise: a Stripe Connect transfer (idempotency-keyed) + a `paid` payout record.
  */
 async function settleWalletPayout({
-  periodId, book, wallet, walletCents, dryRun, userInfoCache,
+  periodId, book, bookName, wallet, walletCents, dryRun, userInfoCache, bookNameCache,
 }: WalletPayout & {
   dryRun: boolean;
   userInfoCache: WalletUserInfoCache;
+  bookNameCache: BookNameCache;
 }): Promise<PayoutResult> {
   const payoutDocRef = likeNFTBookUserCollection
     .doc(wallet)
@@ -151,6 +175,10 @@ async function settleWalletPayout({
     return { outcome: 'pending', ledger: { status: 'pending', amountCents: walletCents } };
   }
   const { stripeConnectAccountId } = userInfo;
+  const title = bookName ?? await getCachedBookName(book.classId, bookNameCache);
+  // A legacy doc could hold a non-string name — fall back rather than throw mid-transfer.
+  const bookLabel = (typeof title === 'string'
+    && title.trim().slice(0, MAX_DESCRIPTION_TITLE_LENGTH)) || book.classId;
 
   // Pool-funded transfer from the platform balance — no source_transaction (unlike a
   // per-charge commission). Idempotency key makes a re-run reuse the same transfer.
@@ -159,7 +187,7 @@ async function settleWalletPayout({
     currency: 'usd',
     destination: stripeConnectAccountId,
     transfer_group: `plus-revshare-${periodId}`,
-    description: `Li3rary revenue share ${periodId} (${book.classId})`,
+    description: `Li3rary revenue share ${periodId} (${bookLabel})`,
     metadata: {
       type: 'plusReadingRevShare',
       periodId,
@@ -217,9 +245,12 @@ function settleWalletPayouts(
   { dryRun }: { dryRun: boolean },
 ): Promise<SettledWalletPayout[]> {
   const userInfoCache: WalletUserInfoCache = new Map();
+  const bookNameCache: BookNameCache = new Map();
   return mapInChunks(payouts, async (payout) => ({
     ...payout,
-    ...await settleWalletPayout({ ...payout, dryRun, userInfoCache }),
+    ...await settleWalletPayout({
+      ...payout, dryRun, userInfoCache, bookNameCache,
+    }),
   }));
 }
 
@@ -422,7 +453,7 @@ export async function settlePlusReadingPeriod({
     }
     for (const { wallet, amountCents: walletCents } of splits) {
       payouts.push({
-        periodId, book, wallet, walletCents,
+        periodId, book, bookName: bookData.name, wallet, walletCents,
       });
     }
   }
@@ -627,6 +658,8 @@ export async function sweepPlusReadingPendingPayouts({ dryRun }: { dryRun: boole
     .filter((p) => p.wallet && p.classId && p.periodId);
 
   // Each record carries its own periodId, so a sweep settles payouts across many periods.
+  // No bookName: the record only stores the classId, so the title is read lazily, and only
+  // for the payouts that actually transfer.
   const payouts: WalletPayout[] = pending
     .map((p) => ({
       periodId: String(p.periodId),

--- a/test/unit/plus-sweep-transfer.test.ts
+++ b/test/unit/plus-sweep-transfer.test.ts
@@ -1,0 +1,114 @@
+import {
+  describe, it, expect, vi, beforeEach, afterEach,
+} from 'vitest';
+
+const { mockTransferCreate } = vi.hoisted(() => ({
+  mockTransferCreate: vi.fn(),
+}));
+
+vi.mock('../../src/util/stripe', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    getStripeClient: () => ({ transfers: { create: mockTransferCreate } }),
+  };
+});
+
+// eslint-disable-next-line import/first
+import { sweepPlusReadingPendingPayouts } from '../../src/util/api/plus/settleJob';
+// eslint-disable-next-line import/first
+import { likeNFTBookCollection, likeNFTBookUserCollection } from '../../src/util/firebase';
+
+const PERIOD = '2026-01';
+
+// Seeds one Connect-ready payee with a pending payout, the shape the sweep re-attempts.
+// The pending record stores only the classId, so the title comes from the book doc.
+async function seedPending(classId: string, wallet: string, {
+  name, amountCents = 100,
+}: { name?: unknown; amountCents?: number } = {}) {
+  if (name !== undefined) {
+    await likeNFTBookCollection.doc(classId).set({ classId, name } as any, { merge: true });
+  }
+  await likeNFTBookUserCollection.doc(wallet).set({
+    isStripeConnectReady: true,
+    stripeConnectAccountId: `acct_${wallet}`,
+  } as any, { merge: true });
+  await likeNFTBookUserCollection.doc(wallet)
+    .collection('plusReadingPayouts').doc(`${PERIOD}_${classId}`)
+    .set({
+      periodId: PERIOD, classId, wallet, amountCents, status: 'pending',
+    } as any);
+}
+
+const descriptionOf = (call: number = 0) => mockTransferCreate.mock.calls[call][0].description;
+
+describe('sweepPlusReadingPendingPayouts transfer description', () => {
+  beforeEach(() => {
+    mockTransferCreate.mockReset();
+    mockTransferCreate.mockImplementation(async () => ({ id: 'tr_test' }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('labels the transfer with the book title', async () => {
+    await seedPending('0xbook1', '0xwallet1', { name: 'The Great Book' });
+
+    const res = await sweepPlusReadingPendingPayouts({ dryRun: false });
+
+    expect(res.paidCount).toBe(1);
+    expect(mockTransferCreate).toHaveBeenCalledTimes(1);
+    expect(descriptionOf()).toBe(`Li3rary revenue share ${PERIOD} (The Great Book)`);
+  });
+
+  it('truncates an overlong title', async () => {
+    const longName = 'a'.repeat(250);
+    await seedPending('0xbook2', '0xwallet2', { name: longName });
+
+    await sweepPlusReadingPendingPayouts({ dryRun: false });
+
+    expect(descriptionOf()).toBe(`Li3rary revenue share ${PERIOD} (${'a'.repeat(200)})`);
+  });
+
+  it('falls back to the classId when the book doc has no title', async () => {
+    await seedPending('0xbook3', '0xwallet3');
+
+    await sweepPlusReadingPendingPayouts({ dryRun: false });
+
+    expect(descriptionOf()).toBe(`Li3rary revenue share ${PERIOD} (0xbook3)`);
+  });
+
+  it('falls back to the classId when a legacy doc holds a non-string title', async () => {
+    await seedPending('0xbook4', '0xwallet4', { name: { en: 'Localized' } });
+
+    await sweepPlusReadingPendingPayouts({ dryRun: false });
+
+    expect(descriptionOf()).toBe(`Li3rary revenue share ${PERIOD} (0xbook4)`);
+  });
+
+  it('still transfers when the title read fails', async () => {
+    await seedPending('0xbook5', '0xwallet5', { name: 'Unreadable' });
+    vi.spyOn(likeNFTBookCollection, 'doc').mockReturnValue({
+      get: () => Promise.reject(new Error('firestore unavailable')),
+    } as any);
+
+    const res = await sweepPlusReadingPendingPayouts({ dryRun: false });
+
+    expect(res.paidCount).toBe(1);
+    expect(descriptionOf()).toBe(`Li3rary revenue share ${PERIOD} (0xbook5)`);
+  });
+
+  it('reads the book doc once for payees sharing a book', async () => {
+    await seedPending('0xbook6', '0xwallet6a', { name: 'Shared Book' });
+    await seedPending('0xbook6', '0xwallet6b');
+    const docSpy = vi.spyOn(likeNFTBookCollection, 'doc');
+
+    await sweepPlusReadingPendingPayouts({ dryRun: false });
+
+    expect(mockTransferCreate).toHaveBeenCalledTimes(2);
+    expect(docSpy).toHaveBeenCalledTimes(1);
+    expect(descriptionOf(0)).toBe(`Li3rary revenue share ${PERIOD} (Shared Book)`);
+    expect(descriptionOf(1)).toBe(`Li3rary revenue share ${PERIOD} (Shared Book)`);
+  });
+});


### PR DESCRIPTION
Payees read the transfer description in their Stripe dashboard, where a bare classId means nothing.

The period settle already holds the book doc, so it passes the title down. The sweep only stores classIds on its payout records, so it reads the title lazily — an already-paid, dry-run, or not-yet-onboarded payout short-circuits before the description is built and never touches the book doc.

Transfers already sent keep their old description: the idempotency key is unchanged, so a re-run reuses the transfer it already made.