### PR TITLE
[TAS-6267] ✨ Rank the popular list by recent reading, not lifetime

### DIFF
--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -189,6 +189,8 @@ export interface NFTBookListingInfo {
   // Lifetime recorded reading + TTS time, denormalized from the `plusUsage`
   // rollups so listings can order by it. See recordPlusReadingUsage.
   plusReadingTotalMs?: number;
+  // Time-weighted reading score for popular order. See getReadingScoreIncrement.
+  plusReadingScore?: number;
   // Time-weighted paid-sales score for bestselling order. See getSaleScoreIncrement.
   salesScore?: number;
   lastSaleTimestamp?: any;

--- a/src/util/api/likernft/book/index.ts
+++ b/src/util/api/likernft/book/index.ts
@@ -332,6 +332,7 @@ export async function newNftBookInfo(
     // Seed the ranking sort keys: Firestore drops documents missing an `orderBy` field,
     // so an unseeded book would never surface in those listings at all.
     plusReadingTotalMs: 0,
+    plusReadingScore: 0,
     salesScore: 0,
   };
   const minPriceInDecimal = getMinListedPriceInDecimal(newPrices);
@@ -644,9 +645,10 @@ export async function listFilteredNFTBookInfo({
 }
 
 /**
- * Books ranked by lifetime recorded reading + TTS time (`plusReadingTotalMs`, maintained by
- * `recordPlusReadingUsage`), then newest-first so the large unread tail — every book is
- * zero-seeded — still browses in a sensible, stable order.
+ * Books ranked by recency-weighted reading + TTS time (`plusReadingScore`, maintained by
+ * `recordPlusReadingUsage`), so the list reflects what is being read now. The score decays
+ * but never reaches zero, so a book read long ago still outranks one never read at all;
+ * only the never-read tail ties, and it is zero-seeded and browses newest-first.
  */
 export async function listPopularNFTBookInfo({
   isPlusReadingEnabled,
@@ -658,7 +660,7 @@ export async function listPopularNFTBookInfo({
   key?: string;
 } = {}) {
   let snapshot = likeNFTBookCollection
-    .orderBy('plusReadingTotalMs', 'desc')
+    .orderBy('plusReadingScore', 'desc')
     .orderBy('timestamp', 'desc');
   if (isPlusReadingEnabled !== undefined) {
     snapshot = snapshot.where('isPlusReadingEnabled', '==', isPlusReadingEnabled);

--- a/src/util/api/likernft/book/popularity.ts
+++ b/src/util/api/likernft/book/popularity.ts
@@ -1,0 +1,25 @@
+import { ONE_DAY_IN_MS } from '../../../../constant';
+
+// Time-weighted popularity score: usage ms × 2^(days / halfLife), so recent reading outweighs
+// old reading without any decay job — writes happen only at usage time, no cron. Usage is
+// floored to the UTC day, which is what lets the backfill recompute a book's score from its
+// `plusUsage` daily rollups and land on what the live increments accumulated.
+// The product (not the exponent) overflows float64 around Sept 2045 — the millisecond
+// multiplicand costs ~6 months against salesScore's unit weight — so rebase both epochs
+// together well before then.
+export const READING_SCORE_EPOCH_MS = Date.UTC(2026, 7, 1);
+export const READING_SCORE_HALF_LIFE_DAYS = 7;
+
+export function getReadingScoreIncrement(usageMs: number, occurredAtMs: number) {
+  // Unlike a sale, a malformed duration has no honest floor — the event carries no unit of its
+  // own — so it scores nothing rather than guessing 1 the way getSaleScoreIncrement does.
+  // `occurredAtMs` is guarded too because it feeds the exponent and, unlike `usageMs`, carries
+  // no upper bound upstream (PlusReadingUsage `occurredAt` is only `int().positive()`): a units
+  // bug in the forwarder would otherwise land Infinity here, and an incremented Infinity pins a
+  // book to rank 1 permanently — the backfill can't heal it, since it recomputes off the same
+  // bad timestamp.
+  if (!(usageMs > 0) || !Number.isFinite(occurredAtMs)) return 0;
+  const days = Math.floor((occurredAtMs - READING_SCORE_EPOCH_MS) / ONE_DAY_IN_MS);
+  const increment = usageMs * 2 ** (days / READING_SCORE_HALF_LIFE_DAYS);
+  return Number.isFinite(increment) ? increment : 0;
+}

--- a/src/util/api/likernft/book/popularity.ts
+++ b/src/util/api/likernft/book/popularity.ts
@@ -1,12 +1,9 @@
 import { ONE_DAY_IN_MS } from '../../../../constant';
 
-// Time-weighted popularity score: usage ms × 2^(days / halfLife), so recent reading outweighs
-// old reading without any decay job — writes happen only at usage time, no cron. Usage is
-// floored to the UTC day, which is what lets the backfill recompute a book's score from its
-// `plusUsage` daily rollups and land on what the live increments accumulated.
-// The product (not the exponent) overflows float64 around Sept 2045 — the millisecond
-// multiplicand costs ~6 months against salesScore's unit weight — so rebase both epochs
-// together well before then.
+// Time-weighted popularity score: usage ms × 2^(days / halfLife), so ordering stays
+// recency-biased with writes only at usage time (no cron). Usage is bucketed to the UTC day
+// so backfills can recompute from `plusUsage` daily rollups and match live increments.
+// The product overflows float64 around Sept 2045; rebase the epoch well before then.
 export const READING_SCORE_EPOCH_MS = Date.UTC(2026, 7, 1);
 export const READING_SCORE_HALF_LIFE_DAYS = 7;
 

--- a/src/util/api/plus/revenueShare.ts
+++ b/src/util/api/plus/revenueShare.ts
@@ -4,6 +4,7 @@ import {
   FieldValue, Timestamp, db, likeNFTBookCollection, userCollection,
 } from '../../firebase';
 import { ValidationError } from '../../ValidationError';
+import { getReadingScoreIncrement } from '../likernft/book/popularity';
 import type { PlusReadingAccrualData } from '../../../types/user';
 
 /**
@@ -180,11 +181,14 @@ export async function recordPlusReadingUsage({
   // Denormalized onto the book doc because Firestore cannot sort on a subcollection sum.
   // Counts non-library time too, so free books (which accrue none) can still rank, and so
   // the public sort key isn't the payout basis settlement pays on.
+  // `plusReadingScore` is the same usage decayed by age. Scored from `dayMs`, not `ts`, so a
+  // backfilled `occurredAt` weighs as of the day it happened and lands on the same weight the
+  // backfill recomputes from this day's rollup.
+  const totalUsageMs = libraryReadingTimeMs + libraryTtsTimeMs
+    + statsNonLibraryReadingTimeMs + statsNonLibraryTtsTimeMs;
   batch.set(bookDocRef, {
-    plusReadingTotalMs: FieldValue.increment(
-      libraryReadingTimeMs + libraryTtsTimeMs
-      + statsNonLibraryReadingTimeMs + statsNonLibraryTtsTimeMs,
-    ),
+    plusReadingTotalMs: FieldValue.increment(totalUsageMs),
+    plusReadingScore: FieldValue.increment(getReadingScoreIncrement(totalUsageMs, dayMs)),
   }, { merge: true });
 
   try {

--- a/test/api/book-list-popular.test.ts
+++ b/test/api/book-list-popular.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect } from 'vitest';
 import axiosist from './axiosist';
 import mockEVMAddress from './address';
 import { likeNFTBookCollection } from '../../src/util/firebase';
+import {
+  READING_SCORE_EPOCH_MS,
+  READING_SCORE_HALF_LIFE_DAYS,
+  getReadingScoreIncrement,
+} from '../../src/util/api/likernft/book/popularity';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 const PATH = '/api/likernft/book/store/list/popular';
 const OWNER = mockEVMAddress(0x33);
@@ -9,11 +16,16 @@ const OWNER = mockEVMAddress(0x33);
 // The stub firestore no-ops orderBy/limit/startAfter, so rank order and cursor paging are
 // not exercised here — those depend on the composite index and need a real Firestore.
 // What is exercised: the library scope flag, hidden/redirect exclusion, the null-cursor
-// boundary, and cursor validation.
+// boundary, cursor validation, and the score math feeding the usage-time increment.
 const seedBook = (classId: string, data: Record<string, unknown> = {}) => likeNFTBookCollection
   .doc(classId)
   .set({
-    classId, ownerWallet: OWNER, isPlusReadingEnabled: true, plusReadingTotalMs: 0, ...data,
+    classId,
+    ownerWallet: OWNER,
+    isPlusReadingEnabled: true,
+    plusReadingTotalMs: 0,
+    plusReadingScore: 0,
+    ...data,
   } as any);
 
 const get = (query = '') => axiosist
@@ -47,15 +59,16 @@ describe('GET /likernft/book/store/list/popular', () => {
     expect(classIds).toContain(notInLibrary);
   });
 
-  it('does not leak the popularity counter to clients', async () => {
+  it('does not leak the popularity counters to clients', async () => {
     const classId = mockEVMAddress(0xa3);
-    await seedBook(classId, { plusReadingTotalMs: 123456 });
+    await seedBook(classId, { plusReadingTotalMs: 123456, plusReadingScore: 98765 });
 
     const res = await get();
     const book = res.data.list.find((b: any) => b.classId === classId);
     expect(book).toBeDefined();
     // Rank order is public; the minutes behind it (the payout basis) are not.
     expect(book.plusReadingTotalMs).toBeUndefined();
+    expect(book.plusReadingScore).toBeUndefined();
   });
 
   it('excludes hidden and redirected books from the list', async () => {
@@ -93,5 +106,67 @@ describe('GET /likernft/book/store/list/popular', () => {
 
     const res = await get(`?key=${mixedCaseClassId}`);
     expect(res.status).toBe(200);
+  });
+});
+
+describe('getReadingScoreIncrement', () => {
+  it('weighs usage one half-life later exactly twice as much', () => {
+    const halfLifeMs = READING_SCORE_HALF_LIFE_DAYS * DAY_MS;
+    const early = getReadingScoreIncrement(1, READING_SCORE_EPOCH_MS);
+    const late = getReadingScoreIncrement(1, READING_SCORE_EPOCH_MS + halfLifeMs);
+    expect(early).toBe(1);
+    expect(late).toBe(2);
+  });
+
+  it('weighs all usage on the same UTC day identically', () => {
+    const dayStart = READING_SCORE_EPOCH_MS + DAY_MS * 3;
+    const dayEnd = dayStart + DAY_MS - 1;
+    expect(getReadingScoreIncrement(1, dayStart)).toBe(getReadingScoreIncrement(1, dayEnd));
+    expect(getReadingScoreIncrement(1, dayStart + DAY_MS))
+      .toBeGreaterThan(getReadingScoreIncrement(1, dayStart));
+  });
+
+  it('gives pre-epoch usage fractional weights', () => {
+    const halfLifeMs = READING_SCORE_HALF_LIFE_DAYS * DAY_MS;
+    expect(getReadingScoreIncrement(1, READING_SCORE_EPOCH_MS - halfLifeMs)).toBe(0.5);
+  });
+
+  it('scales linearly with usage time', () => {
+    const t = READING_SCORE_EPOCH_MS + READING_SCORE_HALF_LIFE_DAYS * DAY_MS * 3;
+    expect(getReadingScoreIncrement(5000, t)).toBe(5000 * getReadingScoreIncrement(1, t));
+  });
+
+  it('scores nothing for zero or malformed usage', () => {
+    const t = READING_SCORE_EPOCH_MS;
+    expect(getReadingScoreIncrement(0, t)).toBe(0);
+    expect(getReadingScoreIncrement(-2, t)).toBe(0);
+    expect(getReadingScoreIncrement(NaN, t)).toBe(0);
+  });
+
+  // An unbounded `occurredAt` (the schema only requires a positive int) would otherwise reach
+  // the exponent and increment the stored score to Infinity, pinning that book to rank 1 with
+  // no way back — a recompute reads the same bad timestamp.
+  it('scores nothing for a timestamp that would overflow the score', () => {
+    expect(getReadingScoreIncrement(1000, Number.MAX_SAFE_INTEGER)).toBe(0);
+    expect(getReadingScoreIncrement(1000, Infinity)).toBe(0);
+    expect(getReadingScoreIncrement(1000, NaN)).toBe(0);
+  });
+
+  // What the backfill actually relies on: summing a day's deltas and scoring the total at that
+  // day's UTC midnight equals scoring each delta at its own moment. Without this, a re-run
+  // would silently re-rank the catalogue.
+  it('scores a day of deltas the same whether summed first or scored individually', () => {
+    const dayStartMs = READING_SCORE_EPOCH_MS + DAY_MS * 11;
+    const deltas: Array<[number, number]> = [[500, 3], [700, 9], [34, 21]];
+    const live = deltas.reduce(
+      (sum, [usageMs, hour]) => sum
+        + getReadingScoreIncrement(usageMs, dayStartMs + hour * 3600000),
+      0,
+    );
+    const recomputed = getReadingScoreIncrement(500 + 700 + 34, dayStartMs);
+    // Float addition isn't associative, so the two agree to precision rather than bit-for-bit.
+    // The gap is ~1e-16 relative, orders of magnitude under any real rank gap — but it does
+    // mean a backfill re-run rewrites every scored book instead of short-circuiting.
+    expect(Math.abs(live - recomputed) / recomputed).toBeLessThan(1e-12);
   });
 });


### PR DESCRIPTION
The library's 熱門 tab ranked by lifetime reading time, so the ordering ossified: a book published today could never outrank a year of accumulated head start, and new library additions stayed invisible.

Adds `plusReadingScore` -- the same usage decayed by age (usage ms × 2^(days / 7)), incremented at usage time the way `salesScore` already is, so ordering stays recency-biased with no decay pass and no cron. Scored from the day bucket rather than the raw timestamp, which is what lets the backfill recompute a book's score from its `plusUsage` rollups and land on what the live increments accumulated (to float precision -- the two sums differ in the last bit, so a re-run rewrites every scored book rather than short-circuiting on equality).

The score decays but never reaches zero, so a book read long ago still outranks one never read at all; only the never-read tail ties, and it stays zero-seeded and newest-first. No lifetime tiebreak: both counters move together from the same delta, so a zero score always implies zero lifetime ms and the extra orderBy would widen the index without ever breaking a tie.

`getReadingScoreIncrement` guards `occurredAtMs` as well as `usageMs`. Only the latter is bounded upstream (`occurredAt` is a bare positive int) and it now feeds an exponent, so a units bug in the forwarder would otherwise increment the score to Infinity and pin that book to rank 1 with no way back -- the backfill can't heal it, since it recomputes off the same bad timestamp.

Needs the composite indexes (`plusReadingScore` desc + `timestamp` desc, and the `isPlusReadingEnabled` variant) created and the backfill run before this deploys: Firestore omits documents missing an `orderBy` field, so until both land the tab returns almost nothing.