### PR TITLE
✅ Check the book fee rules against a shared golden fixture

### DIFF
--- a/test/data/book-revenue.golden.json
+++ b/test/data/book-revenue.golden.json
@@ -1,0 +1,839 @@
+{
+  "version": 1,
+  "source": "likecoin-api-public: src/util/stripe.ts, src/util/api/likernft/book/price.ts, src/util/api/likernft/book/payment.ts",
+  "ratiosVerifiedAgainstDeployment": "2026-08-06",
+  "constants": {
+    "likerLandFeeRatio": 0.05,
+    "tipFeeRatio": 0.1,
+    "commissionRatio": 0.3,
+    "artFeeRatio": 0.1,
+    "stripePercentageFee": 0.029,
+    "stripeInternationalFee": 0.015,
+    "stripeFxFee": 0.01,
+    "stripeFlatFee": 30
+  },
+  "stripeFee": [
+    {
+      "name": "free",
+      "inputAmount": 0,
+      "currency": "usd",
+      "expected": 0
+    },
+    {
+      "name": "US$0.99",
+      "inputAmount": 99,
+      "currency": "usd",
+      "expected": 35
+    },
+    {
+      "name": "US$5",
+      "inputAmount": 500,
+      "currency": "usd",
+      "expected": 52
+    },
+    {
+      "name": "US$10",
+      "inputAmount": 1000,
+      "currency": "usd",
+      "expected": 74
+    },
+    {
+      "name": "US$50",
+      "inputAmount": 5000,
+      "currency": "usd",
+      "expected": 250
+    },
+    {
+      "name": "US$999",
+      "inputAmount": 99900,
+      "currency": "usd",
+      "expected": 4426
+    },
+    {
+      "name": "rounding, US$3.33",
+      "inputAmount": 333,
+      "currency": "usd",
+      "expected": 45
+    },
+    {
+      "name": "non-usd adds the fx fee",
+      "inputAmount": 1000,
+      "currency": "hkd",
+      "expected": 84
+    },
+    {
+      "name": "free in non-usd is still free",
+      "inputAmount": 0,
+      "currency": "hkd",
+      "expected": 0
+    }
+  ],
+  "itemPrices": [
+    {
+      "name": "direct link, US$10",
+      "from": "",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 1000,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "expected": {
+        "quantity": 1,
+        "currency": "usd",
+        "priceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "originalPriceInDecimal": 1000,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 50,
+        "likerLandCommission": 0,
+        "channelCommission": 0,
+        "likerLandArtFee": 0
+      }
+    },
+    {
+      "name": "liker land storefront, US$10",
+      "from": "liker_land",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 1000,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "expected": {
+        "quantity": 1,
+        "currency": "usd",
+        "priceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "originalPriceInDecimal": 1000,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 50,
+        "likerLandCommission": 300,
+        "channelCommission": 0,
+        "likerLandArtFee": 0
+      }
+    },
+    {
+      "name": "affiliate channel, US$10",
+      "from": "some_affiliate",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 1000,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "expected": {
+        "quantity": 1,
+        "currency": "usd",
+        "priceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "originalPriceInDecimal": 1000,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 50,
+        "likerLandCommission": 0,
+        "channelCommission": 300,
+        "likerLandArtFee": 0
+      }
+    },
+    {
+      "name": "waived channel takes no commission",
+      "from": "liker_land_waived",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 1000,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "expected": {
+        "quantity": 1,
+        "currency": "usd",
+        "priceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "originalPriceInDecimal": 1000,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 50,
+        "likerLandCommission": 0,
+        "channelCommission": 0,
+        "likerLandArtFee": 0
+      }
+    },
+    {
+      "name": "free book zeroes every fee",
+      "from": "liker_land",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 0,
+        "originalPriceInDecimal": 0,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "expected": {
+        "quantity": 1,
+        "currency": "usd",
+        "priceInDecimal": 0,
+        "customPriceDiffInDecimal": 0,
+        "originalPriceInDecimal": 0,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 0,
+        "likerLandCommission": 0,
+        "channelCommission": 0,
+        "likerLandArtFee": 0
+      }
+    },
+    {
+      "name": "free book with a tip is not free",
+      "from": "liker_land",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 500,
+        "originalPriceInDecimal": 0,
+        "customPriceDiffInDecimal": 500,
+        "isLikerLandArt": false
+      },
+      "expected": {
+        "quantity": 1,
+        "currency": "usd",
+        "priceInDecimal": 500,
+        "customPriceDiffInDecimal": 500,
+        "originalPriceInDecimal": 0,
+        "likerLandTipFeeAmount": 50,
+        "likerLandFeeAmount": 0,
+        "likerLandCommission": 0,
+        "channelCommission": 0,
+        "likerLandArtFee": 0
+      }
+    },
+    {
+      "name": "reader tip on a paid book",
+      "from": "",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 1500,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 500,
+        "isLikerLandArt": false
+      },
+      "expected": {
+        "quantity": 1,
+        "currency": "usd",
+        "priceInDecimal": 1500,
+        "customPriceDiffInDecimal": 500,
+        "originalPriceInDecimal": 1000,
+        "likerLandTipFeeAmount": 50,
+        "likerLandFeeAmount": 50,
+        "likerLandCommission": 0,
+        "channelCommission": 0,
+        "likerLandArtFee": 0
+      }
+    },
+    {
+      "name": "discount eats into the channel commission",
+      "from": "some_affiliate",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 1500,
+        "originalPriceInDecimal": 2000,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "expected": {
+        "quantity": 1,
+        "currency": "usd",
+        "priceInDecimal": 1500,
+        "customPriceDiffInDecimal": 0,
+        "originalPriceInDecimal": 2000,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 100,
+        "likerLandCommission": 0,
+        "channelCommission": 100,
+        "likerLandArtFee": 0
+      }
+    },
+    {
+      "name": "discount larger than the commission floors it at zero",
+      "from": "liker_land",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 200,
+        "originalPriceInDecimal": 2000,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "expected": {
+        "quantity": 1,
+        "currency": "usd",
+        "priceInDecimal": 200,
+        "customPriceDiffInDecimal": 0,
+        "originalPriceInDecimal": 2000,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 100,
+        "likerLandCommission": 0,
+        "channelCommission": 0,
+        "likerLandArtFee": 0
+      }
+    },
+    {
+      "name": "liker land art fee",
+      "from": "liker_land",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 1000,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": true
+      },
+      "expected": {
+        "quantity": 1,
+        "currency": "usd",
+        "priceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "originalPriceInDecimal": 1000,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 50,
+        "likerLandCommission": 300,
+        "channelCommission": 0,
+        "likerLandArtFee": 100
+      }
+    },
+    {
+      "name": "rounding, US$3.33 direct",
+      "from": "",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 333,
+        "originalPriceInDecimal": 333,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "expected": {
+        "quantity": 1,
+        "currency": "usd",
+        "priceInDecimal": 333,
+        "customPriceDiffInDecimal": 0,
+        "originalPriceInDecimal": 333,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 17,
+        "likerLandCommission": 0,
+        "channelCommission": 0,
+        "likerLandArtFee": 0
+      }
+    },
+    {
+      "name": "quantity 3",
+      "from": "liker_land",
+      "item": {
+        "quantity": 3,
+        "priceInDecimal": 1000,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "expected": {
+        "quantity": 3,
+        "currency": "usd",
+        "priceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "originalPriceInDecimal": 1000,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 50,
+        "likerLandCommission": 300,
+        "channelCommission": 0,
+        "likerLandArtFee": 0
+      }
+    }
+  ],
+  "feeInfo": [
+    {
+      "name": "direct link, US$10",
+      "from": "",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 1000,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "currency": "usd",
+      "expected": {
+        "stripeFeeAmount": 74,
+        "priceInDecimal": 1000,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 50,
+        "likerLandCommission": 0,
+        "channelCommission": 0,
+        "likerLandArtFee": 0,
+        "royaltyToSplit": 876
+      }
+    },
+    {
+      "name": "liker land storefront, US$10",
+      "from": "liker_land",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 1000,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "currency": "usd",
+      "expected": {
+        "stripeFeeAmount": 74,
+        "priceInDecimal": 1000,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 50,
+        "likerLandCommission": 300,
+        "channelCommission": 0,
+        "likerLandArtFee": 0,
+        "royaltyToSplit": 576
+      }
+    },
+    {
+      "name": "affiliate channel, US$10",
+      "from": "some_affiliate",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 1000,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "currency": "usd",
+      "expected": {
+        "stripeFeeAmount": 74,
+        "priceInDecimal": 1000,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 50,
+        "likerLandCommission": 0,
+        "channelCommission": 300,
+        "likerLandArtFee": 0,
+        "royaltyToSplit": 576
+      }
+    },
+    {
+      "name": "waived channel takes no commission",
+      "from": "liker_land_waived",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 1000,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "currency": "usd",
+      "expected": {
+        "stripeFeeAmount": 74,
+        "priceInDecimal": 1000,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 50,
+        "likerLandCommission": 0,
+        "channelCommission": 0,
+        "likerLandArtFee": 0,
+        "royaltyToSplit": 876
+      }
+    },
+    {
+      "name": "free book zeroes every fee",
+      "from": "liker_land",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 0,
+        "originalPriceInDecimal": 0,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "currency": "usd",
+      "expected": {
+        "stripeFeeAmount": 0,
+        "priceInDecimal": 0,
+        "originalPriceInDecimal": 0,
+        "customPriceDiffInDecimal": 0,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 0,
+        "likerLandCommission": 0,
+        "channelCommission": 0,
+        "likerLandArtFee": 0,
+        "royaltyToSplit": 0
+      }
+    },
+    {
+      "name": "free book with a tip is not free",
+      "from": "liker_land",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 500,
+        "originalPriceInDecimal": 0,
+        "customPriceDiffInDecimal": 500,
+        "isLikerLandArt": false
+      },
+      "currency": "usd",
+      "expected": {
+        "stripeFeeAmount": 52,
+        "priceInDecimal": 500,
+        "originalPriceInDecimal": 0,
+        "customPriceDiffInDecimal": 500,
+        "likerLandTipFeeAmount": 50,
+        "likerLandFeeAmount": 0,
+        "likerLandCommission": 0,
+        "channelCommission": 0,
+        "likerLandArtFee": 0,
+        "royaltyToSplit": 398
+      }
+    },
+    {
+      "name": "reader tip on a paid book",
+      "from": "",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 1500,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 500,
+        "isLikerLandArt": false
+      },
+      "currency": "usd",
+      "expected": {
+        "stripeFeeAmount": 96,
+        "priceInDecimal": 1500,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 500,
+        "likerLandTipFeeAmount": 50,
+        "likerLandFeeAmount": 50,
+        "likerLandCommission": 0,
+        "channelCommission": 0,
+        "likerLandArtFee": 0,
+        "royaltyToSplit": 1304
+      }
+    },
+    {
+      "name": "discount eats into the channel commission",
+      "from": "some_affiliate",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 1500,
+        "originalPriceInDecimal": 2000,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "currency": "usd",
+      "expected": {
+        "stripeFeeAmount": 96,
+        "priceInDecimal": 1500,
+        "originalPriceInDecimal": 2000,
+        "customPriceDiffInDecimal": 0,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 100,
+        "likerLandCommission": 0,
+        "channelCommission": 100,
+        "likerLandArtFee": 0,
+        "royaltyToSplit": 1204
+      }
+    },
+    {
+      "name": "discount larger than the commission floors it at zero",
+      "from": "liker_land",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 200,
+        "originalPriceInDecimal": 2000,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "currency": "usd",
+      "expected": {
+        "stripeFeeAmount": 39,
+        "priceInDecimal": 200,
+        "originalPriceInDecimal": 2000,
+        "customPriceDiffInDecimal": 0,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 100,
+        "likerLandCommission": 0,
+        "channelCommission": 0,
+        "likerLandArtFee": 0,
+        "royaltyToSplit": 61
+      }
+    },
+    {
+      "name": "liker land art fee",
+      "from": "liker_land",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 1000,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": true
+      },
+      "currency": "usd",
+      "expected": {
+        "stripeFeeAmount": 74,
+        "priceInDecimal": 1000,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 50,
+        "likerLandCommission": 300,
+        "channelCommission": 0,
+        "likerLandArtFee": 100,
+        "royaltyToSplit": 476
+      }
+    },
+    {
+      "name": "rounding, US$3.33 direct",
+      "from": "",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 333,
+        "originalPriceInDecimal": 333,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "currency": "usd",
+      "expected": {
+        "stripeFeeAmount": 45,
+        "priceInDecimal": 333,
+        "originalPriceInDecimal": 333,
+        "customPriceDiffInDecimal": 0,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 17,
+        "likerLandCommission": 0,
+        "channelCommission": 0,
+        "likerLandArtFee": 0,
+        "royaltyToSplit": 271
+      }
+    },
+    {
+      "name": "quantity 3",
+      "from": "liker_land",
+      "item": {
+        "quantity": 3,
+        "priceInDecimal": 1000,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "currency": "usd",
+      "expected": {
+        "stripeFeeAmount": 162,
+        "priceInDecimal": 3000,
+        "originalPriceInDecimal": 3000,
+        "customPriceDiffInDecimal": 0,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 150,
+        "likerLandCommission": 900,
+        "channelCommission": 0,
+        "likerLandArtFee": 0,
+        "royaltyToSplit": 1788
+      }
+    },
+    {
+      "name": "non-usd direct sale",
+      "from": "",
+      "currency": "hkd",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 1000,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "expected": {
+        "stripeFeeAmount": 84,
+        "priceInDecimal": 1000,
+        "originalPriceInDecimal": 1000,
+        "customPriceDiffInDecimal": 0,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 50,
+        "likerLandCommission": 0,
+        "channelCommission": 0,
+        "likerLandArtFee": 0,
+        "royaltyToSplit": 866
+      }
+    },
+    {
+      "name": "sub-fee price floors the royalty at zero",
+      "from": "liker_land",
+      "currency": "usd",
+      "item": {
+        "quantity": 1,
+        "priceInDecimal": 30,
+        "originalPriceInDecimal": 30,
+        "customPriceDiffInDecimal": 0,
+        "isLikerLandArt": false
+      },
+      "expected": {
+        "stripeFeeAmount": 32,
+        "priceInDecimal": 30,
+        "originalPriceInDecimal": 30,
+        "customPriceDiffInDecimal": 0,
+        "likerLandTipFeeAmount": 0,
+        "likerLandFeeAmount": 2,
+        "likerLandCommission": 9,
+        "channelCommission": 0,
+        "likerLandArtFee": 0,
+        "royaltyToSplit": 0
+      }
+    }
+  ],
+  "authorRevenue": [
+    {
+      "name": "free",
+      "priceInDecimal": 0,
+      "currency": "usd",
+      "expected": {
+        "direct": {
+          "royaltyInDecimal": 0,
+          "ratio": 0
+        },
+        "likerLand": {
+          "royaltyInDecimal": 0,
+          "ratio": 0
+        }
+      }
+    },
+    {
+      "name": "US$0.99",
+      "priceInDecimal": 99,
+      "currency": "usd",
+      "expected": {
+        "direct": {
+          "royaltyInDecimal": 59,
+          "ratio": 0.5959595959595959
+        },
+        "likerLand": {
+          "royaltyInDecimal": 29,
+          "ratio": 0.29292929292929293
+        }
+      }
+    },
+    {
+      "name": "US$5",
+      "priceInDecimal": 500,
+      "currency": "usd",
+      "expected": {
+        "direct": {
+          "royaltyInDecimal": 423,
+          "ratio": 0.846
+        },
+        "likerLand": {
+          "royaltyInDecimal": 273,
+          "ratio": 0.546
+        }
+      }
+    },
+    {
+      "name": "US$10",
+      "priceInDecimal": 1000,
+      "currency": "usd",
+      "expected": {
+        "direct": {
+          "royaltyInDecimal": 876,
+          "ratio": 0.876
+        },
+        "likerLand": {
+          "royaltyInDecimal": 576,
+          "ratio": 0.576
+        }
+      }
+    },
+    {
+      "name": "US$20",
+      "priceInDecimal": 2000,
+      "currency": "usd",
+      "expected": {
+        "direct": {
+          "royaltyInDecimal": 1782,
+          "ratio": 0.891
+        },
+        "likerLand": {
+          "royaltyInDecimal": 1182,
+          "ratio": 0.591
+        }
+      }
+    },
+    {
+      "name": "US$50 — where the direct ratio reaches 90%",
+      "priceInDecimal": 5000,
+      "currency": "usd",
+      "expected": {
+        "direct": {
+          "royaltyInDecimal": 4500,
+          "ratio": 0.9
+        },
+        "likerLand": {
+          "royaltyInDecimal": 3000,
+          "ratio": 0.6
+        }
+      }
+    },
+    {
+      "name": "US$100",
+      "priceInDecimal": 10000,
+      "currency": "usd",
+      "expected": {
+        "direct": {
+          "royaltyInDecimal": 9030,
+          "ratio": 0.903
+        },
+        "likerLand": {
+          "royaltyInDecimal": 6030,
+          "ratio": 0.603
+        }
+      }
+    },
+    {
+      "name": "US$999",
+      "priceInDecimal": 99900,
+      "currency": "usd",
+      "expected": {
+        "direct": {
+          "royaltyInDecimal": 90479,
+          "ratio": 0.9056956956956957
+        },
+        "likerLand": {
+          "royaltyInDecimal": 60509,
+          "ratio": 0.6056956956956957
+        }
+      }
+    },
+    {
+      "name": "US$3.33, rounding",
+      "priceInDecimal": 333,
+      "currency": "usd",
+      "expected": {
+        "direct": {
+          "royaltyInDecimal": 271,
+          "ratio": 0.8138138138138138
+        },
+        "likerLand": {
+          "royaltyInDecimal": 171,
+          "ratio": 0.5135135135135135
+        }
+      }
+    },
+    {
+      "name": "US$10 in a non-usd currency",
+      "priceInDecimal": 1000,
+      "currency": "hkd",
+      "expected": {
+        "direct": {
+          "royaltyInDecimal": 866,
+          "ratio": 0.866
+        },
+        "likerLand": {
+          "royaltyInDecimal": 566,
+          "ratio": 0.566
+        }
+      }
+    }
+  ]
+}

--- a/test/unit/book-revenue-golden.test.ts
+++ b/test/unit/book-revenue-golden.test.ts
@@ -1,0 +1,145 @@
+// Rules mirrored client-side in publish-3ook-com/app/utils/book-revenue.ts. On failure,
+// regenerate the fixture, copy it to publish-3ook-com/test/fixtures/, and update the mirror.
+// Editing the fixture alone is what defeats the check.
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+import { calculateStripeFee } from '../../src/util/stripe';
+import { calculateItemPrices } from '../../src/util/api/likernft/book/price';
+import { calculateItemFeeInfo } from '../../src/util/api/likernft/book/payment';
+import type { CartItemWithInfo } from '../../src/util/api/likernft/book/type';
+import {
+  NFT_BOOK_LIKER_LAND_FEE_RATIO,
+  NFT_BOOK_TIP_LIKER_LAND_FEE_RATIO,
+  NFT_BOOK_LIKER_LAND_COMMISSION_RATIO,
+  NFT_BOOK_LIKER_LAND_ART_FEE_RATIO,
+} from '../../config/config';
+
+// Bump alongside the fixture's `version` when the rules change, so a stale copy
+// on either side fails loudly instead of drifting.
+const EXPECTED_FIXTURE_VERSION = 1;
+
+const fixture = JSON.parse(fs.readFileSync(
+  path.join(__dirname, '../data/book-revenue.golden.json'),
+  'utf-8',
+));
+
+// Cart plumbing the fee rules never read, supplied so the item typechecks.
+const baseItem = {
+  stock: 1,
+  isAllowCustomPrice: false,
+  name: '',
+  description: '',
+  images: [] as string[],
+  ownerWallet: '',
+  chain: 'evm' as const,
+};
+
+type FixtureItem = Pick<CartItemWithInfo,
+  'quantity' | 'priceInDecimal' | 'originalPriceInDecimal' | 'customPriceDiffInDecimal' | 'isLikerLandArt'>;
+
+const makeItem = (item: FixtureItem): CartItemWithInfo => ({ ...baseItem, ...item });
+
+function feeInfoFor(item: FixtureItem, from: string, currency: string) {
+  const [itemPrice] = calculateItemPrices([makeItem(item)], from);
+  const totalPriceInDecimal = item.priceInDecimal * item.quantity;
+  return calculateItemFeeInfo(itemPrice, {
+    totalStripeFeeAmount: calculateStripeFee(totalPriceInDecimal, currency),
+    totalPriceInDecimal,
+  });
+}
+
+// What the wizard's estimateAuthorRevenue() composes, once per channel.
+function authorRevenueFor(priceInDecimal: number, currency: string) {
+  const forChannel = (from: string) => {
+    const { royaltyToSplit } = feeInfoFor({
+      quantity: 1,
+      priceInDecimal,
+      originalPriceInDecimal: priceInDecimal,
+      customPriceDiffInDecimal: 0,
+      isLikerLandArt: false,
+    }, from, currency);
+    return {
+      royaltyInDecimal: royaltyToSplit,
+      ratio: priceInDecimal > 0 ? royaltyToSplit / priceInDecimal : 0,
+    };
+  };
+  return { direct: forChannel(''), likerLand: forChannel('liker_land') };
+}
+
+describe('book revenue golden fixture', () => {
+  it('matches the version this test was written against', () => {
+    expect(fixture.version).toBe(EXPECTED_FIXTURE_VERSION);
+  });
+
+  it('matches the fee ratios in config', () => {
+    expect(fixture.constants.likerLandFeeRatio).toBe(NFT_BOOK_LIKER_LAND_FEE_RATIO);
+    expect(fixture.constants.tipFeeRatio).toBe(NFT_BOOK_TIP_LIKER_LAND_FEE_RATIO);
+    expect(fixture.constants.commissionRatio).toBe(NFT_BOOK_LIKER_LAND_COMMISSION_RATIO);
+    expect(fixture.constants.artFeeRatio).toBe(NFT_BOOK_LIKER_LAND_ART_FEE_RATIO);
+  });
+
+  // The Stripe rates are inline literals in calculateStripeFee, so pin the fixture's
+  // copies to the real formula rather than restating them as literals here.
+  it('reproduces calculateStripeFee from the fixture constants', () => {
+    const {
+      stripePercentageFee, stripeInternationalFee, stripeFxFee, stripeFlatFee,
+    } = fixture.constants;
+    const rateFor = (currency: string) => stripePercentageFee + stripeInternationalFee
+      + (currency === 'usd' ? 0 : stripeFxFee);
+    const fromConstants = (amount: number, currency: string) => (
+      amount === 0 ? 0 : Math.ceil(amount * rateFor(currency) + stripeFlatFee)
+    );
+    [0, 1, 99, 333, 500, 1000, 5000, 99900].forEach((amount) => {
+      ['usd', 'hkd'].forEach((currency) => {
+        expect(fromConstants(amount, currency)).toBe(calculateStripeFee(amount, currency));
+      });
+    });
+  });
+
+  describe('calculateStripeFee', () => {
+    fixture.stripeFee.forEach(({
+      name, inputAmount, currency, expected,
+    }) => {
+      it(name, () => {
+        expect(calculateStripeFee(inputAmount, currency)).toBe(expected);
+      });
+    });
+  });
+
+  describe('calculateItemPrices', () => {
+    fixture.itemPrices.forEach(({
+      name, item, from, expected,
+    }) => {
+      it(name, () => {
+        expect(calculateItemPrices([makeItem(item)], from)[0]).toEqual(expected);
+      });
+    });
+  });
+
+  describe('calculateItemFeeInfo', () => {
+    fixture.feeInfo.forEach(({
+      name, item, from, currency, expected,
+    }) => {
+      it(name, () => {
+        expect(feeInfoFor(item, from, currency)).toEqual(expected);
+      });
+    });
+  });
+
+  describe('author revenue by channel', () => {
+    fixture.authorRevenue.forEach(({
+      name, priceInDecimal, currency, expected,
+    }) => {
+      it(name, () => {
+        const actual = authorRevenueFor(priceInDecimal, currency);
+        expect(actual.direct.royaltyInDecimal).toBe(expected.direct.royaltyInDecimal);
+        expect(actual.likerLand.royaltyInDecimal).toBe(expected.likerLand.royaltyInDecimal);
+        // Ratios are derived, so compare with a tolerance: a harmless
+        // reordering of the division must not fail the check.
+        expect(actual.direct.ratio).toBeCloseTo(expected.direct.ratio, 12);
+        expect(actual.likerLand.ratio).toBeCloseTo(expected.likerLand.ratio, 12);
+      });
+    });
+  });
+});


### PR DESCRIPTION
publish-3ook-com mirrors calculateStripeFee, calculateItemPrices and calculateItemFeeInfo so the publishing wizard can tell an author what a sale earns them before they commit to a price. A mirror without a check drifts silently, and drift here is a wrong number on a commercial decision.

Both repos now assert against a byte-identical fixture, so changing a ratio fails this test and names the mirror as the thing to update. Same shape as preview-cut in the ebook-cors server.