### PR TITLE
🐛 Treat a RevenueCat price of 0 as no charge, not a payment

### DIFF
--- a/src/util/api/plus/revenuecat.ts
+++ b/src/util/api/plus/revenuecat.ts
@@ -275,12 +275,15 @@ async function handleGrant(
     ? purchasedAtMs
     : (user.likerPlus?.since || purchasedAtMs);
 
+  // Stores send `price: 0` on no-charge grants (uncancel/extend/product-change) rather
+  // than omitting the field, so a real charge must test the amount, not just presence.
+  const hasCharge = !isTrial && event.price != null && event.price > 0;
+
   // Per-day value of this term, funding the reading-library revenue-share pool.
   // Gated on the same `isTrial` as currentType so the two always agree. RevenueCat's
   // `price` is normalized to USD, so the pool funds in USD — the actual transaction
   // price still captures intro/promotional and monthly/yearly differences.
-  // Uncancel/extend/product-change grants carry no `price` (no new charge); preserve
-  // the stored dailyValue rather than zeroing accrual until the next priced renewal.
+  // No-charge grants preserve the stored dailyValue rather than zeroing accrual.
   // Civic funds at the Plus-tier rate (see getPlusEquivalentUSDPrice), never
   // its own 10× charge.
   let dailyValue = 0;
@@ -289,7 +292,7 @@ async function handleGrant(
     if (tier === 'civic') {
       fundingAmount = getPlusEquivalentUSDPrice(period);
     }
-    dailyValue = event.price != null && fundingAmount != null
+    dailyValue = hasCharge && fundingAmount != null
       ? calculatePlusDailyValue({
         amountPaid: fundingAmount,
         currentPeriodStart: purchasedAtMs,
@@ -326,9 +329,6 @@ async function handleGrant(
     if (user.likerPlus?.giftClaimToken) likerPlus.giftClaimToken = user.likerPlus.giftClaimToken;
     if (user.likerPlus?.affiliateFrom) likerPlus.affiliateFrom = user.likerPlus.affiliateFrom;
   }
-  // A real charge: priced, non-trial grants. Trials and no-charge grants
-  // (uncancel/extend/product-change) carry no price. Reused by the gift block below.
-  const hasCharge = !isTrial && event.price != null && event.price > 0;
   const grantUpdate: Record<string, unknown> = { likerPlus };
   // Track first/last real payment like the Stripe path so getCustomerType can tell
   // resubscribers from first-time buyers.
@@ -474,11 +474,10 @@ async function handleGrant(
     }
   }
 
-  // Accrue this term's value to the rev-share pool. Only on a real new charge
-  // (`price` present) — never trials or uncancel/extend grants, which carry no price
-  // and would otherwise re-fund a term. RC `price` is already USD. Placed after the
-  // quarantine return so reviewer/sandbox traffic never funds real payouts.
-  if (!isTrial && event.price != null && dailyValue > 0 && transactionId) {
+  // Accrue this term's value to the rev-share pool, only on a real new charge: an extend
+  // shares the running term's accrual key, so accruing would overwrite it with a longer,
+  // unpaid-for paidDays. After the quarantine return so sandbox never funds real payouts.
+  if (hasCharge && dailyValue > 0 && transactionId) {
     // Best-effort: accrual is not yet used for payouts, so a transient Firestore
     // failure must not fail (and make RevenueCat retry) the subscription webhook.
     try {
@@ -516,8 +515,11 @@ async function handleGrant(
   const { amount: paymentAmount, currency: paymentCurrency } = getRevenueCatPaymentAmount(event);
 
   // Independent notifications/analytics — fire in parallel (matches the Stripe path).
-  const sideEffects: Promise<unknown>[] = [
-    sendPlusSubscriptionSlackNotification({
+  // Skipped for uncancel/extend/product-change: nothing was bought, and announcing one
+  // posts a "renewal … 0.00" that reads as a real sale.
+  const sideEffects: Promise<unknown>[] = [];
+  if (logEvent) {
+    sideEffects.push(sendPlusSubscriptionSlackNotification({
       subscriptionId: transactionId || 'N/A',
       email: user.email || 'N/A',
       priceWithCurrency: paymentAmount != null && paymentCurrency
@@ -527,9 +529,7 @@ async function handleGrant(
       userId: likerId,
       method: 'revenuecat',
       isTrial,
-    }),
-  ];
-  if (logEvent) {
+    }));
     // Mirror the Stripe path's value signal so Meta/GA optimize the same for web
     // and IAP — app IAP trials charge 0, so value falls back to predicted LTV.
     const {

--- a/test/api/plus.revenuecat.test.ts
+++ b/test/api/plus.revenuecat.test.ts
@@ -1,8 +1,22 @@
-import { describe, it, expect } from 'vitest';
+import {
+  describe, it, expect, vi,
+} from 'vitest';
 import axiosist from './axiosist';
 import { jwtSign } from './jwt';
 import { getUserWithCivicLikerProperties } from '../../src/util/api/users/getPublicInfo';
 import { userCollection } from '../../src/util/firebase';
+import { sendPlusSubscriptionSlackNotification } from '../../src/util/slack';
+
+// Override only the Slack post so the notification gate is observable: the real
+// helper early-returns on an unset webhook, so it silently passes either way.
+vi.mock('../../src/util/slack', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/util/slack')>();
+  return {
+    ...actual,
+    sendPlusSubscriptionSlackNotification: vi.fn(),
+  };
+});
+const mockSlackNotification = vi.mocked(sendPlusSubscriptionSlackNotification);
 
 const WEBHOOK_PATH = '/api/plus/revenuecat/webhook';
 const AUTH = 'test-rc-webhook-secret'; // matches REVENUECAT_WEBHOOK_AUTHORIZATION in test/setup.ts
@@ -63,8 +77,10 @@ describe('Plus RevenueCat webhook', () => {
   });
 
   it('activates Plus on INITIAL_PURCHASE and tags provider=revenuecat', async () => {
+    mockSlackNotification.mockClear();
     const res = await post({ ...baseEvent, type: 'INITIAL_PURCHASE' }, { Authorization: AUTH });
     expect(res.status).toBe(200);
+    expect(mockSlackNotification).toHaveBeenCalledTimes(1);
 
     const user = await getUserWithCivicLikerProperties('testing');
     expect(user?.likerPlus).toBeTruthy();
@@ -300,6 +316,47 @@ describe('Plus RevenueCat webhook', () => {
     const user = await getUserWithCivicLikerProperties('testing');
     expect(user?.likerPlus?.subscriptionStatus).toBe('active');
     expect(user?.likerPlus?.subscriptionId).toBe('sub_legacy');
+  });
+
+  it('preserves dailyValue on a SUBSCRIPTION_EXTENDED that reports price 0', async () => {
+    // Play sends `price: 0` on a store-granted extension rather than omitting the
+    // field, so a presence check reads it as a real charge and recomputes dailyValue
+    // to 0 — zeroing rev-share funding for the rest of the term.
+    const extendedEnd = FUTURE_PERIOD_END_MS + 24 * 60 * 60 * 1000;
+    mockSlackNotification.mockClear();
+    await userCollection.doc('testing').update({
+      likerPlus: { ...liveAppStorePlus, dailyValue: 0.37, dailyValueCurrency: 'USD' },
+    });
+    const res = await post(
+      {
+        ...baseEvent,
+        id: 'evt_extended',
+        type: 'SUBSCRIPTION_EXTENDED',
+        store: 'PLAY_STORE',
+        price: 0,
+        price_in_purchased_currency: 0,
+        currency: 'GBP',
+        expiration_at_ms: extendedEnd,
+      },
+      { Authorization: AUTH },
+    );
+    expect(res.status).toBe(200);
+
+    const user = await getUserWithCivicLikerProperties('testing');
+    expect(user?.likerPlus?.currentPeriodEnd).toBe(extendedEnd);
+    expect(user?.likerPlus?.dailyValue).toBe(0.37);
+
+    // Preserving dailyValue makes the accrual gate rest solely on hasCharge: an extend
+    // reuses the running term's key, so accruing would re-fund it over a longer span.
+    const accrual = await userCollection.doc('testing')
+      .collection('plusReadingAccrual')
+      .doc(`txn_123_${PURCHASED_AT_MS}`)
+      .get();
+    expect(accrual.exists).toBe(false);
+
+    // Nothing was bought, so announcing one posts a "renewal … 0.00 GBP" that reads
+    // as a real sale.
+    expect(mockSlackNotification).not.toHaveBeenCalled();
   });
 
   it('carries a live subscription to transferred_to on TRANSFER', async () => {


### PR DESCRIPTION
Play sends `price: 0` on a store-granted SUBSCRIPTION_EXTENDED rather than omitting the field, so the `price != null` checks read it as a real charge. That posted a "Plus subscription renewal … 0.00 GBP" to Slack, and recomputed dailyValue to 0, zeroing rev-share funding for the rest of the term.

Hoist `hasCharge` above its three consumers and gate on the amount. The accrual gate moves to it too: with dailyValue preserved, an extend would otherwise overwrite the running term's accrual key with a longer, unpaid-for paidDays — which a civic-tier extend already did, since its funding amount comes from getPlusEquivalentUSDPrice rather than the event. Slack now shares the logEvent gate that analytics and Airtable already used.