### PR TITLE
✨ Treat a RevenueCat paid intro offer as a trial, not a sale

### DIFF
--- a/src/util/api/plus/revenuecat.ts
+++ b/src/util/api/plus/revenuecat.ts
@@ -759,7 +759,7 @@ async function revokeOtherHoldersOfTransaction(
 async function handleExpiration(
   event: RevenueCatEvent,
   likerId: string,
-  user: { likerPlus?: LikerPlusData },
+  user: { email?: string; evmWallet?: string; likerPlus?: LikerPlusData },
   isSandbox: boolean,
 ) {
   // Don't let a (possibly stale) mobile expiration revoke a record that Stripe
@@ -770,6 +770,13 @@ async function handleExpiration(
   if (!user.likerPlus) return;
   if (isSandboxLockedOut(isSandbox, user.likerPlus)) return;
   if (isForOtherSubscription(event, user.likerPlus)) return;
+  // A subscription that lapses without ever converting is a trial end, not a
+  // cancellation — Stripe parity. The stored currentType is authoritative, so this
+  // also covers a paid intro, whose period_type is INTRO rather than TRIAL.
+  const isTrialEnd = user.likerPlus.currentType === 'trial';
+  // Must match the id the grant reported or the funnel doesn't join up. The stored
+  // id is the fallback: an expiration may arrive without one.
+  const transactionId = event.original_transaction_id || user.likerPlus.originalTransactionId;
   const expiredAt = event.expiration_at_ms || Date.now();
   await revokeLikerPlus(likerId, user.likerPlus, {
     currentPeriodEnd: Math.min(user.likerPlus.currentPeriodEnd || expiredAt, expiredAt),
@@ -781,7 +788,36 @@ async function handleExpiration(
   }
   if (isQuarantinedSandbox(isSandbox)) return;
   await clearIntercomPlusFlags(likerId);
-  await sendIntercomEvent({ userId: likerId, eventName: 'plus_subscription_end' });
+  // No value/currency on purpose: churn must reach PostHog but never Meta/GA as a
+  // conversion, which is how the Stripe path reports it too.
+  await Promise.all([
+    sendIntercomEvent({
+      userId: likerId,
+      eventName: isTrialEnd ? 'plus_trial_end' : 'plus_subscription_end',
+    }),
+    logServerEvents(isTrialEnd ? 'TrialEnded' : 'SubscriptionCancelled', {
+      email: user.email,
+      evmWallet: user.evmWallet,
+      paymentId: transactionId,
+      extraProperties: {
+        subscription_id: transactionId,
+        provider: 'revenuecat',
+        platform: 'app',
+        // Closes the funnel StartTrial opened with the same flag. Read off the event
+        // because the record doesn't store it: period_type here describes the period
+        // that expired, so a churned $1 intro reports INTRO.
+        is_paid_trial: isTrialEnd && event.period_type === 'INTRO',
+        store: event.store || user.likerPlus.store,
+        product_id: event.product_id,
+        period: user.likerPlus.period,
+        tier: user.likerPlus.tier,
+        // Named for parity with the Stripe path, which reports Stripe's own reason
+        // under this key. EXPIRATION carries expiration_reason (UNSUBSCRIBED,
+        // BILLING_ERROR, …); cancel_reason is the CANCELLATION event's field.
+        cancel_reason: event.expiration_reason || event.cancel_reason,
+      },
+    }),
+  ]);
 }
 
 async function handleBillingIssue(

--- a/src/util/api/plus/revenuecat.ts
+++ b/src/util/api/plus/revenuecat.ts
@@ -50,7 +50,7 @@ export interface RevenueCatEvent {
   product_id?: string;
   entitlement_id?: string | null;
   entitlement_ids?: string[] | null;
-  period_type?: 'TRIAL' | 'INTRO' | 'NORMAL' | 'PROMOTIONAL';
+  period_type?: 'TRIAL' | 'INTRO' | 'NORMAL' | 'PROMOTIONAL' | 'PREPAID';
   purchased_at_ms?: number;
   expiration_at_ms?: number | null;
   store?: string;
@@ -241,7 +241,17 @@ async function handleGrant(
   if (isSandboxLockedOut(isSandbox, user.likerPlus)) return;
 
   const isInitial = event.type === 'INITIAL_PURCHASE';
-  const isTrial = event.period_type === 'TRIAL';
+  // A paid introductory offer (the $1/7-day trial) is a trial for entitlement, CRM and
+  // analytics — Stripe parity. RevenueCat's dashboard instead books intro offers as
+  // paid immediately, so our trial counts diverge from it by design.
+  const isPaidIntro = event.period_type === 'INTRO';
+  const isTrial = event.period_type === 'TRIAL' || isPaidIntro;
+  // RevenueCat's `is_trial_conversion` is unusable here: it means "the previous period
+  // was a free trial" and stays false for a paid intro, which is the case we run. The
+  // stored record's currentType is authoritative instead.
+  const isTrialToPaidUpgrade = event.type === 'RENEWAL'
+    && !isTrial
+    && user.likerPlus?.currentType === 'trial';
   const purchasedAtMs = event.purchased_at_ms || Date.now();
   const transactionId = event.original_transaction_id || event.id;
   // Gift attribution is keyed to one subscription's original_transaction_id. A
@@ -277,7 +287,9 @@ async function handleGrant(
 
   // Stores send `price: 0` on no-charge grants (uncancel/extend/product-change) rather
   // than omitting the field, so a real charge must test the amount, not just presence.
-  const hasCharge = !isTrial && event.price != null && event.price > 0;
+  // Not gated on `isTrial`: a free trial already reports price 0, while a paid intro
+  // reports its real charge, which must still reach firstPaidAt and the Airtable row.
+  const hasCharge = event.price != null && event.price > 0;
 
   // Per-day value of this term, funding the reading-library revenue-share pool.
   // Gated on the same `isTrial` as currentType so the two always agree. RevenueCat's
@@ -396,8 +408,9 @@ async function handleGrant(
   // the upsell `giftClassId` into the resolved gift book, and affiliate attribution
   // is persisted to `plusAffiliateFrom`. Stripe stores the gift in the subscription
   // metadata; RevenueCat has no subscription, so we persist it on the shared record
-  // for GET /plus/gift to read back. Only on the initial purchase.
-  if (isInitial) {
+  // for GET /plus/gift to read back. Also on the first full charge after a trial, which
+  // is when a trial subscriber's gift finally becomes due (see isGiftEligible).
+  if (isInitial || isTrialToPaidUpgrade) {
     const fromAttr = getSubscriberAttribute(event, 'plusFrom');
     const giftClassIdAttr = getSubscriberAttribute(event, 'plusGiftClassId');
     if (fromAttr || giftClassIdAttr) {
@@ -425,12 +438,13 @@ async function handleGrant(
           userUpdate.likerPlus = { ...likerPlus, affiliateFrom };
         }
 
-        // Gift books only attach to yearly, on a real charge — except an affiliate
-        // `giftOnTrial` gift granted at trial start. The giftCartId guard keeps a
-        // re-delivered INITIAL_PURCHASE idempotent, but only for the same
-        // subscription — a resubscribe earns a fresh gift even though the lapsed
-        // sub's giftCartId still lingers on the record.
-        const isGiftEligible = hasCharge || (!!affiliateGiftOnTrial && isTrial);
+        // Gift books only attach to yearly, on a real full-price charge — except an
+        // affiliate `giftOnTrial` gift at trial start. A paid intro's own tiny charge
+        // doesn't qualify; its gift is deferred to the trial→paid renewal above.
+        const isGiftEligible = isTrial ? !!affiliateGiftOnTrial : hasCharge;
+        // The giftCartId guard keeps a re-delivered INITIAL_PURCHASE idempotent, but only
+        // for the same subscription — a resubscribe earns a fresh gift even though the
+        // lapsed sub's giftCartId still lingers on the record.
         if (
           planPeriod === 'yearly'
           && resolvedGiftClassId
@@ -505,10 +519,19 @@ async function handleGrant(
       userId: likerId,
       eventName: isTrial ? 'plus_trial_start' : 'plus_subscription_start',
     });
+  } else if (isTrialToPaidUpgrade) {
+    // Both events, mirroring the Stripe path so the two providers drive the same
+    // Intercom sequence for a conversion.
+    await sendIntercomEvent({ userId: likerId, eventName: 'plus_trial_end' });
+    await sendIntercomEvent({ userId: likerId, eventName: 'plus_subscription_start' });
   }
 
   let logEvent: 'StartTrial' | 'Subscribe' | 'SubscriptionRenewed' | undefined;
   if (isInitial) logEvent = isTrial ? 'StartTrial' : 'Subscribe';
+  // The first full charge after a trial is the real conversion, not a renewal, so it
+  // reports Subscribe — parity with the Stripe path. PlusAcquisition stays gated on
+  // isInitial below so each subscription is still counted exactly once.
+  else if (isTrialToPaidUpgrade) logEvent = 'Subscribe';
   else if (event.type === 'RENEWAL') logEvent = 'SubscriptionRenewed';
 
   // Resolve once and reuse across Slack, analytics, and the Airtable record.
@@ -525,7 +548,9 @@ async function handleGrant(
       priceWithCurrency: paymentAmount != null && paymentCurrency
         ? `${paymentAmount.toFixed(2)} ${paymentCurrency}`
         : 'N/A',
-      isNew: isInitial,
+      // Treat the first payment converted from a trial as a new subscription, not a
+      // renewal (the record's `since` is unchanged, so isInitial is false).
+      isNew: isInitial || isTrialToPaidUpgrade,
       userId: likerId,
       method: 'revenuecat',
       isTrial,
@@ -568,6 +593,9 @@ async function handleGrant(
         subscription_id: transactionId,
         provider: 'revenuecat',
         platform: 'app',
+        // Separates the $1 paid-intro cohort from a free trial; both report
+        // StartTrial, so without this they collapse into one funnel.
+        is_paid_trial: isPaidIntro,
         store: event.store,
         product_id: event.product_id,
         period,
@@ -613,6 +641,8 @@ async function handleGrant(
       periodInterval: period || '',
       periodStartAt: purchasedAtMs,
       periodEndAt: currentPeriodEnd,
+      // Narrower than the Slack `isNew` above on purpose: Stripe's Airtable row counts
+      // only real subscription creations, so a trial conversion is not "new" here.
       isNew: isInitial,
       isTrial,
     }));

--- a/src/util/api/plus/schemas.ts
+++ b/src/util/api/plus/schemas.ts
@@ -234,9 +234,9 @@ export const RevenueCatConfigResponseSchema = z.object({
 // present, only `event.type` is required and everything else is .nullish() with
 // .passthrough(). Two checks against the official docs (verified against
 // revenuecat.com/docs/.../event-types-and-fields):
-//   - period_type/environment/store are plain strings, not enums — RevenueCat ships
-//     values our TS interface omits (e.g. period_type PREPAID), and an enum would
-//     reject those valid deliveries.
+//   - period_type/environment/store are plain strings, not enums — RevenueCat adds
+//     values over time (period_type gained PREPAID after this shipped), and an enum
+//     would reject those valid deliveries until the union caught up.
 //   - product_id/price/price_in_purchased_currency/currency are explicitly nullable
 //     in the docs, so every scalar is .nullish() (accepts null AND missing).
 export const RevenueCatWebhookBodySchema = z.object({

--- a/test/api/plus.revenuecat.test.ts
+++ b/test/api/plus.revenuecat.test.ts
@@ -6,6 +6,8 @@ import { jwtSign } from './jwt';
 import { getUserWithCivicLikerProperties } from '../../src/util/api/users/getPublicInfo';
 import { userCollection } from '../../src/util/firebase';
 import { sendPlusSubscriptionSlackNotification } from '../../src/util/slack';
+import { sendIntercomEvent } from '../../src/util/intercom';
+import logServerEvents from '../../src/util/logServerEvents';
 
 // Override only the Slack post so the notification gate is observable: the real
 // helper early-returns on an unset webhook, so it silently passes either way.
@@ -17,6 +19,19 @@ vi.mock('../../src/util/slack', async (importOriginal) => {
   };
 });
 const mockSlackNotification = vi.mocked(sendPlusSubscriptionSlackNotification);
+
+// Same reason as Slack: both helpers swallow their own errors and return, so which
+// lifecycle event fired is only observable through a spy. Kept file-local rather than
+// in setup.ts because a suite-wide mock would silence these calls for every other
+// test file, not just the ones asserting on them.
+vi.mock('../../src/util/logServerEvents', () => ({ default: vi.fn() }));
+const mockLogServerEvents = vi.mocked(logServerEvents);
+
+vi.mock('../../src/util/intercom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/util/intercom')>();
+  return { ...actual, sendIntercomEvent: vi.fn() };
+});
+const mockIntercomEvent = vi.mocked(sendIntercomEvent);
 
 const WEBHOOK_PATH = '/api/plus/revenuecat/webhook';
 const AUTH = 'test-rc-webhook-secret'; // matches REVENUECAT_WEBHOOK_AUTHORIZATION in test/setup.ts
@@ -233,6 +248,71 @@ describe('Plus RevenueCat webhook', () => {
     const user = await getUserWithCivicLikerProperties('testing');
     expect(user?.likerPlus?.subscriptionStatus).toBe('canceled');
     expect(user?.likerPlus?.currentPeriodEnd).toBe(PURCHASED_AT_MS + 1000);
+  });
+
+  it('reports a churned paid intro as a trial end, not a cancellation', async () => {
+    // A $1/7-day intro the user cancelled lapses as an EXPIRATION whose period_type
+    // is INTRO. currentType on the record is what makes it a trial end — Stripe parity.
+    await userCollection.doc('testing').update({
+      likerPlus: { ...liveAppStorePlus, currentType: 'trial', period: 'year' },
+    });
+    const res = await post(
+      {
+        ...baseEvent,
+        id: 'evt_intro_expire',
+        type: 'EXPIRATION',
+        period_type: 'INTRO',
+        expiration_reason: 'UNSUBSCRIBED',
+        expiration_at_ms: Date.now(),
+      },
+      { Authorization: AUTH },
+    );
+    expect(res.status).toBe(200);
+    const user = await getUserWithCivicLikerProperties('testing');
+    expect(user?.likerPlus?.subscriptionStatus).toBe('canceled');
+    expect(mockIntercomEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ eventName: 'plus_trial_end' }),
+    );
+    expect(mockLogServerEvents).toHaveBeenCalledWith(
+      'TrialEnded',
+      expect.objectContaining({
+        // Must match the id the grant reported, or the funnel doesn't join up.
+        paymentId: 'txn_123',
+        extraProperties: expect.objectContaining({
+          subscription_id: 'txn_123',
+          provider: 'revenuecat',
+          is_paid_trial: true,
+          cancel_reason: 'UNSUBSCRIBED',
+          period: 'year',
+        }),
+      }),
+    );
+    // Churn carries no value/currency, which is what keeps it out of Meta/GA as a
+    // conversion — logServerEvents returns before those when either is missing.
+    expect(mockLogServerEvents).toHaveBeenCalledTimes(1);
+    const [, options] = mockLogServerEvents.mock.calls[0];
+    expect(options.value).toBeUndefined();
+    expect(options.currency).toBeUndefined();
+  });
+
+  it('reports an expired paid subscription as a cancellation', async () => {
+    await userCollection.doc('testing').update({ likerPlus: { ...liveAppStorePlus } });
+    const res = await post(
+      {
+        ...baseEvent, id: 'evt_paid_expire', type: 'EXPIRATION', expiration_at_ms: Date.now(),
+      },
+      { Authorization: AUTH },
+    );
+    expect(res.status).toBe(200);
+    expect(mockIntercomEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ eventName: 'plus_subscription_end' }),
+    );
+    expect(mockLogServerEvents).toHaveBeenCalledWith(
+      'SubscriptionCancelled',
+      expect.objectContaining({
+        extraProperties: expect.objectContaining({ is_paid_trial: false }),
+      }),
+    );
   });
 
   it('does not revoke a legacy Stripe-owned record (no provider) on EXPIRATION', async () => {

--- a/test/api/plus.revenuecat.test.ts
+++ b/test/api/plus.revenuecat.test.ts
@@ -28,6 +28,8 @@ const EXPIRATION_AT_MS = 1778536000000;
 const PRIOR_PERIOD_START_MS = PURCHASED_AT_MS - 30 * 24 * 60 * 60 * 1000;
 // EXPIRATION_AT_MS is in the past, so guards keyed on live access need their own end.
 const FUTURE_PERIOD_END_MS = Date.now() + 30 * 24 * 60 * 60 * 1000;
+// Period start of the trial→paid renewal, one 7-day trial term after the purchase.
+const CONVERSION_START_MS = PURCHASED_AT_MS + 7 * 24 * 60 * 60 * 1000;
 
 // A live, RevenueCat-owned APP_STORE record — the shape the subscription-scoping
 // and transfer-carry guards operate on. Spread it so tests can't share a reference.
@@ -110,6 +112,69 @@ describe('Plus RevenueCat webhook', () => {
     expect(res.status).toBe(200);
     const user = await getUserWithCivicLikerProperties('testing');
     expect(user?.likerPlus?.currentType).toBe('trial');
+  });
+
+  it('books a paid introductory offer as a trial but keeps its charge', async () => {
+    // The $1/7-day promo arrives as period_type INTRO, not TRIAL. It must read as a
+    // trial for entitlement/CRM/analytics (Stripe parity, where the same promo is a
+    // trialing subscription) while its real charge still funds nothing in rev-share.
+    mockSlackNotification.mockClear();
+    const res = await post(
+      {
+        ...baseEvent, type: 'INITIAL_PURCHASE', period_type: 'INTRO', price: 1,
+      },
+      { Authorization: AUTH },
+    );
+    expect(res.status).toBe(200);
+    const user = await getUserWithCivicLikerProperties('testing');
+    expect(user?.likerPlus?.currentType).toBe('trial');
+    expect(user?.likerPlus?.dailyValue).toBe(0);
+    expect(mockSlackNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isTrial: true,
+        isNew: true,
+        // The $1 is a real charge and must still be reported, unlike a free trial's 0.
+        priceWithCurrency: '1.00 USD',
+      }),
+    );
+  });
+
+  it('reports the first charge after a trial as a new subscription, not a renewal', async () => {
+    // RevenueCat's is_trial_conversion stays false for a paid intro, so the conversion
+    // is detected from the stored record's currentType instead.
+    mockSlackNotification.mockClear();
+    await userCollection.doc('testing').update({
+      likerPlus: { ...liveAppStorePlus, currentType: 'trial' },
+    });
+    const res = await post(
+      {
+        ...baseEvent,
+        id: 'evt_convert',
+        type: 'RENEWAL',
+        period_type: 'NORMAL',
+        price: 49,
+        // Its own period start: the accrual key is `${transaction}_${periodStart}`, and
+        // reusing PURCHASED_AT_MS would seed the doc a later test asserts is absent.
+        purchased_at_ms: CONVERSION_START_MS,
+      },
+      { Authorization: AUTH },
+    );
+    try {
+      expect(res.status).toBe(200);
+      const user = await getUserWithCivicLikerProperties('testing');
+      expect(user?.likerPlus?.currentType).toBe('paid');
+      expect(mockSlackNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ isTrial: false, isNew: true }),
+      );
+    } finally {
+      // This is the only test booking a real charge, so the only one writing a rev-share
+      // accrual. The Firestore stub is shared across test files and plus-settle's "no
+      // accrual" dry run would pick this up, so drop it even when an assertion fails.
+      await userCollection.doc('testing')
+        .collection('plusReadingAccrual')
+        .doc(`txn_123_${CONVERSION_START_MS}`)
+        .delete();
+    }
   });
 
   it('skips the grant when a subscription event has no resolvable period end', async () => {


### PR DESCRIPTION
The $1/7-day promo arrives as period_type INTRO, which fell through as a normal paid subscription: currentType 'paid', no StartTrial, full LTV, and rev-share funded from the $1. Map INTRO onto the same trial semantics the Stripe path gives the identical promo, while keeping the real charge on firstPaidAt and the Airtable row.

The trial's gift book is deferred to the first full charge, detected from the stored currentType — RevenueCat's is_trial_conversion means "previous period was a free trial" and stays false for a paid intro.