### PR TITLE
🐛 Point Plus Slack buttons at a real page, not an empty URL

### DIFF
--- a/src/util/slack.ts
+++ b/src/util/slack.ts
@@ -4,6 +4,7 @@ import { getBook3NFTClassPageURL } from './liker-land';
 import { getNFTBookStoreSendPageURL } from './api/likernft/book';
 import {
   BOOK3_HOSTNAME,
+  EXTERNAL_HOSTNAME,
   IS_TESTNET,
 } from '../constant';
 import {
@@ -16,6 +17,10 @@ import {
 import { Timestamp } from './firebase';
 import type { NFTBookPrice } from '../types/book';
 import type { LikerPlusProvider } from '../types/user';
+
+// RevenueCat has no per-customer URL without a project id, so link to the
+// dashboard and search there for the transaction id shown in the message.
+const REVENUECAT_DASHBOARD_URL = 'https://app.revenuecat.com/';
 
 export async function sendNFTBookNewListingSlackNotification({
   wallet,
@@ -177,7 +182,7 @@ export async function sendPlusSubscriptionSlackNotification({
   email: string;
   priceWithCurrency: string;
   isNew: boolean;
-  userId?: string;
+  userId: string;
   stripeCustomerId?: string;
   method?: LikerPlusProvider;
   isTrial?: boolean;
@@ -194,9 +199,16 @@ export async function sendPlusSubscriptionSlackNotification({
     }
     const customerId = stripeCustomerId || 'N/A';
     const stripeEndpoint = `https://dashboard.stripe.com${IS_TESTNET ? '/test' : ''}`;
-    const customerLink = stripeCustomerId ? `${stripeEndpoint}/customers/${stripeCustomerId}` : undefined;
-    // Non-Stripe subscription ids have no Stripe dashboard page to link to.
-    const subscriptionLink = method === 'stripe' ? `${stripeEndpoint}/subscriptions/${subscriptionId}` : undefined;
+    // The Slack message renders these as link buttons, which reject an empty URL,
+    // so every branch must resolve to a real page.
+    const profileLink = `https://${EXTERNAL_HOSTNAME}/${userId}`;
+    const customerLink = stripeCustomerId ? `${stripeEndpoint}/customers/${stripeCustomerId}` : profileLink;
+    let subscriptionLink = profileLink;
+    if (method === 'stripe') {
+      subscriptionLink = `${stripeEndpoint}/subscriptions/${subscriptionId}`;
+    } else if (method === 'revenuecat') {
+      subscriptionLink = REVENUECAT_DASHBOARD_URL;
+    }
 
     let methodDisplayName = method as string;
     if (method === 'stripe') {

--- a/test/util/slack.test.ts
+++ b/test/util/slack.test.ts
@@ -1,0 +1,88 @@
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest';
+import axios from 'axios';
+
+import { EXTERNAL_HOSTNAME } from '../../src/constant';
+
+const WEBHOOK_URL = 'https://hooks.slack.test/plus';
+
+// Only override the Plus webhook so the notification is not skipped; the rest of
+// the real config still loads for the other modules slack.ts pulls in.
+vi.mock('../../config/config', async (importOriginal) => ({
+  ...(await importOriginal() as object),
+  PLUS_SUBSCRIPTION_NOTIFICATION_WEBHOOK: WEBHOOK_URL,
+}));
+
+vi.mock('axios', () => ({
+  default: { post: vi.fn().mockResolvedValue({ data: {} }) },
+}));
+
+const { sendPlusSubscriptionSlackNotification } = await import('../../src/util/slack');
+
+const postMock = vi.mocked(axios.post);
+
+function getPostedPayload() {
+  expect(postMock).toHaveBeenCalledTimes(1);
+  const [url, payload] = postMock.mock.calls[0];
+  expect(url).toBe(WEBHOOK_URL);
+  return payload as Record<string, unknown>;
+}
+
+describe('sendPlusSubscriptionSlackNotification', () => {
+  beforeEach(() => {
+    postMock.mockClear();
+  });
+
+  it('links a Stripe subscription to its dashboard pages', async () => {
+    await sendPlusSubscriptionSlackNotification({
+      subscriptionId: 'sub_123',
+      email: 'test@example.com',
+      priceWithCurrency: '4.99 USD',
+      isNew: true,
+      userId: 'liker1',
+      stripeCustomerId: 'cus_123',
+      method: 'stripe',
+    });
+    const payload = getPostedPayload();
+    expect(payload.subscriptionLink).toContain('/subscriptions/sub_123');
+    expect(payload.customerLink).toContain('/customers/cus_123');
+    expect(payload.method).toBe('Stripe');
+  });
+
+  it.each([
+    ['revenuecat' as const, 'https://app.revenuecat.com/'],
+    ['shared' as const, `https://${EXTERNAL_HOSTNAME}/liker1`],
+  ])('links a %s subscription to a usable page', async (method, expectedLink) => {
+    await sendPlusSubscriptionSlackNotification({
+      subscriptionId: 'txn_123',
+      email: 'test@example.com',
+      priceWithCurrency: '4.99 USD',
+      isNew: true,
+      userId: 'liker1',
+      method,
+    });
+    const payload = getPostedPayload();
+    expect(payload.subscriptionLink).toBe(expectedLink);
+    expect(payload.customerLink).toBe(`https://${EXTERNAL_HOSTNAME}/liker1`);
+    expect(payload.customerId).toBe('N/A');
+  });
+
+  // The Slack message turns the links into buttons, which reject an empty URL,
+  // and JSON.stringify drops undefined keys before axios ever sends them.
+  it.each(['stripe', 'revenuecat', 'shared'] as const)('sends every link key for %s', async (method) => {
+    await sendPlusSubscriptionSlackNotification({
+      subscriptionId: 'txn_123',
+      email: 'test@example.com',
+      priceWithCurrency: '4.99 USD',
+      isNew: true,
+      userId: 'liker1',
+      method,
+    });
+    const serialised = JSON.parse(JSON.stringify(getPostedPayload()));
+    ['subscriptionLink', 'customerLink'].forEach((key) => {
+      expect(serialised).toHaveProperty(key);
+      expect(() => new URL(serialised[key])).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
The notification renders subscriptionLink and customerLink as Slack link buttons, which reject an empty URL. Both were undefined for non-Stripe subscriptions, and JSON.stringify drops undefined keys, so RevenueCat and Civic-shared sales failed the workflow with parameter_validation_failed.

Fall back to the RevenueCat dashboard or the Liker profile, and require userId so the remaining fallback cannot degrade to the bare hostname.